### PR TITLE
feat: Visual Editor 追加 + ServiceCard ホバー効果統一

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,3 +114,276 @@ This project uses both Japanese and English:
 | `design-tokens/tokens.json`        | W3C DTCG 形式のデザイントークン                                         |
 | `foundations/prohibited.md`        | 禁止パターン一覧                                                        |
 | `foundations/design_philosophy.md` | 設計思想・7原則                                                         |
+
+<!-- claude-memory-sync: auto-generated -->
+
+## グローバル設計方針
+
+# グローバル設計方針
+
+## コンポーネント設計
+
+- 単一責任。1コンポーネント1責務
+- Props は必ず型定義。any 禁止
+- 副作用は hooks に分離する
+
+## 命名規則
+
+- コンポーネント: PascalCase
+- hooks: use プレフィックス
+- 定数: UPPER_SNAKE_CASE
+
+## Claude への指示スタイル
+
+- 差分だけ返す。ファイル全体を返さない
+- 変更理由を1行コメントで添える
+- 選択肢がある場合は推奨を1つ明示してから提示する
+
+## 禁止パターン
+
+- any の使用
+- console.log の commit
+- ハードコードされた文字列（i18n対象はすべて定数化）
+
+---
+
+## AI チャット汎用パターン
+
+### ハイブリッド AI 戦略（オフライン + オンライン）
+
+- 常にオフライン動作可能: FAQ ローカル検索（Fuse.js ファジーマッチ）
+- AI があれば強化: Embedding セマンティック検索 + LLM 生成
+- AI エラー時: FAQ フォールバック
+- 3層: Semantic Search → Keyword Search → Hardcoded Suggestions
+
+### OpenAI/Gemini デュアル対応
+
+- Gemini は OpenAI 互換エンドポイント (`generativelanguage.googleapis.com/v1beta/openai/`) 経由
+- Bearer 認証統一。`model.includes('gemini')` で分岐
+- レスポンス抽出: OpenAI標準 / Responses API / Gemini native の3形式を正規化
+
+### Embedding セマンティック検索
+
+- `text-embedding-3-small` (512次元に短縮でコスト削減)
+- インメモリ VectorIndex（バッチ100件単位でAPI呼び出し）
+- コサイン類似度: `dot / (norm_a * norm_b)`, threshold=0.3, topK=5
+
+### ページ文脈認識パターン
+
+- 現在のページ情報 `{ title, name, description }` をシステムプロンプトに動的注入
+- 指示語解決: 「このUI何?」→ 現在ページのコンポーネントを特定
+- 応用: ドキュメントビューア等で「現在地」パラメータを渡すだけで同じ仕組みが使える
+
+### ペルソナ検出
+
+- ページシグナル(+2点) + 語彙シグナル(+1点/match) でスコアリング
+- 閾値2以上で判定（designer/engineer/unknown）
+- ペルソナ別プロンプト拡張を動的注入
+
+### APIキー管理パターン
+
+- ビルド時デフォルト (`import.meta.env`) → ユーザー入力上書き (localStorage)
+- モデル互換性チェック（defaultKey 使用時に制限）
+- 接続テスト UI
+
+### ショートカット管理
+
+- KeyDown 捕捉 + IME対応 (`e.nativeEvent.isComposing`)
+- 修飾キー正規化（Mac: Cmd / Windows: Ctrl 自動判定）
+- localStorage 永続化 + リセット機能
+
+## Storybook 汎用パターン
+
+### テーマ切替
+
+- toolbar globalTypes で複数テーマを定義
+- `parseThemeValue()` で "dark-scheme" → mode + scheme に分離
+- `data-theme-transitioning` 属性で切替トランジション制御（350ms）
+- 初回マウントはトランジションなし
+
+### Decorator 多重ラップ
+
+- Emotion ThemeProvider → MUI ThemeProvider → CacheProvider → CssBaseline
+- パラメータ制御: noPadding / fullscreenNoPadding / blockLinks
+- コンテキスト注入: viewMode 判定で docs 時は特定コンポーネント非表示
+
+### Story カテゴリ設計
+
+- 番号プレフィックス (00-Guide, 01-Philosophy, 02-Tokens, ...) でソート順を制御
+- storySort で明示的順序指定
+
+## デザインシステム汎用パターン
+
+### マルチスキーム対応
+
+- ColorSet: { main, dark, light, lighter, contrastText } の統一インターフェース
+- lighter スロットをスキーム環境色で上書き（セマンティック色は固有 lighter を保持）
+- CSS Variables で Tailwind と MUI を色共有
+
+### CVA (class-variance-authority) パターン
+
+- variant × size のマトリクスで型安全なバリエーション管理
+- Tailwind utility + CVA = styled-components 不要
+- shadcn/ui 互換の設計
+
+### MUI + Tailwind 共存
+
+- MUI: 複雑な UI コンポーネント（Dialog, DataGrid 等）→ theme.palette トークン参照
+- Tailwind: シンプルなコンポーネント（Button, Card）→ CVA + CSS Variables
+- tailwind.config で `var(--color-*)` を colors に定義 → テーマ自動切替
+
+### W3C DTCG トークン
+
+- `$value` + `$type` 形式で機械可読
+- light/dark を同一ファイルに構造化
+- Figma / デザインツール連携可能
+
+### コンポーネントメタデータ
+
+- JSON で name/category/path/variants/sizes/accessibility/prohibited/sample を定義
+- AI エージェントがコンポーネント仕様を自動認識可能
+
+## LP 汎用パターン
+
+### framer-motion アニメーション
+
+- `useInView({ once: true })` + stagger (index \* delay) でスクロールトリガー
+- `useScroll` + `useTransform` でパララックス効果
+- カスタムイージング: `[0.25, 0.1, 0, 1]` でモダンな減速感
+- グラデーションオーブ: `radial-gradient` + `blur` + keyframes で有機的な背景
+
+### ダークモード分岐
+
+- `const isDark = theme.palette.mode === 'dark'`
+- alpha 値で分岐: dark=0.15, light=0.12（色付きシャドウ）
+- bgcolor/borderColor を三項演算子で切替
+
+### ホバー効果統一パターン
+
+- `transition: 'border-color 0.2s ease, box-shadow 0.2s ease'`
+- `&:hover: { boxShadow: '0 12px 40px rgba(brand,alpha)', borderColor: 'primary.main' }`
+- 全カード系コンポーネントで共通化
+
+### レスポンシブ
+
+- CONTAINER_SX: `{ maxWidth: 1120, mx: 'auto', px: { xs: 2.5, sm: 3, md: 4 } }`
+- Grid: `gridTemplateColumns: { xs: '1fr', md: 'repeat(3, 1fr)' }`
+- フォント: `fontSize: { xs: '2rem', md: '2.8rem' }`
+
+## モノレポ汎用パターン
+
+### pnpm workspace + Turborepo
+
+- `pnpm-workspace.yaml` でパッケージ定義
+- `workspace:*` でルートパッケージを apps から参照
+- turbo.json: `dependsOn: ["^build"]` で依存順ビルド、dev は `cache: false, persistent: true`
+
+### 統合ビルド・デプロイ（Vercel）
+
+- ビルドスクリプトで全アプリを `dist/` サブディレクトリに出力
+- `vercel.json` の rewrites でパスルーティング（`/app-name/(.*)` → `/app-name/$1`）
+- 各アプリは `VITE_BASE_PATH=/app-name/` でビルド
+
+### ポート管理
+
+- デフォルトポートを定数定義
+- localStorage で上書き可能（開発者向け設定パネル）
+- ポート生存確認: HEAD fetch + timeout → 隣接ポートスキャン
+- ローカル/本番リンク自動切替: `isDev ? localhost:PORT : origin + path`
+
+### dev:all 一括起動
+
+- `pnpm dev & pnpm storybook & pnpm -F app1 dev & ... & wait`
+- 個別起動: `pnpm --filter app-name dev`
+
+---
+
+<!-- このファイルは claude-memory-sync が管理します -->
+<!-- 自由に編集してください。cm コマンドで同期されます -->
+
+## プロジェクト固有の記憶（kaze-ux）
+
+# kaze-ux プロジェクト記憶
+
+## モノレポ構成
+
+- pnpm workspace + Turborepo
+- ワークスペース: `.`(ルート), `apps/*`, `packages/*`, `mcp`
+- アプリは `workspace:*` でルートの共有コンポーネント・テーマを参照
+- `dev:all` で5プロセス同時起動（LP:5173, Storybook:6007, SaaS:3001, KazeEats:3002, KazeLogistics:3003）
+- `appLinks.ts` でローカル/本番のリンク自動切替（isDev → localhost:PORT, 本番 → origin + path）
+- ポートは localStorage で上書き可能（DevPortSettings パネル、DEV環境のみ表示）
+- Vercel: `scripts/vercel-build.mjs` で全アプリを `dist/` に統合ビルド → rewrites でルーティング
+
+## Storybook
+
+- Storybook 10 + `@storybook/react-vite`
+- アドオン: a11y, links, docs, mcp
+- テーマ切替: Light / Dark(Dracula) / Dark(Kaze) の3モード（toolbar globalTypes）
+- `parseThemeValue()` で `dark-dracula` → mode=dark, scheme=dracula に分離
+- Decorator: MUI ThemeProvider + Emotion CacheProvider + CssBaseline の多重ラップ
+- ChatSupport: `viewMode !== 'docs'` のとき全 Story に自動注入
+- パラメータ制御: `noPadding`, `fullscreenNoPadding`, `blockLinks`, `forceDarkTheme`
+- manager.ts: Kaze 独自テーマ（dark base, #0EADB8 primary, Inter + Noto Sans JP）
+- Story カテゴリ: 00-Guide → 01-DesignPhilosophy → 02-DesignTokens → 03-Layout → 04-Components → 05-Patterns → 06-Tools
+- ビルド設定: env を `viteFinal` で define 注入、パスワード認証は managerHead で注入
+
+## AI チャット (ChatSupport)
+
+- OpenAI/Gemini デュアル対応: Gemini は OpenAI 互換エンドポイント経由、Bearer 認証統一
+- `callAI()` → `extractContent()` で複数レスポンス形式を正規化（OpenAI標準/Responses API/Gemini native）
+- セマンティック検索: `text-embedding-3-small` (512次元), インメモリ VectorIndex, コサイン類似度, topK=5, threshold=0.3
+- 知識ベース3層: FAQ(faqDatabase) + StoryGuide(storyGuideMap) + MUI Knowledge(muiKnowledge)
+- オフライン動作: Fuse.js ファジー検索 + 同義語展開（SYNONYM_MAP）
+- フォールバック: Semantic Search → FAQ Keyword → Hardcoded Suggestions
+- ページ文脈認識: `currentStory: { title, name, description }` → システムプロンプトに動的注入
+- ペルソナ検出: ページシグナル(+2) + 語彙シグナル(+1/match) → designer/engineer/unknown
+- ペルソナ別プロンプト拡張: デザイナー向け（Figma橋渡し）/ エンジニア向け（コードファースト）
+- 設定: localStorage に apiKey/model/uiMode/sidebarWidth/shortcuts を永続化
+- ショートカット: 8アクション、IME対応（isComposing チェック）、Mac/Windows 自動判定
+- UI: ウィジェット（FAB + 浮遊パネル）/ サイドバー（リサイズ可能）切替
+- Storybook 専用として維持。他アプリ設置は費用対効果が低い（contextMap 新規作成が必要）
+
+## デザインシステム
+
+- カラー: マルチスキーム（Kaze/Dracula/Monotone）× Light/Dark = 6テーマ
+- プライマリ: #0EADB8（ティール）、フォント: Inter + Noto Sans JP、baseFontSize=14px
+- spacing: 4px基準、borderRadius: xs=4/sm=6/md=8/lg=10/xl=12/2xl=16
+- ブレイクポイント: mobile(0)/tablet(768)/laptop(1366)/desktop(1920)
+- CVA (class-variance-authority): Button/Card で shadcn 互換バリアントパターン
+- MUI + Tailwind 共存: MUI は複雑 UI、Tailwind は CVA コンポーネント。CSS Variables で色共有
+- W3C DTCG トークン: `design-tokens/tokens.json` で機械可読
+- メタデータ: `metadata/components.json` で全コンポーネント仕様を AI 可読に
+- 禁止: React.FC / any / セミコロン / ダブルクォート / Grid item旧API / ハードコード色 / window.confirm()
+
+## LP (ランディングページ)
+
+- framer-motion: グラデーションオーブ3層 + グリッド + パーティクル8個 + 装飾リング
+- キーフレーム: orbDrift(16s), orbFloat(12s), particle(6-22s), ringRotate(24-30s)
+- スクロール連動: `useScroll` + `useTransform` でヒーローの opacity/scale 変換（0-15%範囲）
+- ProductCard: `useInView` + stagger(index\*0.15s) + カスタムイージング [0.25,0.1,0,1]
+- ホバー効果統一: `boxShadow: '0 12px 40px rgba(14,173,184,0.15/0.12)'` + `borderColor: primary.main`
+- isDark 分岐: `theme.palette.mode === 'dark'` で alpha/bgcolor/borderColor を切替
+- セクション: Hero → Products(4) → Features(6) → TechStack(8) → GettingStarted(3) → AI Chat → Footer
+- CONTAINER_SX: `{ maxWidth: 1120, mx: 'auto', px: { xs: 2.5, sm: 3, md: 4 } }`
+- BauhausDivider: 3バリアント(a/b/c) + flip + スクロール連動アニメーション
+
+## Visual Editor
+
+- `src/stories/06-Tools/` に配置。Storybook「Tools」カテゴリ
+- ChatSupport の AI インフラ（callAI, extractContent, loadChatConfig）を再利用
+- COMPONENT_REGISTRY でホワイトリスト制御（23コンポーネント登録）
+- MAX_DEPTH=10 で再帰レンダリングの安全弁
+- 3パネル: ComponentPalette(左) + LivePreview(中央) + PromptInput(下)
+- プリセット4種: KPI Dashboard / Registration Form / Activity Feed / Settings Page
+- プロトタイプ段階。テストコードなし
+
+## ブランチ・PR 運用
+
+- feature ブランチから main への PR は squash merge
+- PR #18-#21: マージ済み
+- PR #22: Visual Editor + ServiceCard ホバー効果（レビュー済み、マージ待ち）
+
+---
+
+<!-- このファイルは claude-memory-sync が管理します -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -376,6 +376,9 @@ This project uses both Japanese and English:
 - MAX_DEPTH=10 で再帰レンダリングの安全弁
 - 3パネル: ComponentPalette(左) + LivePreview(中央) + PromptInput(下)
 - プリセット4種: KPI Dashboard / Registration Form / Activity Feed / Settings Page
+- 送信ボタン: MUI IconButton(SendIcon) + Tooltip でショートカット表示（⌘/Ctrl + Enter）
+- ChatSupport FAB との重なり回避: PromptInput に `pr: 7` の右パディング
+- lucide-react の Sparkles は MUI AutoAwesomeIcon に置換（Storybook 環境での安定性）
 - プロトタイプ段階。テストコードなし
 
 ## ブランチ・PR 運用

--- a/src/components/ui/card/serviceCard.tsx
+++ b/src/components/ui/card/serviceCard.tsx
@@ -64,6 +64,14 @@ export const ServiceCard = ({
         height: '100%',
         display: 'flex',
         flexDirection: 'column',
+        transition: 'border-color 0.2s ease, box-shadow 0.2s ease',
+        '&:hover': {
+          boxShadow: (theme) =>
+            theme.palette.mode === 'dark'
+              ? '0 12px 40px rgba(14,173,184,0.15)'
+              : '0 12px 40px rgba(14,173,184,0.12)',
+          borderColor: 'primary.main',
+        },
       }}>
       {/* ヘッダー */}
       <Box

--- a/src/stories/06-Tools/VisualEditor.stories.tsx
+++ b/src/stories/06-Tools/VisualEditor.stories.tsx
@@ -1,0 +1,26 @@
+// Visual Editor — Storybook Story
+
+import { VisualEditor } from './components/VisualEditor'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta: Meta<typeof VisualEditor> = {
+  title: 'Tools/Visual Editor',
+  component: VisualEditor,
+  parameters: {
+    layout: 'fullscreen',
+    noPadding: true,
+    fullscreenNoPadding: true,
+    docs: {
+      description: {
+        component:
+          'AIを使ってkaze-uxコンポーネントを組み合わせるビジュアルエディタ。自然言語でUIを記述すると、登録済みコンポーネントのみでレイアウトを生成します。',
+      },
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof VisualEditor>
+
+export const Default: Story = {}

--- a/src/stories/06-Tools/components/ComponentPalette.tsx
+++ b/src/stories/06-Tools/components/ComponentPalette.tsx
@@ -1,0 +1,60 @@
+// 左パネル: コンポーネント一覧
+
+import { Box, Chip, Typography } from '@mui/material'
+
+import { PALETTE_CATEGORIES } from './componentRegistry'
+
+interface ComponentPaletteProps {
+  onSelect: (name: string) => void
+}
+
+export const ComponentPalette = ({ onSelect }: ComponentPaletteProps) => (
+  <Box
+    sx={{
+      width: 220,
+      flexShrink: 0,
+      borderRight: 1,
+      borderColor: 'divider',
+      overflow: 'auto',
+      p: 1.5,
+    }}>
+    <Typography
+      variant='caption'
+      color='text.secondary'
+      sx={{
+        fontWeight: 600,
+        letterSpacing: '0.05em',
+        mb: 1,
+        display: 'block',
+      }}>
+      COMPONENTS
+    </Typography>
+    {PALETTE_CATEGORIES.map((cat) => (
+      <Box key={cat.label} sx={{ mb: 2 }}>
+        <Typography
+          variant='caption'
+          color='text.secondary'
+          sx={{ fontSize: 11, mb: 0.5, display: 'block' }}>
+          {cat.label}
+        </Typography>
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+          {cat.components.map((name) => (
+            <Chip
+              key={name}
+              label={name}
+              size='small'
+              variant='outlined'
+              onClick={() => onSelect(name)}
+              sx={{
+                fontSize: 11,
+                height: 24,
+                cursor: 'pointer',
+                '&:hover': { bgcolor: 'action.hover' },
+              }}
+            />
+          ))}
+        </Box>
+      </Box>
+    ))}
+  </Box>
+)

--- a/src/stories/06-Tools/components/ComponentRenderer.tsx
+++ b/src/stories/06-Tools/components/ComponentRenderer.tsx
@@ -1,0 +1,63 @@
+// 再帰レンダラー: JSONノード → React要素
+
+import { Box, Typography } from '@mui/material'
+import { createElement } from 'react'
+
+import { COMPONENT_REGISTRY } from './componentRegistry'
+
+import type { ComponentNode } from './editorTypes'
+
+const MAX_DEPTH = 10
+
+// 未知コンポーネント用のエラー表示
+const UnknownComponent = ({ name }: { name: string }) => (
+  <Box
+    sx={{
+      border: '2px dashed',
+      borderColor: 'error.main',
+      borderRadius: 1,
+      p: 1,
+      my: 0.5,
+    }}>
+    <Typography variant='caption' color='error'>
+      Unknown: {name}
+    </Typography>
+  </Box>
+)
+
+// 単一ノードをReact要素に変換
+const renderNode = (
+  node: ComponentNode,
+  depth: number,
+  index: number
+): React.ReactNode => {
+  if (depth > MAX_DEPTH) return null
+
+  const Component = COMPONENT_REGISTRY[node.component]
+  if (!Component) {
+    return <UnknownComponent key={index} name={node.component} />
+  }
+
+  // props組み立て
+  const props: Record<string, unknown> = {
+    ...node.props,
+    key: index,
+  }
+  if (node.sx) props.sx = node.sx
+  if (node.className) props.className = node.className
+
+  // children
+  let children: React.ReactNode = undefined
+  if (typeof node.children === 'string') {
+    children = node.children
+  } else if (Array.isArray(node.children)) {
+    children = node.children.map((child, i) => renderNode(child, depth + 1, i))
+  }
+
+  return createElement(Component, props, children)
+}
+
+// レイアウト全体をレンダリング
+export const ComponentRenderer = ({ nodes }: { nodes: ComponentNode[] }) => (
+  <>{nodes.map((node, i) => renderNode(node, 0, i))}</>
+)

--- a/src/stories/06-Tools/components/LivePreview.tsx
+++ b/src/stories/06-Tools/components/LivePreview.tsx
@@ -1,0 +1,65 @@
+// 中央パネル: ライブプレビュー
+
+import { Alert, Box, Typography } from '@mui/material'
+
+import { ComponentRenderer } from './ComponentRenderer'
+
+import type { EditorLayout } from './editorTypes'
+
+interface LivePreviewProps {
+  layout: EditorLayout | null
+  error: string | null
+  isGenerating: boolean
+}
+
+export const LivePreview = ({
+  layout,
+  error,
+  isGenerating,
+}: LivePreviewProps) => (
+  <Box sx={{ flex: 1, overflow: 'auto', p: 3 }}>
+    {/* エラー表示 */}
+    {error && (
+      <Alert severity='error' sx={{ mb: 2 }}>
+        {error}
+      </Alert>
+    )}
+
+    {/* 生成中 */}
+    {isGenerating && (
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: '100%',
+        }}>
+        <Typography color='text.secondary' sx={{ fontSize: 14 }}>
+          コンポーネントを生成中...
+        </Typography>
+      </Box>
+    )}
+
+    {/* 空状態 */}
+    {!layout && !isGenerating && !error && (
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: '100%',
+          gap: 1,
+          opacity: 0.5,
+        }}>
+        <Typography sx={{ fontSize: 32 }}>⬡</Typography>
+        <Typography color='text.secondary' sx={{ fontSize: 13 }}>
+          プリセットを選択するか、プロンプトを入力してUIを生成
+        </Typography>
+      </Box>
+    )}
+
+    {/* レンダリング結果 */}
+    {layout && !isGenerating && <ComponentRenderer nodes={layout.layout} />}
+  </Box>
+)

--- a/src/stories/06-Tools/components/PromptInput.tsx
+++ b/src/stories/06-Tools/components/PromptInput.tsx
@@ -1,7 +1,7 @@
 // 下パネル: プロンプト入力 + プリセット
 
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome'
 import { Box, Chip, Stack, TextField, useTheme } from '@mui/material'
-import { Sparkles } from 'lucide-react'
 import { useState, useCallback } from 'react'
 
 import { Button } from '../../../components/ui/Button'
@@ -85,7 +85,7 @@ export const PromptInput = ({ onGenerate, isGenerating }: PromptInputProps) => {
             key={p.label}
             label={p.label}
             size='small'
-            icon={<Sparkles size={12} />}
+            icon={<AutoAwesomeIcon sx={{ fontSize: 14 }} />}
             onClick={() => handlePreset(p.prompt)}
             disabled={isGenerating}
             sx={{ fontSize: 12 }}

--- a/src/stories/06-Tools/components/PromptInput.tsx
+++ b/src/stories/06-Tools/components/PromptInput.tsx
@@ -1,10 +1,18 @@
 // 下パネル: プロンプト入力 + プリセット
 
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome'
-import { Box, Chip, Stack, TextField, useTheme } from '@mui/material'
+import SendIcon from '@mui/icons-material/Send'
+import {
+  Box,
+  Chip,
+  IconButton,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+  useTheme,
+} from '@mui/material'
 import { useState, useCallback } from 'react'
-
-import { Button } from '../../../components/ui/Button'
 
 // プリセットテンプレート
 const PRESETS = [
@@ -64,6 +72,9 @@ export const PromptInput = ({ onGenerate, isGenerating }: PromptInputProps) => {
     [onGenerate]
   )
 
+  const isMac = /Mac|iPhone|iPad/.test(navigator.userAgent)
+  const modKey = isMac ? '⌘' : 'Ctrl'
+
   return (
     <Box
       sx={{
@@ -93,7 +104,7 @@ export const PromptInput = ({ onGenerate, isGenerating }: PromptInputProps) => {
         ))}
       </Stack>
 
-      {/* 入力欄 */}
+      {/* 入力欄 + 送信ボタン */}
       <Stack direction='row' spacing={1} alignItems='flex-end'>
         <TextField
           value={input}
@@ -109,14 +120,36 @@ export const PromptInput = ({ onGenerate, isGenerating }: PromptInputProps) => {
             input: { sx: { fontSize: 14 } },
           }}
         />
-        <Button
-          variant='default'
-          size='sm'
-          onClick={handleSubmit}
-          disabled={!input.trim() || isGenerating}>
-          {isGenerating ? '生成中...' : '生成'}
-        </Button>
+        <Tooltip title={`生成 (${modKey} + Enter)`} placement='top'>
+          <span>
+            <IconButton
+              onClick={handleSubmit}
+              disabled={!input.trim() || isGenerating}
+              sx={{
+                bgcolor: 'primary.main',
+                color: '#fff',
+                width: 40,
+                height: 40,
+                flexShrink: 0,
+                '&:hover': { bgcolor: 'primary.dark' },
+                '&.Mui-disabled': {
+                  bgcolor: 'action.disabledBackground',
+                  color: 'action.disabled',
+                },
+              }}>
+              <SendIcon sx={{ fontSize: 18 }} />
+            </IconButton>
+          </span>
+        </Tooltip>
       </Stack>
+
+      {/* ショートカットヒント */}
+      <Typography
+        variant='caption'
+        color='text.secondary'
+        sx={{ mt: 1, display: 'block', fontSize: 11, opacity: 0.7 }}>
+        {modKey} + Enter で送信 / プリセットをクリックで即時生成
+      </Typography>
     </Box>
   )
 }

--- a/src/stories/06-Tools/components/PromptInput.tsx
+++ b/src/stories/06-Tools/components/PromptInput.tsx
@@ -104,8 +104,8 @@ export const PromptInput = ({ onGenerate, isGenerating }: PromptInputProps) => {
         ))}
       </Stack>
 
-      {/* 入力欄 + 送信ボタン */}
-      <Stack direction='row' spacing={1} alignItems='flex-end'>
+      {/* 入力欄 + 送信ボタン（右端に ChatSupport FAB 分の余白） */}
+      <Stack direction='row' spacing={1} alignItems='flex-end' sx={{ pr: 7 }}>
         <TextField
           value={input}
           onChange={(e) => setInput(e.target.value)}

--- a/src/stories/06-Tools/components/PromptInput.tsx
+++ b/src/stories/06-Tools/components/PromptInput.tsx
@@ -1,0 +1,122 @@
+// 下パネル: プロンプト入力 + プリセット
+
+import { Box, Chip, Stack, TextField, useTheme } from '@mui/material'
+import { Sparkles } from 'lucide-react'
+import { useState, useCallback } from 'react'
+
+import { Button } from '../../../components/ui/Button'
+
+// プリセットテンプレート
+const PRESETS = [
+  {
+    label: 'KPI Dashboard',
+    prompt:
+      'KPIカード4枚を2x2グリッドで。売上・ユーザー数・注文数・コンバージョン率。各カードにタイトル・数値・前月比を表示',
+  },
+  {
+    label: 'Registration Form',
+    prompt:
+      'ユーザー登録フォーム。名前・メールアドレス・パスワード・都道府県選択・利用規約チェック・登録ボタン。Cardでラップ',
+  },
+  {
+    label: 'Activity Feed',
+    prompt:
+      'アクティビティフィード。5件のリストアイテムにアバター・ユーザー名・アクション内容・時刻を表示。StatusTagでステータス表示',
+  },
+  {
+    label: 'Settings Page',
+    prompt:
+      '設定画面。通知設定（メール通知・プッシュ通知のスイッチ）、表示設定（言語セレクト・テーマ切替）をCardでグループ化',
+  },
+] as const
+
+interface PromptInputProps {
+  onGenerate: (prompt: string) => void
+  isGenerating: boolean
+}
+
+export const PromptInput = ({ onGenerate, isGenerating }: PromptInputProps) => {
+  const [input, setInput] = useState('')
+  const theme = useTheme()
+
+  const handleSubmit = useCallback(() => {
+    const text = input.trim()
+    if (!text || isGenerating) return
+    onGenerate(text)
+  }, [input, isGenerating, onGenerate])
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.nativeEvent.isComposing) return
+      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault()
+        handleSubmit()
+      }
+    },
+    [handleSubmit]
+  )
+
+  const handlePreset = useCallback(
+    (prompt: string) => {
+      setInput(prompt)
+      onGenerate(prompt)
+    },
+    [onGenerate]
+  )
+
+  return (
+    <Box
+      sx={{
+        borderTop: 1,
+        borderColor: 'divider',
+        p: 2,
+        bgcolor:
+          theme.palette.mode === 'dark'
+            ? 'rgba(0,0,0,0.2)'
+            : 'rgba(0,0,0,0.02)',
+      }}>
+      {/* プリセット */}
+      <Stack
+        direction='row'
+        spacing={0.5}
+        sx={{ mb: 1.5, flexWrap: 'wrap', gap: 0.5 }}>
+        {PRESETS.map((p) => (
+          <Chip
+            key={p.label}
+            label={p.label}
+            size='small'
+            icon={<Sparkles size={12} />}
+            onClick={() => handlePreset(p.prompt)}
+            disabled={isGenerating}
+            sx={{ fontSize: 12 }}
+          />
+        ))}
+      </Stack>
+
+      {/* 入力欄 */}
+      <Stack direction='row' spacing={1} alignItems='flex-end'>
+        <TextField
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder='作りたいUIを日本語で説明...'
+          size='small'
+          multiline
+          maxRows={3}
+          fullWidth
+          disabled={isGenerating}
+          slotProps={{
+            input: { sx: { fontSize: 14 } },
+          }}
+        />
+        <Button
+          variant='default'
+          size='sm'
+          onClick={handleSubmit}
+          disabled={!input.trim() || isGenerating}>
+          {isGenerating ? '生成中...' : '生成'}
+        </Button>
+      </Stack>
+    </Box>
+  )
+}

--- a/src/stories/06-Tools/components/VisualEditor.tsx
+++ b/src/stories/06-Tools/components/VisualEditor.tsx
@@ -1,0 +1,84 @@
+// Visual Editor メインコンテナ
+
+import { Box, Stack, Typography, useTheme } from '@mui/material'
+import { useState, useCallback } from 'react'
+
+import { ComponentPalette } from './ComponentPalette'
+import { generateLayout } from './editorAiService'
+import { LivePreview } from './LivePreview'
+import { PromptInput } from './PromptInput'
+
+import type { EditorLayout } from './editorTypes'
+
+export const VisualEditor = () => {
+  const [layout, setLayout] = useState<EditorLayout | null>(null)
+  const [isGenerating, setIsGenerating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const theme = useTheme()
+
+  const handleGenerate = useCallback(async (prompt: string) => {
+    setIsGenerating(true)
+    setError(null)
+    try {
+      const result = await generateLayout(prompt)
+      setLayout(result)
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'レイアウト生成に失敗しました'
+      setError(message)
+    } finally {
+      setIsGenerating(false)
+    }
+  }, [])
+
+  // パレットからコンポーネント名を入力欄に追加（将来用）
+  const handlePaletteSelect = useCallback((_name: string) => {
+    // プロトタイプではクリック時のフィードバックのみ
+  }, [])
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100vh',
+        bgcolor: 'background.default',
+      }}>
+      {/* ヘッダー */}
+      <Stack
+        direction='row'
+        alignItems='center'
+        spacing={1}
+        sx={{
+          px: 2,
+          py: 1,
+          borderBottom: 1,
+          borderColor: 'divider',
+          bgcolor:
+            theme.palette.mode === 'dark'
+              ? 'rgba(14,173,184,0.08)'
+              : 'rgba(14,173,184,0.04)',
+        }}>
+        <Typography sx={{ fontSize: 14, fontWeight: 600 }}>
+          Visual Editor
+        </Typography>
+        <Typography variant='caption' color='text.secondary'>
+          kaze-ux コンポーネントで画面を組み立てる
+        </Typography>
+      </Stack>
+
+      {/* メイン: パレット + プレビュー */}
+      <Box sx={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
+        <ComponentPalette onSelect={handlePaletteSelect} />
+        <LivePreview
+          layout={layout}
+          error={error}
+          isGenerating={isGenerating}
+        />
+      </Box>
+
+      {/* 下部: プロンプト入力 */}
+      <PromptInput onGenerate={handleGenerate} isGenerating={isGenerating} />
+    </Box>
+  )
+}

--- a/src/stories/06-Tools/components/componentRegistry.ts
+++ b/src/stories/06-Tools/components/componentRegistry.ts
@@ -1,0 +1,142 @@
+// コンポーネント名 → React.ComponentType マッピング
+
+import {
+  Alert,
+  Avatar,
+  Box,
+  Chip,
+  Divider,
+  Grid,
+  LinearProgress,
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  Paper,
+  Stack,
+  Switch,
+  Typography,
+  TextField,
+  FormControlLabel,
+  Checkbox,
+  Radio,
+  RadioGroup,
+  FormControl,
+  FormLabel,
+  IconButton,
+  Badge,
+} from '@mui/material'
+
+import { CustomSelect } from '../../../components/Form/CustomSelect'
+import { CustomTextField } from '../../../components/Form/CustomTextField'
+import { CustomAccordion } from '../../../components/ui/accordion/customAccordion'
+import { UserAvatar } from '../../../components/ui/avatar/userAvatar'
+import { Button } from '../../../components/ui/Button'
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from '../../../components/ui/Card'
+import { StatusTag } from '../../../components/ui/tag/statusTag'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyComponent = React.ComponentType<any>
+
+// レジストリ: 文字列名 → 実コンポーネント
+export const COMPONENT_REGISTRY: Record<string, AnyComponent> = {
+  // kaze-ux
+  Button,
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+  CustomTextField,
+  CustomSelect,
+  StatusTag,
+  UserAvatar,
+  CustomAccordion,
+  // MUI
+  Alert,
+  Avatar,
+  Badge,
+  Box,
+  Checkbox,
+  Chip,
+  Divider,
+  FormControl,
+  FormControlLabel,
+  FormLabel,
+  Grid,
+  IconButton,
+  LinearProgress,
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  Paper,
+  Radio,
+  RadioGroup,
+  Stack,
+  Switch,
+  TextField,
+  Typography,
+}
+
+// パレット表示用: カテゴリ分類
+export const PALETTE_CATEGORIES = [
+  {
+    label: 'Layout',
+    components: ['Box', 'Stack', 'Grid', 'Paper', 'Divider'],
+  },
+  {
+    label: 'UI',
+    components: [
+      'Button',
+      'Card',
+      'CardHeader',
+      'CardTitle',
+      'CardDescription',
+      'CardContent',
+      'CardFooter',
+      'Chip',
+      'Alert',
+      'Badge',
+      'Avatar',
+      'UserAvatar',
+      'StatusTag',
+      'LinearProgress',
+      'CustomAccordion',
+      'IconButton',
+    ],
+  },
+  {
+    label: 'Form',
+    components: [
+      'CustomTextField',
+      'CustomSelect',
+      'TextField',
+      'Checkbox',
+      'Switch',
+      'Radio',
+      'RadioGroup',
+      'FormControl',
+      'FormControlLabel',
+      'FormLabel',
+    ],
+  },
+  {
+    label: 'Data',
+    components: [
+      'Typography',
+      'List',
+      'ListItem',
+      'ListItemText',
+      'ListItemAvatar',
+    ],
+  },
+]

--- a/src/stories/06-Tools/components/editorAiService.ts
+++ b/src/stories/06-Tools/components/editorAiService.ts
@@ -1,0 +1,155 @@
+// Visual Editor AI サービス
+// 既存の ChatSupport 基盤を再利用
+
+import { COMPONENT_REGISTRY } from './componentRegistry'
+import {
+  callAI,
+  extractContent,
+} from '../../../components/ui/ChatSupport/chatAiService'
+import { loadChatConfig } from '../../../components/ui/ChatSupport/chatSupportConstants'
+
+import type { EditorLayout } from './editorTypes'
+import type { ChatSupportConfig } from '../../../components/ui/ChatSupport/chatSupportTypes'
+
+// 利用可能コンポーネント一覧をシステムプロンプトに埋め込む
+const AVAILABLE_COMPONENTS = Object.keys(COMPONENT_REGISTRY).join(', ')
+
+const SYSTEM_PROMPT = `あなたはデザインシステムのビジュアルエディタAIです。
+ユーザーの自然言語指示に基づいて、コンポーネント構成をJSON形式で出力してください。
+
+## 利用可能コンポーネント（これ以外は使用禁止）
+${AVAILABLE_COMPONENTS}
+
+## 出力フォーマット（厳守）
+JSONのみを出力。説明文やマークダウンは不要。
+
+\`\`\`json
+{
+  "layout": [
+    {
+      "component": "コンポーネント名",
+      "props": { "prop名": "値" },
+      "sx": { "MUI sxオブジェクト" },
+      "children": [
+        { "component": "子コンポーネント", "children": "テキスト内容" }
+      ]
+    }
+  ]
+}
+\`\`\`
+
+## ルール
+- componentは利用可能コンポーネント一覧のみ使用可能
+- childrenはコンポーネント配列またはテキスト文字列
+- MUI v7 Grid: size={{ xs: 12, sm: 6 }} を使用（旧 item prop 禁止）
+- 色はデザイントークン参照（primary.main, text.secondary 等）。HEX直書き禁止
+- spacing は MUI の数値（1=8px, 2=16px, 3=24px）
+- レスポンシブ対応: Grid の size prop でブレークポイント指定
+- 現実的なダミーデータを使用（"Lorem ipsum" 禁止）
+
+## コンポーネント補足
+- Card = CardHeader + CardContent + CardFooter の組み合わせ
+- CardHeader の中に CardTitle, CardDescription を配置
+- CustomTextField: label, placeholder, required, size("small"/"medium") prop対応
+- CustomSelect: label, options=[{value,label}] prop対応
+- StatusTag: text, status("active"/"inactive"/"pending"/"error") prop対応
+- Button: variant("default"/"destructive"/"outline"/"secondary"/"ghost"), size("default"/"sm"/"lg") prop対応
+- Stack: direction("row"/"column"), spacing, alignItems prop対応
+- Typography: variant("h4"/"h5"/"h6"/"body1"/"body2"/"caption"), color prop対応
+
+## 出力例
+ユーザー: "KPIカードを2枚横並びで"
+\`\`\`json
+{
+  "layout": [
+    {
+      "component": "Grid",
+      "props": { "container": true, "spacing": 2 },
+      "children": [
+        {
+          "component": "Grid",
+          "props": { "size": { "xs": 12, "sm": 6 } },
+          "children": [
+            {
+              "component": "Card",
+              "children": [
+                {
+                  "component": "CardHeader",
+                  "children": [
+                    { "component": "CardTitle", "children": "月間売上" }
+                  ]
+                },
+                {
+                  "component": "CardContent",
+                  "children": [
+                    { "component": "Typography", "props": { "variant": "h4" }, "children": "¥2,450,000" },
+                    { "component": "Typography", "props": { "variant": "caption", "color": "text.secondary" }, "children": "前月比 +12.5%" }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "component": "Grid",
+          "props": { "size": { "xs": 12, "sm": 6 } },
+          "children": [
+            {
+              "component": "Card",
+              "children": [
+                {
+                  "component": "CardHeader",
+                  "children": [
+                    { "component": "CardTitle", "children": "アクティブユーザー" }
+                  ]
+                },
+                {
+                  "component": "CardContent",
+                  "children": [
+                    { "component": "Typography", "props": { "variant": "h4" }, "children": "1,284" },
+                    { "component": "Typography", "props": { "variant": "caption", "color": "text.secondary" }, "children": "前月比 +8.3%" }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+\`\`\``
+
+// JSONブロックを抽出（マークダウンコードブロック対応）
+const extractJson = (text: string): string => {
+  // ```json ... ``` ブロックを抽出
+  const codeBlockMatch = text.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/)
+  if (codeBlockMatch) return codeBlockMatch[1].trim()
+  // { で始まるJSON直書き
+  const jsonMatch = text.match(/\{[\s\S]*\}/)
+  if (jsonMatch) return jsonMatch[0]
+  return text
+}
+
+export const generateLayout = async (
+  prompt: string,
+  config?: ChatSupportConfig
+): Promise<EditorLayout> => {
+  const resolvedConfig = config ?? loadChatConfig()
+
+  const messages = [
+    { role: 'system', content: SYSTEM_PROMPT },
+    { role: 'user', content: prompt },
+  ]
+
+  const data = await callAI(resolvedConfig, messages)
+  const rawText = extractContent(data)
+  const jsonStr = extractJson(rawText)
+
+  const parsed = JSON.parse(jsonStr) as EditorLayout
+  if (!parsed.layout || !Array.isArray(parsed.layout)) {
+    throw new Error('不正なレイアウト形式です')
+  }
+
+  return parsed
+}

--- a/src/stories/06-Tools/components/editorTypes.ts
+++ b/src/stories/06-Tools/components/editorTypes.ts
@@ -1,0 +1,24 @@
+// Visual Editor 型定義
+
+export interface ComponentNode {
+  /** レジストリのキー名（例: "Card", "Typography"） */
+  component: string
+  /** コンポーネントに渡すprops */
+  props?: Record<string, unknown>
+  /** 子要素（コンポーネント配列 or テキスト） */
+  children?: ComponentNode[] | string
+  /** MUI sx prop */
+  sx?: Record<string, unknown>
+  /** Tailwind CSSクラス */
+  className?: string
+}
+
+export interface EditorLayout {
+  layout: ComponentNode[]
+}
+
+export interface EditorHistoryEntry {
+  prompt: string
+  layout: EditorLayout
+  timestamp: Date
+}


### PR DESCRIPTION
## Summary
- Visual Editor プロトタイプを Storybook「Tools」カテゴリに追加（AI + JSON スキーマでコンポーネント構成を生成）
- ServiceCard に LP ProductCard と同パターンのホバーエフェクト（ティール色シャドウ + ボーダーハイライト）を追加
- ChatSupport は Storybook 専用アシスタントとして維持（他アプリ設置は費用対効果が低いため見送り）

## Visual Editor
- 自然言語プロンプト → JSON スキーマ → kaze-ux コンポーネントでリアルタイムプレビュー
- 23個の登録コンポーネント（kaze-ux + MUI）
- 4つのプリセットテンプレート（KPI Dashboard, Registration Form, Activity Feed, Settings Page）
- 既存 ChatSupport の AI インフラ（OpenAI/Gemini）を再利用

## Test plan
- [x] TypeScript 型チェック通過（Visual Editor 固有エラーなし）
- [x] `pnpm build-storybook` 成功
- [x] `pnpm test:all` 全テスト通過
- [x] `pnpm fix` lint + format 通過
- [ ] Storybook で Visual Editor の AI 生成動作確認
- [ ] ServiceCard ホバー効果の視覚確認（Light/Dark）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visual Editorツールを追加：プロンプトでAIがUIレイアウトを生成、生成状況やエラーを画面表示
  * プリセットと自由入力対応のプロンプト入力、ショートカットで送信可能
  * 左側コンポーネントパレットとライブプレビューで要素選択・即時確認
  * StorybookにVisual Editorのストーリーを追加（開発向けドキュメント表示）

* **Style**
  * ServiceCard にダーク/ライト対応のホバー時アニメーション（境界線・影）を追加

* **Documentation**
  * プロジェクト運用やAIチャット運用に関するドキュメントを追記
<!-- end of auto-generated comment: release notes by coderabbit.ai -->