### PR TITLE
feat(ChatSupport): バックエンドプロキシ + レート制限 (Matlens パターン取り込み)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,44 @@
-# Mapbox access token - get yours at https://account.mapbox.com/tokens/
+# ============================================================================
+# Mapbox
+# ============================================================================
+# Get yours at https://account.mapbox.com/tokens/
 VITE_MAPBOX_ACCESS_TOKEN=your_mapbox_token_here
 
-# OpenAI API settings - for Storybook AI Concierge
+# ============================================================================
+# Storybook ChatSupport — Direct Mode (legacy / GitHub Pages 等)
+# ============================================================================
+# ブラウザから直接 OpenAI/Gemini を呼ぶモード。
+# JSバンドルにキーが埋め込まれるため、社内限定 or 認証付きデプロイ専用。
+# 公開デプロイの場合は Backend Mode を使用してください。
 VITE_OPENAI_API_KEY=your_openai_api_key_here
 VITE_OPENAI_MODEL=gpt-5.4-nano
+
+# ============================================================================
+# Storybook ChatSupport — Backend Mode (Vercel deployment 推奨)
+# ============================================================================
+# /api/ai 経由でサーバープロキシを使うモード。
+# - APIキーはサーバー env vars に保管（バンドルに含まれない）
+# - lib/ratelimit.ts による DAILY_LIMIT 適用
+# - X-User-API-Key ヘッダーで自前キー利用時はレート制限免除
+
+# このURLが設定されていればChatSupportは Backend Mode で動作する
+# 例: https://kaze-ux.vercel.app
+VITE_API_BASE=
+
+# ----------------------------------------------------------------------------
+# 以下はサーバー側 env vars (Vercel project settings)
+# .env ファイルではなく Vercel ダッシュボードで設定すること
+# ----------------------------------------------------------------------------
+
+# 共有プール用のサーバーキー（VITE_ プレフィックスなし、ブラウザに露出しない）
+# OPENAI_API_KEY=sk-...
+# GOOGLE_GENERATIVE_AI_API_KEY=...
+# (互換: GEMINI_API_KEY=...)
+
+# レート制限の上限（IP / 日）。デフォルト 30
+# DAILY_LIMIT=30
+
+# Upstash Redis (本番レート制限の永続化)
+# 設定がない場合は in-memory フォールバック（開発専用）
+# UPSTASH_REDIS_REST_URL=https://...
+# UPSTASH_REDIS_REST_TOKEN=...

--- a/api/ai.ts
+++ b/api/ai.ts
@@ -1,0 +1,232 @@
+// Vercel Function: AI チャットエンドポイント
+// - ChatSupport から呼ばれるバックエンドプロキシ
+// - サーバー側で API キーを保持し、ブラウザに露出させない
+// - X-User-API-Key ヘッダーで自前キー利用時はレート制限免除
+// - requiresUserKey なモデル（gpt-5.4 等）はサーバー側でも拒否
+
+import { createGoogleGenerativeAI } from '@ai-sdk/google'
+import { createOpenAI } from '@ai-sdk/openai'
+import { generateText, type ModelMessage } from 'ai'
+
+import { isAllowedOrigin, setCorsHeaders } from '../lib/cors.js'
+import {
+  checkRateLimit,
+  getClientIdentifier,
+  getDailyLimit,
+} from '../lib/ratelimit.js'
+
+// ---------------------------------------------------------------------------
+// モデル別のサーバー側ポリシー
+// ---------------------------------------------------------------------------
+
+// requiresUserKey: 共有プールで使用不可（高コストモデル）
+const REQUIRES_USER_KEY_MODELS = new Set<string>(['gpt-5.4'])
+
+const DEFAULT_MODEL = 'gpt-5.4-nano'
+
+// ---------------------------------------------------------------------------
+// リクエスト/レスポンス型
+// ---------------------------------------------------------------------------
+
+interface AIRequestBody {
+  messages: { role: string; content: string }[]
+  model?: string
+  system?: string
+  maxOutputTokens?: number
+}
+
+interface VercelRequest {
+  method?: string
+  headers: Record<string, string | string[] | undefined>
+  body?: AIRequestBody | string
+}
+
+interface VercelResponse {
+  status: (code: number) => VercelResponse
+  setHeader: (name: string, value: string) => void
+  json: (data: unknown) => void
+  end: (data?: unknown) => void
+}
+
+// ---------------------------------------------------------------------------
+// モデル解決
+// ---------------------------------------------------------------------------
+
+const resolveModel = (modelId: string, apiKey: string) => {
+  if (modelId.includes('gemini')) {
+    const google = createGoogleGenerativeAI({ apiKey })
+    return google(modelId)
+  }
+  const openai = createOpenAI({ apiKey })
+  return openai(modelId)
+}
+
+const resolveMaxOutputTokens = (model: string, requested?: number): number => {
+  if (typeof requested === 'number' && requested > 0 && requested <= 32000) {
+    return requested
+  }
+  if (model.includes('nano')) return 4000
+  if (model.includes('gpt-5') || model.includes('o1') || model.includes('o3')) {
+    return 16000
+  }
+  return 4000
+}
+
+const toModelMessages = (
+  payload: { role: string; content: string }[],
+  system?: string
+): ModelMessage[] => {
+  const messages: ModelMessage[] = []
+  if (system) {
+    messages.push({ role: 'system', content: system })
+  }
+  for (const m of payload) {
+    if (m.role === 'system') {
+      messages.push({ role: 'system', content: m.content })
+    } else if (m.role === 'assistant') {
+      messages.push({ role: 'assistant', content: m.content })
+    } else {
+      messages.push({ role: 'user', content: m.content })
+    }
+  }
+  return messages
+}
+
+const headerToString = (
+  value: string | string[] | undefined
+): string | undefined => {
+  if (!value) return undefined
+  if (Array.isArray(value)) return value[0]
+  return value
+}
+
+// ---------------------------------------------------------------------------
+// ハンドラー本体
+// ---------------------------------------------------------------------------
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const origin = headerToString(req.headers.origin)
+  setCorsHeaders(res, origin)
+
+  // CORS preflight
+  if (req.method === 'OPTIONS') {
+    res.status(204).end()
+    return
+  }
+
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' })
+    return
+  }
+
+  // Origin allowlist チェック（本番のみ）
+  if (process.env.NODE_ENV === 'production' && !isAllowedOrigin(origin)) {
+    res.status(403).json({ error: 'Origin not allowed', code: 'ORIGIN_DENIED' })
+    return
+  }
+
+  // リクエストボディのパース
+  let body: AIRequestBody
+  try {
+    if (typeof req.body === 'string') {
+      body = JSON.parse(req.body) as AIRequestBody
+    } else if (req.body) {
+      body = req.body
+    } else {
+      res.status(400).json({ error: 'Missing request body' })
+      return
+    }
+  } catch {
+    res.status(400).json({ error: 'Invalid JSON body' })
+    return
+  }
+
+  if (!Array.isArray(body.messages) || body.messages.length === 0) {
+    res.status(400).json({ error: 'messages array is required' })
+    return
+  }
+
+  const modelId = body.model || DEFAULT_MODEL
+
+  // 自前 API キー（ヘッダー）— レート制限を免除
+  const userApiKey = headerToString(req.headers['x-user-api-key'])
+
+  // requiresUserKey モデルのサーバー側強制
+  if (REQUIRES_USER_KEY_MODELS.has(modelId) && !userApiKey) {
+    res.status(403).json({
+      error: 'This model requires a user-provided API key',
+      code: 'USER_KEY_REQUIRED',
+    })
+    return
+  }
+
+  let apiKey: string
+  let usedSharedPool = false
+
+  if (userApiKey) {
+    apiKey = userApiKey
+  } else {
+    // 共有プール使用：env var からキーを取得
+    const isGemini = modelId.includes('gemini')
+    apiKey = isGemini
+      ? process.env.GOOGLE_GENERATIVE_AI_API_KEY ||
+        process.env.GEMINI_API_KEY ||
+        ''
+      : process.env.OPENAI_API_KEY || ''
+
+    if (!apiKey) {
+      res.status(500).json({
+        error: 'Server API key not configured',
+        code: 'SERVER_KEY_MISSING',
+      })
+      return
+    }
+
+    // 共有プール使用時のみレート制限を適用
+    const identifier = getClientIdentifier(req)
+    const result = await checkRateLimit(identifier)
+
+    res.setHeader('X-RateLimit-Limit', String(result.limit))
+    res.setHeader('X-RateLimit-Remaining', String(result.remaining))
+    res.setHeader('X-RateLimit-Reset', String(result.reset))
+
+    if (!result.success) {
+      res.status(429).json({
+        error: 'Daily quota exceeded',
+        code: 'RATE_LIMIT',
+        limit: result.limit,
+        remaining: result.remaining,
+        reset: result.reset,
+      })
+      return
+    }
+
+    usedSharedPool = true
+  }
+
+  // AI SDK 呼び出し
+  try {
+    const model = resolveModel(modelId, apiKey)
+    const result = await generateText({
+      model,
+      messages: toModelMessages(body.messages, body.system),
+      maxOutputTokens: resolveMaxOutputTokens(modelId, body.maxOutputTokens),
+      abortSignal: AbortSignal.timeout(45000),
+    })
+
+    res.status(200).json({
+      text: result.text,
+      finishReason: result.finishReason,
+      usedSharedPool,
+      sharedPoolLimit: usedSharedPool ? getDailyLimit() : undefined,
+    })
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error)
+    const statusCode =
+      error instanceof Error && error.name === 'TimeoutError' ? 504 : 502
+    res.status(statusCode).json({
+      error: message,
+      code: statusCode === 504 ? 'TIMEOUT' : 'AI_PROVIDER_ERROR',
+    })
+  }
+}

--- a/lib/__tests__/cors.test.ts
+++ b/lib/__tests__/cors.test.ts
@@ -1,0 +1,104 @@
+// lib/cors ユニットテスト
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { isAllowedOrigin, setCorsHeaders } from '../cors'
+
+describe('isAllowedOrigin', () => {
+  it('localhost を許可', () => {
+    expect(isAllowedOrigin('http://localhost')).toBe(true)
+    expect(isAllowedOrigin('http://localhost:5173')).toBe(true)
+    expect(isAllowedOrigin('https://localhost:6006')).toBe(true)
+  })
+
+  it('127.0.0.1 を許可', () => {
+    expect(isAllowedOrigin('http://127.0.0.1')).toBe(true)
+    expect(isAllowedOrigin('http://127.0.0.1:6006')).toBe(true)
+  })
+
+  it('Vercel デプロイ URL を許可', () => {
+    expect(isAllowedOrigin('https://kaze-ux.vercel.app')).toBe(true)
+    expect(isAllowedOrigin('https://kaze-ux-git-main.vercel.app')).toBe(true)
+    expect(
+      isAllowedOrigin(
+        'https://kaze-ux-feat-chatsupport-backend-proxy.vercel.app'
+      )
+    ).toBe(true)
+  })
+
+  it('GitHub Pages を許可', () => {
+    expect(isAllowedOrigin('https://boxpistols.github.io')).toBe(true)
+  })
+
+  it('未許可オリジンを拒否', () => {
+    expect(isAllowedOrigin('https://evil.example.com')).toBe(false)
+    expect(isAllowedOrigin('https://kaze-ux.evil.com')).toBe(false)
+    expect(isAllowedOrigin('http://kaze-ux.vercel.app')).toBe(false) // http
+    expect(isAllowedOrigin('https://other.vercel.app')).toBe(false)
+  })
+
+  it('null/undefined/空文字を拒否', () => {
+    expect(isAllowedOrigin(undefined)).toBe(false)
+    expect(isAllowedOrigin(null)).toBe(false)
+    expect(isAllowedOrigin('')).toBe(false)
+  })
+})
+
+describe('setCorsHeaders', () => {
+  const createResMock = () => {
+    const setHeader = vi.fn()
+    return { setHeader, headers: () => setHeader.mock.calls }
+  }
+
+  it('許可オリジンの場合、Access-Control-Allow-Origin にエコー', () => {
+    const res = createResMock()
+    setCorsHeaders(res, 'https://kaze-ux.vercel.app')
+
+    const calls = res.headers()
+    expect(calls).toContainEqual([
+      'Access-Control-Allow-Origin',
+      'https://kaze-ux.vercel.app',
+    ])
+    expect(calls).toContainEqual(['Vary', 'Origin'])
+  })
+
+  it('未許可オリジンの場合、Allow-Origin を設定しない', () => {
+    const res = createResMock()
+    setCorsHeaders(res, 'https://evil.example.com')
+
+    const calls = res.headers()
+    const hasAllowOrigin = calls.some(
+      ([name]) => name === 'Access-Control-Allow-Origin'
+    )
+    expect(hasAllowOrigin).toBe(false)
+  })
+
+  it('共通ヘッダー（Methods/Headers/Max-Age）は常に設定', () => {
+    const res = createResMock()
+    setCorsHeaders(res, 'https://kaze-ux.vercel.app')
+
+    const calls = res.headers()
+    expect(calls).toContainEqual([
+      'Access-Control-Allow-Methods',
+      'POST, OPTIONS',
+    ])
+    expect(calls).toContainEqual([
+      'Access-Control-Allow-Headers',
+      'Content-Type, X-User-API-Key',
+    ])
+    expect(calls).toContainEqual(['Access-Control-Max-Age', '86400'])
+  })
+
+  it('レート制限ヘッダーを Expose-Headers に含める', () => {
+    const res = createResMock()
+    setCorsHeaders(res, 'https://kaze-ux.vercel.app')
+
+    const calls = res.headers()
+    const exposeCall = calls.find(
+      ([name]) => name === 'Access-Control-Expose-Headers'
+    )
+    expect(exposeCall?.[1]).toContain('X-RateLimit-Limit')
+    expect(exposeCall?.[1]).toContain('X-RateLimit-Remaining')
+    expect(exposeCall?.[1]).toContain('X-RateLimit-Reset')
+  })
+})

--- a/lib/__tests__/ratelimit.test.ts
+++ b/lib/__tests__/ratelimit.test.ts
@@ -1,0 +1,126 @@
+// lib/ratelimit ユニットテスト
+// - in-memory フォールバックの挙動を検証
+// - Upstash Redis 経路は env vars が設定されていないので自動的に in-memory が使われる
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  __resetRateLimitState,
+  checkRateLimit,
+  getClientIdentifier,
+  getDailyLimit,
+} from '../ratelimit'
+
+beforeEach(() => {
+  __resetRateLimitState()
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+// ---------------------------------------------------------------------------
+// checkRateLimit (in-memory mode)
+// ---------------------------------------------------------------------------
+
+describe('checkRateLimit (in-memory)', () => {
+  it('初回呼び出しは success=true、remaining=limit-1', async () => {
+    const result = await checkRateLimit('user-1')
+    expect(result.success).toBe(true)
+    expect(result.limit).toBe(getDailyLimit())
+    expect(result.remaining).toBe(getDailyLimit() - 1)
+    expect(result.reset).toBeGreaterThan(Date.now())
+  })
+
+  it('連続呼び出しで remaining が減少する', async () => {
+    const r1 = await checkRateLimit('user-2')
+    const r2 = await checkRateLimit('user-2')
+    const r3 = await checkRateLimit('user-2')
+
+    expect(r1.remaining).toBe(getDailyLimit() - 1)
+    expect(r2.remaining).toBe(getDailyLimit() - 2)
+    expect(r3.remaining).toBe(getDailyLimit() - 3)
+  })
+
+  it('異なる identifier は独立してカウント', async () => {
+    await checkRateLimit('user-a')
+    await checkRateLimit('user-a')
+    const userA = await checkRateLimit('user-a')
+    const userB = await checkRateLimit('user-b')
+
+    expect(userA.remaining).toBe(getDailyLimit() - 3)
+    expect(userB.remaining).toBe(getDailyLimit() - 1)
+  })
+
+  it('上限到達後は success=false', async () => {
+    const limit = getDailyLimit()
+    let lastResult
+    for (let i = 0; i < limit + 1; i++) {
+      lastResult = await checkRateLimit('user-overflow')
+    }
+    expect(lastResult?.success).toBe(false)
+    expect(lastResult?.remaining).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getDailyLimit (env var 解釈)
+// ---------------------------------------------------------------------------
+
+describe('getDailyLimit', () => {
+  it('デフォルトは 30', () => {
+    // env var なしで初期化（モジュールキャッシュの都合で動的に検証は難しい）
+    // 現在のプロセスで env が設定されていない前提で 30 を期待
+    const limit = getDailyLimit()
+    expect(typeof limit).toBe('number')
+    expect(limit).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getClientIdentifier
+// ---------------------------------------------------------------------------
+
+describe('getClientIdentifier', () => {
+  it('x-vercel-forwarded-for を優先', () => {
+    const id = getClientIdentifier({
+      headers: {
+        'x-vercel-forwarded-for': '203.0.113.5, 198.51.100.1',
+        'x-forwarded-for': '10.0.0.1',
+      },
+    })
+    expect(id).toBe('203.0.113.5')
+  })
+
+  it('x-forwarded-for にフォールバック', () => {
+    const id = getClientIdentifier({
+      headers: {
+        'x-forwarded-for': '203.0.113.10, 198.51.100.5',
+      },
+    })
+    expect(id).toBe('203.0.113.10')
+  })
+
+  it('x-real-ip にフォールバック', () => {
+    const id = getClientIdentifier({
+      headers: {
+        'x-real-ip': '203.0.113.20',
+      },
+    })
+    expect(id).toBe('203.0.113.20')
+  })
+
+  it('全て無い場合は unknown', () => {
+    const id = getClientIdentifier({ headers: {} })
+    expect(id).toBe('unknown')
+  })
+
+  it('配列ヘッダー値も処理', () => {
+    const id = getClientIdentifier({
+      headers: {
+        'x-vercel-forwarded-for': ['203.0.113.30', '198.51.100.10'],
+      },
+    })
+    expect(id).toBe('203.0.113.30')
+  })
+})

--- a/lib/cors.ts
+++ b/lib/cors.ts
@@ -1,0 +1,40 @@
+// CORS 設定
+// - Storybook (gh-pages / Vercel preview / production) からのアクセスを許可
+// - localhost は開発用に常時許可
+// - 厳格な allowlist で wild card は使わない
+
+const ALLOWED_ORIGIN_PATTERNS: RegExp[] = [
+  // ローカル開発
+  /^https?:\/\/localhost(:\d+)?$/,
+  /^https?:\/\/127\.0\.0\.1(:\d+)?$/,
+  // Vercel デプロイ（production / preview / branch）
+  /^https:\/\/kaze-ux(-[a-z0-9-]+)?\.vercel\.app$/,
+  // GitHub Pages
+  /^https:\/\/boxpistols\.github\.io$/,
+]
+
+export const isAllowedOrigin = (origin: string | undefined | null): boolean => {
+  if (!origin) return false
+  return ALLOWED_ORIGIN_PATTERNS.some((pattern) => pattern.test(origin))
+}
+
+interface ResponseLike {
+  setHeader: (name: string, value: string) => void
+}
+
+export const setCorsHeaders = (
+  res: ResponseLike,
+  origin: string | undefined | null
+): void => {
+  if (origin && isAllowedOrigin(origin)) {
+    res.setHeader('Access-Control-Allow-Origin', origin)
+    res.setHeader('Vary', 'Origin')
+  }
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, X-User-API-Key')
+  res.setHeader(
+    'Access-Control-Expose-Headers',
+    'X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset'
+  )
+  res.setHeader('Access-Control-Max-Age', '86400')
+}

--- a/lib/ratelimit.ts
+++ b/lib/ratelimit.ts
@@ -1,0 +1,163 @@
+// レート制限
+// - Upstash Redis 設定があれば slidingWindow で本番運用
+// - 設定がない場合は in-memory フォールバック（開発専用）
+// - IP ベース、X-Vercel-Forwarded-For を優先
+
+import { Ratelimit } from '@upstash/ratelimit'
+import { Redis } from '@upstash/redis'
+
+// ---------------------------------------------------------------------------
+// 設定
+// ---------------------------------------------------------------------------
+
+const DEFAULT_DAILY_LIMIT = 30
+const DAILY_LIMIT = (() => {
+  const raw = process.env.DAILY_LIMIT
+  if (!raw) return DEFAULT_DAILY_LIMIT
+  const parsed = parseInt(raw, 10)
+  return Number.isNaN(parsed) || parsed <= 0 ? DEFAULT_DAILY_LIMIT : parsed
+})()
+
+// ---------------------------------------------------------------------------
+// Upstash インスタンス（lazy init）
+// ---------------------------------------------------------------------------
+
+let cachedRatelimit: Ratelimit | null = null
+let upstashAvailable: boolean | null = null
+
+const getUpstashRatelimit = (): Ratelimit | null => {
+  if (cachedRatelimit) return cachedRatelimit
+  if (upstashAvailable === false) return null
+
+  const url = process.env.UPSTASH_REDIS_REST_URL
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN
+
+  if (!url || !token) {
+    upstashAvailable = false
+    return null
+  }
+
+  try {
+    const redis = new Redis({ url, token })
+    cachedRatelimit = new Ratelimit({
+      redis,
+      limiter: Ratelimit.slidingWindow(DAILY_LIMIT, '1 d'),
+      analytics: true,
+      prefix: 'kaze-ux/ai',
+    })
+    upstashAvailable = true
+    return cachedRatelimit
+  } catch (error) {
+    console.error('[ratelimit] Upstash 初期化失敗:', error)
+    upstashAvailable = false
+    return null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// In-memory フォールバック（開発専用）
+// ---------------------------------------------------------------------------
+
+interface InMemoryEntry {
+  count: number
+  resetAt: number
+}
+
+const inMemoryStore = new Map<string, InMemoryEntry>()
+const DAY_MS = 24 * 60 * 60 * 1000
+
+const checkInMemory = (identifier: string): RateLimitResult => {
+  const now = Date.now()
+  const entry = inMemoryStore.get(identifier)
+
+  if (!entry || entry.resetAt < now) {
+    inMemoryStore.set(identifier, { count: 1, resetAt: now + DAY_MS })
+    return {
+      success: true,
+      limit: DAILY_LIMIT,
+      remaining: DAILY_LIMIT - 1,
+      reset: now + DAY_MS,
+    }
+  }
+
+  entry.count += 1
+  return {
+    success: entry.count <= DAILY_LIMIT,
+    limit: DAILY_LIMIT,
+    remaining: Math.max(0, DAILY_LIMIT - entry.count),
+    reset: entry.resetAt,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 公開 API
+// ---------------------------------------------------------------------------
+
+export interface RateLimitResult {
+  success: boolean
+  limit: number
+  remaining: number
+  reset: number
+}
+
+export const checkRateLimit = async (
+  identifier: string
+): Promise<RateLimitResult> => {
+  const upstash = getUpstashRatelimit()
+
+  if (upstash) {
+    const result = await upstash.limit(identifier)
+    return {
+      success: result.success,
+      limit: result.limit,
+      remaining: result.remaining,
+      reset: result.reset,
+    }
+  }
+
+  return checkInMemory(identifier)
+}
+
+export const getDailyLimit = (): number => DAILY_LIMIT
+
+// ---------------------------------------------------------------------------
+// クライアント識別子（IP）取得
+// ---------------------------------------------------------------------------
+
+interface RequestLike {
+  headers: Record<string, string | string[] | undefined>
+}
+
+const headerToString = (
+  value: string | string[] | undefined
+): string | undefined => {
+  if (!value) return undefined
+  if (Array.isArray(value)) return value[0]
+  return value
+}
+
+export const getClientIdentifier = (req: RequestLike): string => {
+  // Vercel 環境では x-vercel-forwarded-for が最も信頼可能
+  const vercelFwd = headerToString(req.headers['x-vercel-forwarded-for'])
+  if (vercelFwd) return vercelFwd.split(',')[0].trim()
+
+  // 標準フォールバック
+  const xff = headerToString(req.headers['x-forwarded-for'])
+  if (xff) return xff.split(',')[0].trim()
+
+  const realIp = headerToString(req.headers['x-real-ip'])
+  if (realIp) return realIp
+
+  return 'unknown'
+}
+
+// ---------------------------------------------------------------------------
+// テスト用ヘルパー
+// ---------------------------------------------------------------------------
+
+/** 内部状態をリセット（テスト専用） */
+export const __resetRateLimitState = (): void => {
+  inMemoryStore.clear()
+  cachedRatelimit = null
+  upstashAvailable = null
+}

--- a/package.json
+++ b/package.json
@@ -105,6 +105,8 @@
     "@turf/turf": "^7.3.4",
     "@types/maplibre-gl": "^1.14.0",
     "@types/react-router-dom": "^5.3.3",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.37.0",
     "ai": "^6.0.156",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,12 @@ importers:
       '@types/react-router-dom':
         specifier: ^5.3.3
         version: 5.3.3
+      '@upstash/ratelimit':
+        specifier: ^2.0.8
+        version: 2.0.8(@upstash/redis@1.37.0)
+      '@upstash/redis':
+        specifier: ^1.37.0
+        version: 1.37.0
       ai:
         specifier: ^6.0.156
         version: 6.0.156(zod@4.3.6)
@@ -2279,6 +2285,18 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@upstash/core-analytics@0.0.10':
+    resolution: {integrity: sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==}
+    engines: {node: '>=16.0.0'}
+
+  '@upstash/ratelimit@2.0.8':
+    resolution: {integrity: sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==}
+    peerDependencies:
+      '@upstash/redis': ^1.34.3
+
+  '@upstash/redis@1.37.0':
+    resolution: {integrity: sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==}
 
   '@valibot/to-json-schema@1.6.0':
     resolution: {integrity: sha512-d6rYyK5KVa2XdqamWgZ4/Nr+cXhxjy7lmpe6Iajw15J/jmU+gyxl2IEd1Otg1d7Rl3gOQL5reulnSypzBtYy1A==}
@@ -5420,6 +5438,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -8511,6 +8532,19 @@ snapshots:
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@upstash/core-analytics@0.0.10':
+    dependencies:
+      '@upstash/redis': 1.37.0
+
+  '@upstash/ratelimit@2.0.8(@upstash/redis@1.37.0)':
+    dependencies:
+      '@upstash/core-analytics': 0.0.10
+      '@upstash/redis': 1.37.0
+
+  '@upstash/redis@1.37.0':
+    dependencies:
+      uncrypto: 0.1.3
 
   '@valibot/to-json-schema@1.6.0(valibot@1.2.0(typescript@5.9.3))':
     dependencies:
@@ -12372,6 +12406,8 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  uncrypto@0.1.3: {}
 
   undici-types@6.21.0: {}
 

--- a/src/components/ui/ChatSupport/__tests__/chatAiService.test.ts
+++ b/src/components/ui/ChatSupport/__tests__/chatAiService.test.ts
@@ -238,3 +238,162 @@ describe('extractContent', () => {
     spy.mockRestore()
   })
 })
+
+// ---------------------------------------------------------------------------
+// callAI (バックエンドモード) — VITE_API_BASE が設定されている場合の挙動
+// ---------------------------------------------------------------------------
+
+describe('callAI (backend mode)', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.resetModules()
+    vi.stubEnv('VITE_API_BASE', 'https://api.example.com')
+    fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+  })
+
+  const mockBackendResponse = (
+    status: number,
+    body: object,
+    headers: Record<string, string> = {}
+  ) => {
+    fetchSpy.mockResolvedValue({
+      ok: status >= 200 && status < 300,
+      status,
+      headers: new Headers(headers),
+      json: () => Promise.resolve(body),
+    })
+  }
+
+  describe('正常系', () => {
+    it('VITE_API_BASE が設定されると /api/ai を呼ぶ', async () => {
+      mockBackendResponse(200, { text: 'こんにちは', finishReason: 'stop' })
+      const { callAI } = await import('../chatAiService')
+
+      const result = await callAI(baseConfig, userMessage)
+
+      expect(result).toBe('こんにちは')
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://api.example.com/api/ai',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+
+    it('config.apiKey があれば X-User-API-Key ヘッダーを送る', async () => {
+      mockBackendResponse(200, { text: 'ok', finishReason: 'stop' })
+      const { callAI } = await import('../chatAiService')
+
+      await callAI({ ...baseConfig, apiKey: 'sk-user-key' }, userMessage)
+
+      const callArgs = fetchSpy.mock.calls[0][1]
+      expect(callArgs.headers['X-User-API-Key']).toBe('sk-user-key')
+    })
+
+    it('config.apiKey が空なら X-User-API-Key を送らない', async () => {
+      mockBackendResponse(200, { text: 'ok', finishReason: 'stop' })
+      const { callAI } = await import('../chatAiService')
+
+      await callAI({ ...baseConfig, apiKey: '' }, userMessage)
+
+      const callArgs = fetchSpy.mock.calls[0][1]
+      expect(callArgs.headers['X-User-API-Key']).toBeUndefined()
+    })
+
+    it('リクエストボディに messages / model / maxOutputTokens を含む', async () => {
+      mockBackendResponse(200, { text: 'ok', finishReason: 'stop' })
+      const { callAI } = await import('../chatAiService')
+
+      await callAI({ ...baseConfig, model: 'gpt-5-nano' }, userMessage)
+
+      const callArgs = fetchSpy.mock.calls[0][1]
+      const body = JSON.parse(callArgs.body)
+      expect(body.messages).toEqual(userMessage)
+      expect(body.model).toBe('gpt-5-nano')
+      expect(body.maxOutputTokens).toBe(4000)
+    })
+  })
+
+  describe('エラーハンドリング', () => {
+    it('429 → AIQuotaError をスロー', async () => {
+      mockBackendResponse(
+        429,
+        { error: 'Daily quota exceeded', limit: 30, remaining: 0, reset: 123 },
+        { 'X-RateLimit-Limit': '30', 'X-RateLimit-Remaining': '0' }
+      )
+      const { callAI, AIQuotaError } = await import('../chatAiService')
+
+      await expect(callAI(baseConfig, userMessage)).rejects.toThrow(
+        AIQuotaError
+      )
+    })
+
+    it('AIQuotaError は remaining/limit/reset を持つ', async () => {
+      mockBackendResponse(429, {
+        error: 'Daily quota exceeded',
+        limit: 30,
+        remaining: 0,
+        reset: 999,
+      })
+      const { callAI, AIQuotaError } = await import('../chatAiService')
+
+      try {
+        await callAI(baseConfig, userMessage)
+        expect.fail('should throw')
+      } catch (error) {
+        expect(error).toBeInstanceOf(AIQuotaError)
+        if (error instanceof AIQuotaError) {
+          expect(error.limit).toBe(30)
+          expect(error.remaining).toBe(0)
+          expect(error.reset).toBe(999)
+        }
+      }
+    })
+
+    it('403 + USER_KEY_REQUIRED → AIUserKeyRequiredError をスロー', async () => {
+      mockBackendResponse(403, {
+        error: 'requires user key',
+        code: 'USER_KEY_REQUIRED',
+      })
+      const { callAI, AIUserKeyRequiredError } =
+        await import('../chatAiService')
+
+      await expect(callAI(baseConfig, userMessage)).rejects.toThrow(
+        AIUserKeyRequiredError
+      )
+    })
+
+    it('403 (オリジン拒否等) は通常のエラー', async () => {
+      mockBackendResponse(403, { error: 'Origin not allowed' })
+      const { callAI } = await import('../chatAiService')
+
+      await expect(callAI(baseConfig, userMessage)).rejects.toThrow(
+        'Origin not allowed'
+      )
+    })
+
+    it('5xx エラーをスロー', async () => {
+      mockBackendResponse(502, { error: 'AI provider error' })
+      const { callAI } = await import('../chatAiService')
+
+      await expect(callAI(baseConfig, userMessage)).rejects.toThrow(
+        'AI provider error'
+      )
+    })
+  })
+
+  describe('finishReason フォールバック', () => {
+    it('空テキスト + finishReason=length でトークン上限メッセージ', async () => {
+      mockBackendResponse(200, { text: '', finishReason: 'length' })
+      const { callAI } = await import('../chatAiService')
+
+      const result = await callAI(baseConfig, userMessage)
+      expect(result).toContain('トークン上限')
+    })
+  })
+})

--- a/src/components/ui/ChatSupport/chatAiService.ts
+++ b/src/components/ui/ChatSupport/chatAiService.ts
@@ -1,7 +1,14 @@
-// ChatSupport AI API呼び出しサービス（AI SDK v6ベース）
-// - 手動fetch / URL切替 / レスポンス抽出ロジックを AI SDK v6 に一任
-// - OpenAI / Gemini / OpenAI Responses API を SDK 内部で透過的に処理
-// - タイムアウトは AbortSignal.timeout による宣言的制御
+// ChatSupport AI API呼び出しサービス（AI SDK v6 + ハイブリッドモード）
+//
+// モード切替:
+// - VITE_API_BASE が設定されていれば → バックエンドプロキシ (/api/ai) 経由
+// - 設定されていなければ → ブラウザから AI SDK 直接呼び出し（旧来動作）
+//
+// バックエンド経由のメリット:
+// - APIキーがブラウザに露出しない（サーバー env vars に保管）
+// - サーバー側 lib/ratelimit.ts による DAILY_LIMIT 適用
+// - X-User-API-Key ヘッダーで自前キー利用時はレート制限免除
+// - requiresUserKey なモデルはサーバー側でも拒否
 
 import { createGoogleGenerativeAI } from '@ai-sdk/google'
 import { createOpenAI } from '@ai-sdk/openai'
@@ -10,24 +17,40 @@ import { generateText, type ModelMessage } from 'ai'
 import type { ChatSupportConfig } from './chatSupportTypes'
 
 // ---------------------------------------------------------------------------
-// モデルプロバイダの解決
+// モード判定
 // ---------------------------------------------------------------------------
 
-const resolveModel = (config: ChatSupportConfig) => {
-  const isGemini = config.model.includes('gemini')
-  if (isGemini) {
-    const google = createGoogleGenerativeAI({ apiKey: config.apiKey })
-    return google(config.model)
+const API_BASE = (import.meta.env.VITE_API_BASE as string | undefined) || ''
+const isBackendMode = (): boolean => API_BASE.length > 0
+
+// ---------------------------------------------------------------------------
+// 構造化エラー: UI 側でクォータ表示・自前キー入力 CTA を出すために型で区別
+// ---------------------------------------------------------------------------
+
+export class AIQuotaError extends Error {
+  constructor(
+    public readonly remaining: number,
+    public readonly limit: number,
+    public readonly reset: number
+  ) {
+    super(
+      `本日の無料枠 (${limit}回) を使い切りました。明日リセットされます。設定から自前APIキーを入力すると無制限利用できます。`
+    )
+    this.name = 'AIQuotaError'
   }
-  const openai = createOpenAI({ apiKey: config.apiKey })
-  return openai(config.model)
+}
+
+export class AIUserKeyRequiredError extends Error {
+  constructor() {
+    super(
+      'このモデルは自分のAPIキーが必要です。設定からキーを入力してください。'
+    )
+    this.name = 'AIUserKeyRequiredError'
+  }
 }
 
 // ---------------------------------------------------------------------------
-// モデル別 maxOutputTokens の決定
-// - nano 系: 4000 で十分
-// - mini/reasoning 系: 推論トークン消費を見込んで 16000
-// - テスト接続: 50 固定
+// 共通: モデル別 maxOutputTokens の決定
 // ---------------------------------------------------------------------------
 
 const resolveMaxOutputTokens = (model: string, isTest: boolean): number => {
@@ -40,7 +63,7 @@ const resolveMaxOutputTokens = (model: string, isTest: boolean): number => {
 }
 
 // ---------------------------------------------------------------------------
-// メッセージ変換: 独自形式 → AI SDK v6 の ModelMessage 配列
+// 共通: メッセージ変換
 // ---------------------------------------------------------------------------
 
 const toModelMessages = (
@@ -57,9 +80,123 @@ const toModelMessages = (
   })
 
 // ---------------------------------------------------------------------------
-// AI 呼び出し（OpenAI / Gemini 両対応・AI SDK v6）
-// - 戻り値は生成テキスト文字列
-// - 既存呼び出し側互換のため extractContent もパススルーで維持
+// バックエンドモード: /api/ai 経由
+// ---------------------------------------------------------------------------
+
+interface BackendResponse {
+  text: string
+  finishReason?: string
+  usedSharedPool?: boolean
+  sharedPoolLimit?: number
+}
+
+const callViaBackend = async (
+  config: ChatSupportConfig,
+  messagesPayload: { role: string; content: string }[],
+  isTest: boolean
+): Promise<string> => {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  }
+
+  // 自前 APIキーがあればヘッダーで送信 → サーバー側でレート制限免除
+  if (config.apiKey) {
+    headers['X-User-API-Key'] = config.apiKey
+  }
+
+  const response = await fetch(`${API_BASE}/api/ai`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      messages: messagesPayload,
+      model: config.model,
+      maxOutputTokens: resolveMaxOutputTokens(config.model, isTest),
+    }),
+    signal: AbortSignal.timeout(60000),
+  })
+
+  // 429: クォータ超過 → AIQuotaError
+  if (response.status === 429) {
+    const data = (await response.json().catch(() => ({}))) as {
+      remaining?: number
+      limit?: number
+      reset?: number
+    }
+    throw new AIQuotaError(
+      data.remaining ?? 0,
+      data.limit ?? 30,
+      data.reset ?? 0
+    )
+  }
+
+  // 403: モデル制限（USER_KEY_REQUIRED）or オリジン拒否
+  if (response.status === 403) {
+    const data = (await response.json().catch(() => ({}))) as {
+      code?: string
+      error?: string
+    }
+    if (data.code === 'USER_KEY_REQUIRED') {
+      throw new AIUserKeyRequiredError()
+    }
+    throw new Error(data.error || 'Forbidden')
+  }
+
+  if (!response.ok) {
+    const data = (await response.json().catch(() => ({}))) as {
+      error?: string
+    }
+    throw new Error(data.error || `HTTP ${response.status}`)
+  }
+
+  const data = (await response.json()) as BackendResponse
+
+  // finishReason=length で空テキストの場合のフォールバック
+  if (!data.text && data.finishReason === 'length') {
+    return '(回答生成中にトークン上限に達しました。もう少し短い質問で再度お試しください)'
+  }
+
+  return data.text
+}
+
+// ---------------------------------------------------------------------------
+// ダイレクトモード: ブラウザから AI SDK 直接呼び出し（旧来動作）
+// ---------------------------------------------------------------------------
+
+const resolveModelDirect = (config: ChatSupportConfig) => {
+  const isGemini = config.model.includes('gemini')
+  if (isGemini) {
+    const google = createGoogleGenerativeAI({ apiKey: config.apiKey })
+    return google(config.model)
+  }
+  const openai = createOpenAI({ apiKey: config.apiKey })
+  return openai(config.model)
+}
+
+const callDirect = async (
+  config: ChatSupportConfig,
+  messagesPayload: { role: string; content: string }[],
+  isTest: boolean
+): Promise<string> => {
+  const model = resolveModelDirect(config)
+  const maxOutputTokens = resolveMaxOutputTokens(config.model, isTest)
+  const abortSignal = AbortSignal.timeout(60000)
+
+  const result = await generateText({
+    model,
+    messages: toModelMessages(messagesPayload),
+    maxOutputTokens,
+    abortSignal,
+  })
+
+  if (!result.text && result.finishReason === 'length') {
+    return '(回答生成中にトークン上限に達しました。もう少し短い質問で再度お試しください)'
+  }
+
+  return result.text
+}
+
+// ---------------------------------------------------------------------------
+// 公開 API: callAI（ハイブリッドディスパッチャー）
 // ---------------------------------------------------------------------------
 
 export const callAI = async (
@@ -67,28 +204,21 @@ export const callAI = async (
   messagesPayload: { role: string; content: string }[],
   isTest = false
 ): Promise<string> => {
-  const model = resolveModel(config)
-  const maxOutputTokens = resolveMaxOutputTokens(config.model, isTest)
-
-  // タイムアウト60秒（AI SDK v6のabortSignal経由）
-  const abortSignal = AbortSignal.timeout(60000)
-
   try {
-    const result = await generateText({
-      model,
-      messages: toModelMessages(messagesPayload),
-      maxOutputTokens,
-      abortSignal,
-    })
-
-    // finish_reason が 'length' でテキストが空の場合はフォールバックメッセージ
-    if (!result.text && result.finishReason === 'length') {
-      return '(回答生成中にトークン上限に達しました。もう少し短い質問で再度お試しください)'
+    if (isBackendMode()) {
+      return await callViaBackend(config, messagesPayload, isTest)
+    }
+    return await callDirect(config, messagesPayload, isTest)
+  } catch (error: unknown) {
+    // 構造化エラーはそのまま再スロー（UI 側で型分岐するため）
+    if (
+      error instanceof AIQuotaError ||
+      error instanceof AIUserKeyRequiredError
+    ) {
+      throw error
     }
 
-    return result.text
-  } catch (error: unknown) {
-    // AbortSignal.timeout は TimeoutError、従来は AbortError
+    // タイムアウト系
     if (error instanceof Error) {
       if (error.name === 'AbortError' || error.name === 'TimeoutError') {
         throw new Error('リクエストがタイムアウトしました (60秒)')
@@ -100,9 +230,7 @@ export const callAI = async (
 }
 
 // ---------------------------------------------------------------------------
-// 後方互換: 旧API extractContent
-// - 新 callAI は文字列を直接返すため、単なるパススルー
-// - 既存の ChatSupport.tsx の `extractContent(data)` 呼び出しを壊さない
+// 後方互換: extractContent（パススルー）
 // ---------------------------------------------------------------------------
 
 export const extractContent = (data: unknown): string => {


### PR DESCRIPTION
## Summary

- `api/ai.ts` — Vercel Function としてバックエンドプロキシを追加。API キーをサーバー側で保持しブラウザに露出させない
- `lib/ratelimit.ts` — Upstash Redis による sliding window レート制限（未設定時は in-memory フォールバック）
- `lib/cors.ts` — 許可オリジン制御
- `chatAiService.ts` — プロキシ優先 + ユーザー自前キーの2パス切り替え
- Matlens の本番投入済みパターンを kaze-ux に逆輸入

**PR #25（AI SDK v6）の上に積んでいたブランチを main にリベース済み。**

## Test plan

- [x] `pnpm test:run` — 324/324 passed
- [x] `pnpm lint` — clean
- [x] `pnpm build-storybook` — success
- [ ] Vercel デプロイ後: `/api/ai` エンドポイントの疎通確認
- [ ] `UPSTASH_REDIS_REST_URL` 未設定時の in-memory フォールバック動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * AIチャットのバックエンドプロキシモードに対応。`VITE_API_BASE`が設定されている場合、リクエストはサーバー経由で処理されます。
  * 1日のAPI利用回数制限機能を実装。レート制限超過時は詳細な残回数情報を提供します。
  * 複数のAIプロバイダー（OpenAI、Google Gemini）をサポート。
  * APIキー不足や利用超過時の専用エラーハンドリングを追加。

* **その他**
  * 環境設定例を更新し、ダイレクトモードとバックエンドモードの設定を整理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->