### PR TITLE
refactor(ChatSupport): 1831行モノリスを hooks + components に分割

### DIFF
--- a/src/components/ui/ChatSupport/ChatSupport.tsx
+++ b/src/components/ui/ChatSupport/ChatSupport.tsx
@@ -1,1621 +1,154 @@
-import {
-  Avatar,
-  Box,
-  Fab,
-  IconButton,
-  Paper,
-  Stack,
-  TextField,
-  Typography,
-  Zoom,
-  useTheme,
-  CircularProgress,
-  MenuItem,
-  InputAdornment,
-  Divider,
-  Button,
-  Alert,
-  Slide,
-  Link,
-  Chip,
-} from '@mui/material'
-import {
-  X,
-  Send,
-  User,
-  Bot,
-  Trash2,
-  Sparkles,
-  Settings,
-  Eye,
-  EyeOff,
-  ChevronLeft,
-  CheckCircle2,
-  AlertCircle,
-  PanelRight,
-  MessageSquare,
-  Download,
-  Keyboard,
-  Info,
-  Lock,
-} from 'lucide-react'
-import { useState, useRef, useEffect, useCallback, useMemo } from 'react'
-import ReactMarkdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
+// ChatSupport — Storybook AI コンシェルジュ
+// ロジックは hooks/ に、UI は components/ に分割済み。
+// このファイルはレイアウト構成のみを担当する (~170行)。
+
+import { Box, Fab, Paper, Slide, Zoom, useTheme } from '@mui/material'
+import { useCallback } from 'react'
 
 import BookConciergeIcon from './BookConciergeIcon'
-import { callAI, extractContent } from './chatAiService'
-import {
-  SYSTEM_PROMPT,
-  isMac,
-  SHORTCUT_METADATA,
-  createDefaultShortcuts,
-  normalizeShortcutKey,
-  formatShortcutLabel,
-  MODIFIER_ONLY_KEYS,
-  CHAT_STORAGE_KEY,
-  CONFIG_STORAGE_KEY,
-  DEFAULT_API_KEY,
-  DEFAULT_MODEL,
-  OPENAI_MODELS,
-  GEMINI_MODELS,
-  loadChatConfig,
-  isShortcutMatch,
-} from './chatSupportConstants'
-import CodeBlock, { CodeBlockPre } from './CodeBlock'
-import {
-  initEmbeddingIndex,
-  semanticSearch,
-  buildSemanticContext,
-  findSemanticFaqAnswer,
-  getEmbeddingIndex,
-} from './embeddingSearch'
-import {
-  FAQ_DATABASE,
-  findFaqAnswer,
-  QUICK_SUGGESTIONS,
-  INITIAL_GREETING,
-} from './faqDatabase'
-import { findStoryGuide } from './storyGuideMap'
+import { ChatHeader } from './components/ChatHeader'
+import { ChatInput } from './components/ChatInput'
+import { ChatMessageList } from './components/ChatMessageList'
+import { ChatPageContextChip } from './components/ChatPageContextChip'
+import { ChatSettings } from './components/ChatSettings'
+import { useChatConfig } from './hooks/useChatConfig'
+import { useChatMessage } from './hooks/useChatMessage'
+import { useChatShortcuts } from './hooks/useChatShortcuts'
+import { useChatState } from './hooks/useChatState'
 import { useWidgetResize, useSidebarResize } from './useResize'
 import { ConfirmDialog } from '../dialog/confirmDialog'
 
-import type {
-  Message,
-  CurrentStoryContext,
-  ChatSupportProps,
-  ChatSupportConfig,
-  ShortcutActionId,
-  ShortcutBinding,
-} from './chatSupportTypes'
-import type { StoryGuideEntry } from './storyGuideMap'
+import type { CurrentStoryContext, ChatSupportProps } from './chatSupportTypes'
 
-// 後方互換のためのre-export
-export type { Message, CurrentStoryContext }
+// 後方互換のための re-export
+export type { CurrentStoryContext }
 
 export const ChatSupport = ({ currentStory }: ChatSupportProps) => {
-  const [isOpen, setIsOpenRaw] = useState(() => {
-    try {
-      return sessionStorage.getItem('chat_support_open') === '1'
-    } catch {
-      return false
-    }
-  })
-  const setIsOpen = useCallback((v: boolean | ((prev: boolean) => boolean)) => {
-    setIsOpenRaw((prev) => {
-      const next = typeof v === 'function' ? v(prev) : v
-      try {
-        sessionStorage.setItem('chat_support_open', next ? '1' : '0')
-      } catch {
-        // sessionStorage が無効な環境では無視
-      }
-      return next
-    })
-  }, [])
-  const [isTyping, setIsTyping] = useState(false)
-  const [isTesting, setIsTesting] = useState(false)
-  const [showSettings, setShowSettings] = useState(false)
-  const [showApiKey, setShowApiKey] = useState(false)
-  const [testResult, setTestResult] = useState<{
-    success: boolean
-    message: string
-  } | null>(null)
-
-  const [config, setConfig] = useState<ChatSupportConfig>(() =>
-    loadChatConfig()
-  )
-  const [confirmResetOpen, setConfirmResetOpen] = useState(false)
-  const [confirmClearOpen, setConfirmClearOpen] = useState(false)
-
-  // APIキー入力欄のローカルstate（paste問題の回避）
-  const [apiKeyDraft, setApiKeyDraft] = useState(() => {
-    const c = loadChatConfig()
-    return !c.apiKey || c.apiKey === DEFAULT_API_KEY ? '' : c.apiKey
-  })
-
-  // デフォルトAPIキー使用中かどうかの判定
-  const isUsingDefaultKey = !config.apiKey || config.apiKey === DEFAULT_API_KEY
-
-  const [message, setMessage] = useState('')
-  const [messages, setMessages] = useState<Message[]>(() => {
-    const defaultMsg: Message[] = [
-      {
-        id: '1',
-        text: INITIAL_GREETING,
-        sender: 'bot',
-        timestamp: new Date(),
-      },
-    ]
-    const saved = localStorage.getItem(CHAT_STORAGE_KEY)
-    if (saved) {
-      try {
-        const parsed = JSON.parse(saved)
-        const restored = parsed.map((m: Message & { timestamp: string }) => ({
-          ...m,
-          timestamp: new Date(m.timestamp),
-        }))
-        // 初回メッセージが古い挨拶文なら新しいものに差し替え
-        if (
-          restored[0]?.sender === 'bot' &&
-          restored[0]?.text !== INITIAL_GREETING
-        ) {
-          restored[0] = { ...restored[0], text: INITIAL_GREETING }
-        }
-        return restored
-      } catch (e) {
-        console.error(e)
-      }
-    }
-    return defaultMsg
-  })
-
-  const scrollRef = useRef<HTMLDivElement>(null)
-  const inputRef = useRef<HTMLInputElement>(null)
   const theme = useTheme()
 
-  // 現在のページのガイド情報
-  const storyGuide: StoryGuideEntry | null = useMemo(
-    () => (currentStory ? findStoryGuide(currentStory.title) : null),
-    [currentStory]
+  // --- 状態 hooks ---
+  const {
+    isOpen, setIsOpen,
+    message, setMessage,
+    messages, setMessages,
+    scrollRef, inputRef,
+    confirmClearOpen, setConfirmClearOpen,
+    clearChat, executeClearChat,
+  } = useChatState()
+
+  const {
+    config, setConfig,
+    apiKeyDraft, setApiKeyDraft,
+    isUsingDefaultKey,
+    showSettings, setShowSettings,
+    showApiKey, setShowApiKey,
+    testResult, setTestResult,
+    isTesting,
+    confirmResetOpen, setConfirmResetOpen,
+    submitShortcutLabel,
+    handleTestConnection,
+    handleShortcutInputKeyDown,
+    resetShortcuts,
+    toggleUiMode,
+    DEFAULT_API_KEY,
+    DEFAULT_MODEL,
+  } = useChatConfig()
+
+  const {
+    isTyping,
+    storyGuide,
+    addBotMessage,
+    buildPageContextAnswer,
+    handleDownload,
+    handleSend,
+    handleSuggestionClick,
+    hasUserMessages,
+  } = useChatMessage({ currentStory, messages, setMessages, config })
+
+  // handleSend のクロージャ（message / setMessage を束縛）
+  const onSend = useCallback(
+    () => handleSend(message, () => setMessage('')),
+    [handleSend, message, setMessage]
   )
 
-  // ページコンテキスト付きシステムプロンプト
-  const contextualPrompt = useMemo(() => {
-    if (!currentStory) return SYSTEM_PROMPT
-    const parts = [SYSTEM_PROMPT]
-    parts.push(
-      `\n\n## 現在のページ情報\nユーザーは現在「${currentStory.title}」の「${currentStory.name}」ストーリーを見ています。`
-    )
-    if (currentStory.description) {
-      parts.push(`ページ説明: ${currentStory.description}`)
-    }
-    if (storyGuide) {
-      parts.push(`概要: ${storyGuide.summary}`)
-      parts.push(
-        `実装コンテキスト:\n${storyGuide.codeContext.map((c) => `- ${c}`).join('\n')}`
-      )
-      if (storyGuide.references?.length) {
-        parts.push(
-          `参考リンク:\n${storyGuide.references.map((r) => `- ${r}`).join('\n')}`
-        )
-      }
-      if (storyGuide.related?.length) {
-        parts.push(`関連ページ: ${storyGuide.related.join(', ')}`)
-      }
-    }
-    parts.push(
-      'ユーザーが「この画面」「今見てるページ」等と言った場合、上記コンテキストを基に具体的に回答してください。参考リンクがあれば回答に含めてください。'
-    )
-    return parts.join('\n')
-  }, [currentStory, storyGuide])
+  const { handleKeyDown } = useChatShortcuts({
+    config, isOpen, setIsOpen, setShowSettings,
+    clearChat, handleDownload, toggleUiMode, inputRef,
+  })
 
   const { widgetSize, handleResizeStart } = useWidgetResize()
-
   const { handleSidebarResize } = useSidebarResize(
     config.sidebarWidth,
     useCallback(
-      (width: number) =>
-        setConfig((prev) => ({ ...prev, sidebarWidth: width })),
-      []
+      (width: number) => setConfig((prev) => ({ ...prev, sidebarWidth: width })),
+      [setConfig]
     )
   )
 
-  useEffect(() => {
-    localStorage.setItem(CHAT_STORAGE_KEY, JSON.stringify(messages))
-    if (scrollRef.current) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight
-    }
-  }, [messages])
-
-  useEffect(() => {
-    localStorage.setItem(CONFIG_STORAGE_KEY, JSON.stringify(config))
-  }, [config])
-
-  // Embeddingインデックスの初期化（APIキーがある場合のみ、バックグラウンドで1回実行）
-  useEffect(() => {
-    if (!config.apiKey || config.apiKey === DEFAULT_API_KEY) return
-    if (getEmbeddingIndex()?.isReady()) return
-    initEmbeddingIndex(config.apiKey).catch(() => {
-      // エラーは initEmbeddingIndex 内でログ済み
-    })
-  }, [config.apiKey])
-
-  const clearChat = useCallback(() => {
-    setConfirmClearOpen(true)
-  }, [])
-
-  const executeClearChat = useCallback(() => {
-    setMessages([
-      {
-        id: '1',
-        text: INITIAL_GREETING,
-        sender: 'bot',
-        timestamp: new Date(),
-      },
-    ])
-    setConfirmClearOpen(false)
-  }, [])
-
-  const handleTestConnection = async () => {
-    if (!config.apiKey) {
-      setTestResult({ success: false, message: 'APIキーを入力してください。' })
-      return
-    }
-    setIsTesting(true)
-    setTestResult(null)
-    try {
-      await callAI(config, [{ role: 'user', content: 'Say OK' }], true)
-      setTestResult({ success: true, message: '接続成功！AIと対話可能です。' })
-    } catch (error: unknown) {
-      setTestResult({
-        success: false,
-        message: `接続失敗: ${error instanceof Error ? error.message : String(error)}`,
-      })
-    } finally {
-      setIsTesting(false)
-    }
-  }
-
-  const addBotMessage = (text: string) => {
-    setMessages((prev) => [
-      ...prev,
-      {
-        id: (Date.now() + 1).toString(),
-        text,
-        sender: 'bot' as const,
-        timestamp: new Date(),
-      },
-    ])
-  }
-
-  /** ページ文脈クエリ判定キーワード */
-  const isPageContextQuery = (q: string): boolean => {
-    const keywords = [
-      'この画面',
-      'このページ',
-      '今見てる',
-      '今見ている',
-      '今のページ',
-      '今の画面',
-      '何のページ',
-      '何を見て',
-      'ここは何',
-      'ここって何',
-      'ここは',
-      'what is this',
-      'what page',
-    ]
-    return keywords.some((kw) => q.toLowerCase().includes(kw))
-  }
-
-  /** 現在のページに関するFAQ回答を生成 */
-  const buildPageContextAnswer = (query?: string): string | null => {
-    if (!currentStory || !storyGuide) return null
-    const q = query?.toLowerCase() || ''
-    const isImplementation = q.includes('実装') || q.includes('コード')
-
-    const lines = [
-      `**${currentStory.title}** > ${currentStory.name}`,
-      '',
-      isImplementation ? '### 実装のポイント' : storyGuide.summary,
-      '',
-      ...storyGuide.codeContext.map((c) => `- ${c}`),
-    ]
-    if (storyGuide.references?.length) {
-      lines.push('', '**参考:**', ...storyGuide.references.map((r) => `- ${r}`))
-    }
-    if (storyGuide.related?.length) {
-      lines.push('', `関連: ${storyGuide.related.join(' / ')}`)
-    }
-    return lines.join('\n')
-  }
-
-  /** FAQ回答から「やるべきこと」セクションを除去し端的にする */
-  const trimFaqAnswer = (text: string): string => {
-    return text.replace(/\n+## やるべきこと[\s\S]*$/, '').trimEnd()
-  }
-
-  const respondWithFaq = (query: string) => {
-    // ページ文脈クエリを優先チェック
-    if (isPageContextQuery(query)) {
-      const pageAnswer = buildPageContextAnswer(query)
-      if (pageAnswer) {
-        addBotMessage(pageAnswer)
-        return
-      }
-    }
-
-    const answer = findFaqAnswer(query)
-    if (answer) {
-      addBotMessage(trimFaqAnswer(answer))
-    } else {
-      addBotMessage(
-        '該当するFAQが見つかりませんでした。以下のトピックをお試しください:\n\n' +
-          FAQ_DATABASE.map((f) => `- **${f.title}**`).join('\n') +
-          '\n\nAI接続すると自由な質問に対応できます。設定からAPIキーを入力してください。'
-      )
-    }
-  }
-
-  const handleDownload = useCallback(() => {
-    const lines = [
-      '# Concierge - チャット履歴',
-      `> ${new Date().toLocaleDateString('ja-JP')} エクスポート`,
-      '',
-    ]
-    for (const msg of messages) {
-      if (msg.sender === 'user') {
-        lines.push(`## Q: ${msg.text}`, '')
-      } else {
-        lines.push(msg.text, '')
-      }
-      lines.push('---', '')
-    }
-    const blob = new Blob([lines.join('\n')], {
-      type: 'text/markdown;charset=utf-8',
-    })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `concierge-${new Date().toISOString().slice(0, 10)}.md`
-    document.body.appendChild(a)
-    a.click()
-    document.body.removeChild(a)
-    URL.revokeObjectURL(url)
-  }, [messages])
-
-  const handleSend = async () => {
-    if (!message.trim() || isTyping) return
-    const userText = message
-    const newUserMessage: Message = {
-      id: Date.now().toString(),
-      text: userText,
-      sender: 'user',
-      timestamp: new Date(),
-    }
-    setMessages((prev) => [...prev, newUserMessage])
-    setMessage('')
-
-    // APIキーなし → FAQ検索
-    if (!config.apiKey) {
-      respondWithFaq(userText)
-      return
-    }
-
-    // AI呼び出し
-    setIsTyping(true)
-    try {
-      // セマンティック検索で関連知識を取得し、システムプロンプトを強化
-      let enrichedPrompt = contextualPrompt
-      const embeddingResults = await semanticSearch(config.apiKey, userText)
-      if (embeddingResults.length > 0) {
-        enrichedPrompt += buildSemanticContext(embeddingResults)
-      }
-
-      const payload = [
-        { role: 'system', content: enrichedPrompt },
-        ...messages.map((m) => ({
-          role: m.sender === 'user' ? 'user' : 'assistant',
-          content: m.text,
-        })),
-        { role: 'user', content: userText },
-      ]
-      const data = await callAI(config, payload)
-      const aiText = extractContent(data)
-      addBotMessage(aiText)
-    } catch (error: unknown) {
-      const errMsg =
-        error instanceof Error
-          ? error.name === 'AbortError'
-            ? 'タイムアウト: 応答に時間がかかりすぎています。'
-            : error.message
-          : String(error)
-      // AI失敗時もFAQで応答を試みる（セマンティック → キーワード の順）
-      const embeddingFaq = await semanticSearch(config.apiKey, userText).catch(
-        () => []
-      )
-      const semanticAnswer = findSemanticFaqAnswer(embeddingFaq)
-      const faqAnswer = semanticAnswer ?? findFaqAnswer(userText)
-      if (faqAnswer) {
-        addBotMessage(
-          `*AI接続エラー: ${errMsg}*\n\n---\n\nFAQから回答します:\n\n${trimFaqAnswer(faqAnswer)}`
-        )
-      } else {
-        addBotMessage(`エラー: ${errMsg}`)
-      }
-    } finally {
-      setIsTyping(false)
-    }
-  }
-
-  const submitShortcutLabel = formatShortcutLabel(config.shortcuts.sendMessage)
-
-  const handleShortcutInputKeyDown =
-    (shortcutId: ShortcutActionId) =>
-    (event: React.KeyboardEvent<HTMLElement>) => {
-      if (event.key === 'Tab') return
-      event.preventDefault()
-      event.stopPropagation()
-
-      const normalizedKey = normalizeShortcutKey(event.key)
-      if (MODIFIER_ONLY_KEYS.has(normalizedKey)) return
-
-      const nextShortcut: ShortcutBinding = {
-        key: normalizedKey,
-        mod: isMac ? event.metaKey : event.ctrlKey,
-        shift: event.shiftKey,
-        alt: event.altKey,
-      }
-      setConfig((prev) => ({
-        ...prev,
-        shortcuts: {
-          ...prev.shortcuts,
-          [shortcutId]: nextShortcut,
-        },
-      }))
-    }
-
-  const resetShortcuts = () => {
-    setConfig((prev) => ({
-      ...prev,
-      shortcuts: createDefaultShortcuts(),
-    }))
-  }
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    // IME入力中（日本語変換中）は無視
-    if (e.nativeEvent.isComposing) return
-
-    // 設定されたショートカットで送信
-    if (isShortcutMatch(e.nativeEvent, config.shortcuts.sendMessage)) {
-      e.preventDefault()
-      handleSend()
-    }
-    // Enterのみ → 改行（multiline TextFieldのデフォルト動作）
-    // Shift+Enter → 改行（同上）
-  }
-
-  const toggleUiMode = useCallback(() => {
-    setConfig((prev) => ({
-      ...prev,
-      uiMode: prev.uiMode === 'widget' ? 'sidebar' : 'widget',
-    }))
-  }, [])
-
-  // グローバルキーボードショートカット
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      // IME変換中は無視
-      if (e.isComposing) return
-
-      // テキスト入力欄にフォーカス中はショートカットを無効化（paste等を妨げない）
-      const tag = (e.target as HTMLElement)?.tagName
-      const isInputFocused =
-        tag === 'INPUT' ||
-        tag === 'TEXTAREA' ||
-        (e.target as HTMLElement)?.isContentEditable
-
-      // チャット開閉（入力欄フォーカス中でも動作させる）
-      if (isShortcutMatch(e, config.shortcuts.toggleChat)) {
-        e.preventDefault()
-        setIsOpen((prev) => !prev)
-        return
-      }
-
-      // 以下はチャットが開いている時のみ
-      if (!isOpen) return
-
-      // 入力欄フォーカス中は残りのショートカットをスキップ
-      if (isInputFocused) return
-
-      // チャットを閉じる
-      if (isShortcutMatch(e, config.shortcuts.closeChat)) {
-        setIsOpen(false)
-        return
-      }
-
-      // 入力欄にフォーカス
-      if (isShortcutMatch(e, config.shortcuts.focusInput)) {
-        e.preventDefault()
-        inputRef.current?.focus()
-        return
-      }
-
-      // 設定パネル切替
-      if (isShortcutMatch(e, config.shortcuts.toggleSettings)) {
-        e.preventDefault()
-        setShowSettings((prev) => !prev)
-        return
-      }
-
-      // ダウンロード
-      if (isShortcutMatch(e, config.shortcuts.downloadHistory)) {
-        e.preventDefault()
-        handleDownload()
-        return
-      }
-
-      // UI切替
-      if (isShortcutMatch(e, config.shortcuts.toggleUiMode)) {
-        e.preventDefault()
-        toggleUiMode()
-        return
-      }
-
-      // 履歴クリア
-      if (isShortcutMatch(e, config.shortcuts.clearHistory)) {
-        e.preventDefault()
-        clearChat()
-        return
-      }
-    }
-
-    document.addEventListener('keydown', handler)
-    return () => document.removeEventListener('keydown', handler)
-  }, [
-    config.shortcuts,
-    isOpen,
-    setIsOpen,
-    clearChat,
-    handleDownload,
-    toggleUiMode,
-  ])
-
-  const hasUserMessages = messages.some((m) => m.sender === 'user')
-
-  const handleSuggestionClick = (query: string) => {
-    if (isTyping) return
-    setMessage(query)
-    // setMessageの後にhandleSendを呼ぶため、直接送信ロジックを実行
-    const userMsg: Message = {
-      id: Date.now().toString(),
-      text: query,
-      sender: 'user',
-      timestamp: new Date(),
-    }
-    setMessages((prev) => [...prev, userMsg])
-    setMessage('')
-
-    // APIキーなし → FAQ
-    if (!config.apiKey) {
-      respondWithFaq(query)
-      return
-    }
-
-    // AI呼び出し（セマンティック検索で知識を補強）
-    setIsTyping(true)
-
-    // セマンティック検索 → システムプロンプト強化 → AI呼び出し
-    semanticSearch(config.apiKey, query)
-      .catch(() => [])
-      .then((embeddingResults) => {
-        let enrichedPrompt = contextualPrompt
-        if (embeddingResults.length > 0) {
-          enrichedPrompt += buildSemanticContext(embeddingResults)
-        }
-        const payload = [
-          { role: 'system', content: enrichedPrompt },
-          ...messages.map((m) => ({
-            role: m.sender === 'user' ? 'user' : 'assistant',
-            content: m.text,
-          })),
-          { role: 'user', content: query },
-        ]
-        return callAI(config, payload)
-      })
-      .then((data) => {
-        addBotMessage(extractContent(data))
-      })
-      .catch((error: unknown) => {
-        const errMsg =
-          error instanceof Error
-            ? error.name === 'AbortError'
-              ? 'タイムアウト: 応答に時間がかかりすぎています。'
-              : error.message
-            : String(error)
-        const faqAnswer = findFaqAnswer(query)
-        if (faqAnswer) {
-          addBotMessage(`*AI接続エラー*\n\n---\n\n${trimFaqAnswer(faqAnswer)}`)
-        } else {
-          addBotMessage(`エラー: ${errMsg}`)
-        }
-      })
-      .finally(() => {
-        setIsTyping(false)
-      })
-  }
-
+  // --- チャット本体 JSX ---
   const ChatContent = (
-    <Box
-      sx={{
-        height: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-        bgcolor: 'transparent',
-      }}>
-      {/* ヘッダー */}
-      <Box
-        sx={{
-          bgcolor:
-            theme.palette.mode === 'dark'
-              ? 'rgba(14,173,184,0.55)'
-              : 'primary.main',
-          color: '#ffffff',
-          backdropFilter: 'blur(12px)',
-        }}>
-        {/* タイトル行 */}
-        <Stack
-          direction='row'
-          justifyContent='space-between'
-          alignItems='center'
-          sx={{ px: 2, pt: 1.5, pb: 0.5 }}>
-          <Stack direction='row' spacing={1.5} alignItems='center'>
-            {showSettings ? (
-              <IconButton
-                size='small'
-                color='inherit'
-                onClick={() => setShowSettings(false)}>
-                <ChevronLeft size={20} />
-              </IconButton>
-            ) : (
-              <Avatar
-                sx={{
-                  bgcolor: 'rgba(255,255,255,0.2)',
-                  width: 32,
-                  height: 32,
-                }}>
-                <Bot size={20} />
-              </Avatar>
-            )}
-            <Box>
-              <Typography
-                variant='subtitle2'
-                sx={{ fontWeight: 600, lineHeight: 1.2 }}>
-                {showSettings
-                  ? 'AI設定'
-                  : currentStory
-                    ? currentStory.name
-                    : 'Concierge'}
-              </Typography>
-              {!showSettings && currentStory && (
-                <Typography
-                  variant='caption'
-                  sx={{ opacity: 0.8, display: 'block', lineHeight: 1.4 }}>
-                  {currentStory.title}
-                </Typography>
-              )}
-            </Box>
-          </Stack>
-        </Stack>
-        {/* アイコンツールバー + モデル名 */}
-        <Stack
-          direction='row'
-          justifyContent='space-between'
-          alignItems='center'
-          sx={{ px: 1.5, pb: 1, pt: 0.5 }}>
-          <Stack direction='row' alignItems='center'>
-            {!showSettings && (
-              <>
-                <IconButton
-                  size='small'
-                  color='inherit'
-                  onClick={toggleUiMode}
-                  title={
-                    config.uiMode === 'widget'
-                      ? 'サイドバーに切替'
-                      : 'ウィジェットに切替'
-                  }>
-                  {config.uiMode === 'widget' ? (
-                    <PanelRight size={18} />
-                  ) : (
-                    <MessageSquare size={18} />
-                  )}
-                </IconButton>
-                <IconButton
-                  size='small'
-                  color='inherit'
-                  onClick={() => setShowSettings(true)}>
-                  <Settings size={18} />
-                </IconButton>
-                <IconButton
-                  size='small'
-                  color='inherit'
-                  onClick={handleDownload}
-                  title='Markdownでダウンロード'>
-                  <Download size={18} />
-                </IconButton>
-                <IconButton
-                  size='small'
-                  color='inherit'
-                  onClick={clearChat}
-                  title='履歴クリア'>
-                  <Trash2 size={18} />
-                </IconButton>
-              </>
-            )}
-            <IconButton
-              size='small'
-              color='inherit'
-              onClick={() => setIsOpen(false)}>
-              <X size={18} />
-            </IconButton>
-          </Stack>
-          {!showSettings && (
-            <Typography
-              sx={{
-                opacity: 0.6,
-                fontSize: 12,
-                whiteSpace: 'nowrap',
-              }}>
-              {!config.apiKey && !DEFAULT_API_KEY
-                ? 'FAQモード'
-                : config.model || DEFAULT_MODEL}
-            </Typography>
-          )}
-        </Stack>
-      </Box>
+    <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column', bgcolor: 'transparent' }}>
+      <ChatHeader
+        showSettings={showSettings}
+        currentStory={currentStory}
+        config={config}
+        onBack={() => setShowSettings(false)}
+        onToggleUiMode={toggleUiMode}
+        onToggleSettings={() => setShowSettings(true)}
+        onDownload={handleDownload}
+        onClearChat={clearChat}
+        onClose={() => setIsOpen(false)}
+      />
 
-      {/* ページ解説トリガー: スティッキー */}
-      {!showSettings && storyGuide && currentStory && (
-        <Box
-          sx={{
-            px: 1.5,
-            py: 0.75,
-            bgcolor:
-              theme.palette.mode === 'dark'
-                ? 'rgba(14,173,184,0.3)'
-                : 'rgba(63,81,181,0.08)',
-            borderBottom: '1px solid',
-            borderColor: 'divider',
-            position: 'sticky',
-            top: 0,
-            zIndex: 1,
-          }}>
-          <Chip
-            icon={<Info size={14} />}
-            label={`${currentStory.title} の解説を見る`}
-            size='small'
-            variant='outlined'
-            onClick={() => {
-              const pageAnswer = buildPageContextAnswer()
-              if (pageAnswer) addBotMessage(pageAnswer)
-            }}
-            sx={{
-              height: 28,
-              fontSize: '0.75rem',
-              cursor: 'pointer',
-              borderColor:
-                theme.palette.mode === 'dark'
-                  ? 'rgba(255,255,255,0.2)'
-                  : 'primary.light',
-              color:
-                theme.palette.mode === 'dark'
-                  ? 'rgba(255,255,255,0.9)'
-                  : 'primary.main',
-              '& .MuiChip-icon': {
-                color: 'inherit',
-              },
-              '&:hover': {
-                bgcolor:
-                  theme.palette.mode === 'dark'
-                    ? 'rgba(255,255,255,0.08)'
-                    : 'rgba(63,81,181,0.12)',
-              },
-            }}
-          />
-        </Box>
+      {!showSettings && (
+        <ChatPageContextChip
+          storyGuide={storyGuide}
+          currentStory={currentStory}
+          onExplain={() => {
+            const answer = buildPageContextAnswer()
+            if (answer) addBotMessage(answer)
+          }}
+        />
       )}
 
-      {/* 設定パネル or チャットエリア */}
       {showSettings ? (
-        <Box sx={{ p: 3, flexGrow: 1, overflowY: 'auto' }}>
-          <Stack spacing={3}>
-            {/* 現在の接続状態セクション */}
-            <Box
-              sx={{
-                bgcolor:
-                  theme.palette.mode === 'dark'
-                    ? 'rgba(255,255,255,0.05)'
-                    : 'rgba(0,0,0,0.03)',
-                borderRadius: 1,
-                p: 2,
-              }}>
-              <Typography
-                variant='caption'
-                sx={{ fontWeight: 600, display: 'block', mb: 0.5 }}>
-                現在の設定
-              </Typography>
-              {isUsingDefaultKey ? (
-                DEFAULT_API_KEY ? (
-                  <>
-                    <Typography
-                      variant='caption'
-                      color='text.secondary'
-                      sx={{ display: 'block', lineHeight: 1.6 }}>
-                      {config.model} を使用中（プロジェクト提供）
-                    </Typography>
-                    <Stack
-                      direction='row'
-                      alignItems='center'
-                      spacing={0.5}
-                      sx={{ mt: 0.5 }}>
-                      <CheckCircle2
-                        size={14}
-                        color={theme.palette.success.main}
-                      />
-                      <Typography variant='caption' color='success.main'>
-                        AI対話モード
-                      </Typography>
-                    </Stack>
-                  </>
-                ) : (
-                  <>
-                    <Typography
-                      variant='caption'
-                      color='text.secondary'
-                      sx={{ display: 'block', lineHeight: 1.6 }}>
-                      APIキー未設定
-                    </Typography>
-                    <Stack
-                      direction='row'
-                      alignItems='center'
-                      spacing={0.5}
-                      sx={{ mt: 0.5 }}>
-                      <AlertCircle
-                        size={14}
-                        color={theme.palette.warning.main}
-                      />
-                      <Typography variant='caption' color='warning.main'>
-                        FAQモードのみ（AI対話にはAPIキーが必要）
-                      </Typography>
-                    </Stack>
-                  </>
-                )
-              ) : (
-                <>
-                  <Typography
-                    variant='caption'
-                    color='text.secondary'
-                    sx={{ display: 'block', lineHeight: 1.6 }}>
-                    {config.model} を使用中（カスタムAPIキー）
-                  </Typography>
-                  <Stack
-                    direction='row'
-                    alignItems='center'
-                    spacing={0.5}
-                    sx={{ mt: 0.5 }}>
-                    <CheckCircle2
-                      size={14}
-                      color={theme.palette.success.main}
-                    />
-                    <Typography variant='caption' color='success.main'>
-                      AI対話モード
-                    </Typography>
-                  </Stack>
-                </>
-              )}
-            </Box>
-
-            <Divider />
-
-            {/* カスタムAPI設定セクション */}
-            <Box>
-              <Typography
-                variant='caption'
-                sx={{ fontWeight: 600, display: 'block', mb: 0.5 }}>
-                カスタムAPI設定（任意）
-              </Typography>
-              <Typography
-                variant='caption'
-                color='text.secondary'
-                sx={{ display: 'block', mb: 1.5, lineHeight: 1.6 }}>
-                自分のAPIキーを使うと、より高性能なモデルを選択できます。
-              </Typography>
-
-              {/* プロバイダー選択タブ */}
-              <Stack direction='row' spacing={1} sx={{ mb: 1.5 }}>
-                {(['openai', 'gemini'] as const).map((provider) => {
-                  const isGemini = (config.model ?? '').includes('gemini')
-                  const active =
-                    (provider === 'gemini' && isGemini) ||
-                    (provider === 'openai' && !isGemini)
-                  return (
-                    <Chip
-                      key={provider}
-                      label={provider === 'openai' ? 'OpenAI' : 'Google Gemini'}
-                      size='small'
-                      variant={active ? 'filled' : 'outlined'}
-                      color={active ? 'primary' : 'default'}
-                      onClick={() => {
-                        const models =
-                          provider === 'gemini' ? GEMINI_MODELS : OPENAI_MODELS
-                        const defaultModel = (
-                          models.find((m) => !m.requiresUserKey) ?? models[0]
-                        ).value
-                        setConfig({ ...config, model: defaultModel })
-                        setTestResult(null)
-                      }}
-                      sx={{
-                        cursor: 'pointer',
-                        fontWeight: 500,
-                        fontSize: '0.75rem',
-                      }}
-                    />
-                  )
-                })}
-              </Stack>
-
-              <TextField
-                fullWidth
-                size='small'
-                type='text'
-                autoComplete='off'
-                value={apiKeyDraft}
-                onChange={(e) => {
-                  const v = e.target.value
-                  setApiKeyDraft(v)
-                  if (v) {
-                    setConfig({ ...config, apiKey: v })
-                  } else {
-                    setConfig({
-                      ...config,
-                      apiKey: DEFAULT_API_KEY,
-                      model: DEFAULT_MODEL,
-                    })
-                  }
-                  setTestResult(null)
-                }}
-                placeholder={
-                  (config.model ?? '').includes('gemini')
-                    ? 'AIza...'
-                    : 'sk-proj-...'
-                }
-                inputProps={{
-                  style:
-                    !showApiKey && apiKeyDraft
-                      ? ({ WebkitTextSecurity: 'disc' } as React.CSSProperties)
-                      : undefined,
-                }}
-                InputProps={{
-                  endAdornment: (
-                    <InputAdornment position='end'>
-                      {apiKeyDraft && (
-                        <IconButton
-                          size='small'
-                          onClick={() => setConfirmResetOpen(true)}
-                          title='デフォルトに戻す'>
-                          <X size={16} />
-                        </IconButton>
-                      )}
-                      <IconButton
-                        size='small'
-                        onClick={() => setShowApiKey(!showApiKey)}>
-                        {showApiKey ? <EyeOff size={16} /> : <Eye size={16} />}
-                      </IconButton>
-                    </InputAdornment>
-                  ),
-                }}
-              />
-            </Box>
-
-            {/* モデル選択 — 常に表示 */}
-            <Box>
-              <Typography
-                variant='caption'
-                color='text.secondary'
-                sx={{ display: 'block', mb: 0.8, fontWeight: 600 }}>
-                AIモデル
-              </Typography>
-              <TextField
-                select
-                fullWidth
-                size='small'
-                value={config.model}
-                onChange={(e) => {
-                  setConfig({ ...config, model: e.target.value })
-                  setTestResult(null)
-                }}>
-                {((config.model ?? '').includes('gemini')
-                  ? GEMINI_MODELS
-                  : OPENAI_MODELS
-                ).map((opt) => {
-                  const isLocked = isUsingDefaultKey && !!opt.requiresUserKey
-                  return (
-                    <MenuItem
-                      key={opt.value}
-                      value={opt.value}
-                      disabled={isLocked}
-                      title={
-                        isLocked
-                          ? '自分のAPIキーを設定すると使用できます'
-                          : undefined
-                      }
-                      sx={{ py: 1.5, alignItems: 'flex-start' }}>
-                      <Box sx={{ width: '100%' }}>
-                        <Box
-                          sx={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            gap: 0.75,
-                            mb: 0.25,
-                          }}>
-                          {isLocked && <Lock size={12} />}
-                          <Typography variant='body2' sx={{ fontWeight: 600 }}>
-                            {opt.label}
-                          </Typography>
-                          <Chip
-                            label={
-                              opt.tier === 'premium'
-                                ? 'Premium'
-                                : opt.tier === 'economy'
-                                  ? 'Economy'
-                                  : 'Standard'
-                            }
-                            size='small'
-                            color={
-                              opt.tier === 'premium'
-                                ? 'primary'
-                                : opt.tier === 'economy'
-                                  ? 'default'
-                                  : 'info'
-                            }
-                            variant='outlined'
-                            sx={{
-                              height: 18,
-                              fontSize: '0.6rem',
-                              '& .MuiChip-label': { px: 0.75 },
-                            }}
-                          />
-                        </Box>
-                        <Typography
-                          variant='caption'
-                          color='text.secondary'
-                          sx={{ display: 'block', lineHeight: 1.4, mb: 0.5 }}>
-                          {opt.description}
-                        </Typography>
-                        <Box
-                          sx={{
-                            display: 'flex',
-                            flexWrap: 'wrap',
-                            gap: 0.5,
-                          }}>
-                          {opt.usecases.map((uc) => (
-                            <Typography
-                              key={uc}
-                              variant='caption'
-                              sx={{
-                                fontSize: '0.65rem',
-                                color: 'text.disabled',
-                                lineHeight: 1.2,
-                                '&::before': { content: '"- "' },
-                              }}>
-                              {uc}
-                            </Typography>
-                          ))}
-                        </Box>
-                      </Box>
-                    </MenuItem>
-                  )
-                })}
-              </TextField>
-            </Box>
-
-            {/* カスタムキー入力時のみテストボタンを表示 */}
-            {!!apiKeyDraft && (
-              <>
-                <Button
-                  fullWidth
-                  variant='outlined'
-                  size='medium'
-                  onClick={handleTestConnection}
-                  disabled={isTesting || !config.apiKey}
-                  sx={{ py: 1 }}
-                  startIcon={
-                    isTesting ? (
-                      <CircularProgress size={16} color='inherit' />
-                    ) : (
-                      <Sparkles size={16} />
-                    )
-                  }>
-                  {isTesting ? 'テスト中...' : 'API接続テスト'}
-                </Button>
-                {testResult && (
-                  <Alert
-                    severity={testResult.success ? 'success' : 'error'}
-                    icon={
-                      testResult.success ? (
-                        <CheckCircle2 size={18} />
-                      ) : (
-                        <AlertCircle size={18} />
-                      )
-                    }>
-                    <Typography variant='caption'>
-                      {testResult.message}
-                    </Typography>
-                  </Alert>
-                )}
-              </>
-            )}
-
-            <Divider />
-            <Typography variant='caption' color='text.secondary'>
-              キーはブラウザにのみ保存されます。モデルを切り替えたらテストを推奨します。
-            </Typography>
-            <Box
-              sx={{
-                bgcolor:
-                  theme.palette.mode === 'dark'
-                    ? 'rgba(255,255,255,0.05)'
-                    : 'rgba(0,0,0,0.03)',
-                borderRadius: 1,
-                p: 1.5,
-              }}>
-              <Typography
-                variant='caption'
-                sx={{ fontWeight: 600, display: 'block', mb: 0.5 }}>
-                APIキーの取得方法
-              </Typography>
-              <Typography
-                variant='caption'
-                color='text.secondary'
-                component='div'
-                sx={{ lineHeight: 1.7 }}>
-                <Box component='ul' sx={{ pl: 2, m: 0, '& li': { mb: 0.5 } }}>
-                  <li>
-                    <strong>OpenAI</strong>:{' '}
-                    <Link
-                      href='https://platform.openai.com/api-keys'
-                      target='_blank'
-                      rel='noopener noreferrer'
-                      sx={{ fontSize: 'inherit' }}>
-                      platform.openai.com
-                    </Link>{' '}
-                    でアカウント作成後、API Keysページでキーを発行（従量課金制）
-                  </li>
-                  <li>
-                    <strong>Google Gemini</strong>:{' '}
-                    <Link
-                      href='https://aistudio.google.com/apikey'
-                      target='_blank'
-                      rel='noopener noreferrer'
-                      sx={{ fontSize: 'inherit' }}>
-                      aistudio.google.com
-                    </Link>{' '}
-                    でGoogleアカウントでログイン後、APIキーを発行（無料枠あり）
-                  </li>
-                </Box>
-              </Typography>
-            </Box>
-            <Divider />
-            <Box>
-              <Stack
-                direction='row'
-                justifyContent='space-between'
-                spacing={1}
-                alignItems='center'
-                sx={{ mb: 1 }}>
-                <Stack direction='row' spacing={1} alignItems='center'>
-                  <Keyboard size={14} />
-                  <Typography variant='caption' sx={{ fontWeight: 600 }}>
-                    キーボードショートカット
-                  </Typography>
-                </Stack>
-                <Button size='small' variant='text' onClick={resetShortcuts}>
-                  既定値に戻す
-                </Button>
-              </Stack>
-              <Typography
-                variant='caption'
-                color='text.secondary'
-                sx={{ display: 'block', mb: 1.2 }}>
-                入力欄にフォーカスして希望のキーを押すと更新されます。
-              </Typography>
-              <Box
-                component='table'
-                sx={{
-                  width: '100%',
-                  borderCollapse: 'collapse',
-                  '& td': {
-                    py: 0.6,
-                    fontSize: 11,
-                    verticalAlign: 'middle',
-                  },
-                  '& td:first-of-type': {
-                    width: 160,
-                    pr: 1,
-                  },
-                }}>
-                <tbody>
-                  {SHORTCUT_METADATA.map((s) => (
-                    <tr key={s.id}>
-                      <td>
-                        <TextField
-                          size='small'
-                          value={formatShortcutLabel(config.shortcuts[s.id])}
-                          onKeyDown={handleShortcutInputKeyDown(s.id)}
-                          InputProps={{
-                            readOnly: true,
-                            inputProps: {
-                              'aria-label': `${s.desc} のショートカット`,
-                              style: {
-                                fontFamily: 'monospace',
-                                fontSize: 10,
-                                textAlign: 'center',
-                                paddingTop: 4,
-                                paddingBottom: 4,
-                              },
-                            },
-                          }}
-                        />
-                      </td>
-                      <td>
-                        <Typography variant='caption' color='text.secondary'>
-                          {s.desc}
-                        </Typography>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </Box>
-            </Box>
-          </Stack>
-        </Box>
+        <ChatSettings
+          config={config}
+          setConfig={setConfig}
+          apiKeyDraft={apiKeyDraft}
+          setApiKeyDraft={setApiKeyDraft}
+          isUsingDefaultKey={isUsingDefaultKey}
+          showApiKey={showApiKey}
+          setShowApiKey={setShowApiKey}
+          testResult={testResult}
+          setTestResult={setTestResult}
+          isTesting={isTesting}
+          onTestConnection={handleTestConnection}
+          onResetShortcuts={resetShortcuts}
+          onShortcutInputKeyDown={handleShortcutInputKeyDown}
+          onResetApiKey={() => setConfirmResetOpen(true)}
+        />
       ) : (
         <>
-          <Box
-            ref={scrollRef}
-            sx={{
-              flexGrow: 1,
-              px: 1.5,
-              py: 1.5,
-              overflowY: 'auto',
-              bgcolor:
-                theme.palette.mode === 'dark'
-                  ? 'rgba(255,255,255,0.03)'
-                  : 'rgba(248,249,250,0.8)',
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 1.5,
-            }}>
-            {messages.map((msg) => {
-              const isUser = msg.sender === 'user'
-              return (
-                <Box
-                  key={msg.id}
-                  sx={{
-                    display: 'flex',
-                    justifyContent: isUser ? 'flex-end' : 'flex-start',
-                  }}>
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      flexDirection: isUser ? 'row-reverse' : 'row',
-                      alignItems: 'flex-start',
-                      gap: 0.75,
-                      maxWidth: '96%',
-                    }}>
-                    <Avatar
-                      sx={{
-                        width: 28,
-                        height: 28,
-                        mt: 0.5,
-                        flexShrink: 0,
-                        bgcolor: isUser ? 'secondary.main' : 'primary.light',
-                        fontSize: 12,
-                      }}>
-                      {isUser ? <User size={14} /> : <Bot size={14} />}
-                    </Avatar>
-                    <Box
-                      sx={{
-                        px: 2,
-                        pt: '5px',
-                        pb: '4px',
-                        minWidth: 0,
-                        overflow: 'hidden',
-                        borderRadius: '12px',
-                        borderTopLeftRadius: isUser ? '12px' : '2px',
-                        borderTopRightRadius: isUser ? '2px' : '12px',
-                        bgcolor: isUser
-                          ? theme.palette.mode === 'dark'
-                            ? 'rgba(14,173,184,0.45)'
-                            : 'primary.main'
-                          : theme.palette.mode === 'dark'
-                            ? 'rgba(255,255,255,0.06)'
-                            : 'background.paper',
-                        color: isUser ? 'primary.contrastText' : 'text.primary',
-                        boxShadow: 'none',
-                      }}>
-                      {isUser ? (
-                        <Typography
-                          variant='body2'
-                          sx={{
-                            whiteSpace: 'pre-wrap',
-                            lineHeight: 1.7,
-                            fontSize: 14,
-                          }}>
-                          {msg.text}
-                        </Typography>
-                      ) : (
-                        <Box
-                          sx={{
-                            fontSize: 14,
-                            lineHeight: 1.7,
-                            wordBreak: 'break-word',
-                            '& p': {
-                              m: 0,
-                              mb: 1,
-                              '&:last-child': { mb: 0 },
-                            },
-                            '& h1, & h2, & h3, & h4, & h5, & h6': {
-                              mt: 2,
-                              mb: 1,
-                              lineHeight: 1.5,
-                              fontWeight: 600,
-                            },
-                            '& h1': { fontSize: 18 },
-                            '& h2': { fontSize: 16 },
-                            '& h3': { fontSize: 14 },
-                            '& ul, & ol': { pl: 2.5, my: 1 },
-                            '& li': { mb: 0.5 },
-                            '& code': {
-                              bgcolor:
-                                theme.palette.mode === 'dark'
-                                  ? 'rgba(255,255,255,0.07)'
-                                  : 'rgba(0,0,0,0.06)',
-                              px: 0.5,
-                              py: 0.25,
-                              border: 'none',
-                              borderRadius: 0.5,
-                              fontSize: 12,
-                              fontFamily: '"Fira Code", "Consolas", monospace',
-                              lineHeight: 1.75,
-                            },
-                            '& pre': {
-                              bgcolor:
-                                theme.palette.mode === 'dark'
-                                  ? 'rgba(0,0,0,0.2)'
-                                  : 'rgba(0,0,0,0.04)',
-                              p: 1.5,
-                              border: 'none',
-                              borderRadius: 1,
-                              overflowX: 'auto',
-                              my: 1,
-                              '& code': {
-                                bgcolor: 'transparent',
-                                border: 'none',
-                                px: 0,
-                                py: 0,
-                              },
-                            },
-                            '& blockquote': {
-                              borderLeft: '3px solid',
-                              borderColor: 'divider',
-                              pl: 1.5,
-                              ml: 0,
-                              my: 1,
-                              opacity: 0.85,
-                            },
-                            '& a': {
-                              color: 'primary.main',
-                              textDecoration: 'underline',
-                            },
-                            '& table': {
-                              borderCollapse: 'collapse',
-                              my: 1,
-                              width: '100%',
-                              '& th, & td': {
-                                border: '1px solid',
-                                borderColor: 'divider',
-                                px: 1,
-                                py: 0.5,
-                                fontSize: 12,
-                              },
-                              '& th': {
-                                fontWeight: 600,
-                                bgcolor:
-                                  theme.palette.mode === 'dark'
-                                    ? 'rgba(255,255,255,0.04)'
-                                    : 'rgba(0,0,0,0.03)',
-                              },
-                            },
-                          }}>
-                          <ReactMarkdown
-                            remarkPlugins={[remarkGfm]}
-                            components={{
-                              code: CodeBlock,
-                              pre: CodeBlockPre,
-                              a: ({ href, children: linkChildren }) => (
-                                <a
-                                  href={href}
-                                  target='_blank'
-                                  rel='noopener noreferrer'>
-                                  {linkChildren}
-                                </a>
-                              ),
-                            }}>
-                            {msg.text}
-                          </ReactMarkdown>
-                        </Box>
-                      )}
-                    </Box>
-                  </Box>
-                </Box>
-              )
-            })}
-            {!hasUserMessages && !isTyping && (
-              <Box
-                sx={{
-                  display: 'flex',
-                  flexWrap: 'wrap',
-                  gap: 0.75,
-                  mt: 0.5,
-                  ml: 4.5,
-                }}>
-                {storyGuide && (
-                  <>
-                    <Chip
-                      label='現在のページの解説'
-                      size='small'
-                      variant='outlined'
-                      onClick={() =>
-                        handleSuggestionClick('この画面の解説をお願いします')
-                      }
-                      sx={{
-                        cursor: 'pointer',
-                        fontSize: 12,
-                        borderColor: 'success.main',
-                        color: 'success.main',
-                        '&:hover': {
-                          bgcolor:
-                            theme.palette.mode === 'dark'
-                              ? 'rgba(76,175,80,0.08)'
-                              : 'rgba(76,175,80,0.06)',
-                          borderColor: 'success.main',
-                        },
-                      }}
-                    />
-                    <Chip
-                      label='実装のポイント'
-                      size='small'
-                      variant='outlined'
-                      onClick={() =>
-                        handleSuggestionClick(
-                          'この画面の実装のポイントを教えて'
-                        )
-                      }
-                      sx={{
-                        cursor: 'pointer',
-                        fontSize: 12,
-                        borderColor: 'info.main',
-                        color: 'info.main',
-                        '&:hover': {
-                          bgcolor:
-                            theme.palette.mode === 'dark'
-                              ? 'rgba(29,175,194,0.08)'
-                              : 'rgba(29,175,194,0.06)',
-                          borderColor: 'info.main',
-                        },
-                      }}
-                    />
-                  </>
-                )}
-                {QUICK_SUGGESTIONS.map((s) => (
-                  <Chip
-                    key={s.label}
-                    label={s.label}
-                    size='small'
-                    variant='outlined'
-                    onClick={() => handleSuggestionClick(s.query)}
-                    sx={{
-                      cursor: 'pointer',
-                      fontSize: 12,
-                      borderColor:
-                        theme.palette.mode === 'dark'
-                          ? 'rgba(255,255,255,0.12)'
-                          : 'rgba(14,173,184,0.3)',
-                      color:
-                        theme.palette.mode === 'dark'
-                          ? 'rgba(255,255,255,0.6)'
-                          : 'primary.main',
-                      '&:hover': {
-                        bgcolor:
-                          theme.palette.mode === 'dark'
-                            ? 'rgba(255,255,255,0.06)'
-                            : 'rgba(14,173,184,0.06)',
-                        borderColor:
-                          theme.palette.mode === 'dark'
-                            ? 'rgba(255,255,255,0.25)'
-                            : 'primary.main',
-                      },
-                    }}
-                  />
-                ))}
-              </Box>
-            )}
-            {isTyping && (
-              <Box
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 1,
-                  ml: 1,
-                }}>
-                <CircularProgress size={14} />
-                <Typography variant='caption' color='text.secondary'>
-                  AI回答中...
-                </Typography>
-              </Box>
-            )}
-          </Box>
-          <Box
-            sx={{
-              pt: '16px',
-              pr: '4px',
-              pb: '10px',
-              pl: '16px',
-              bgcolor:
-                theme.palette.mode === 'dark'
-                  ? 'rgba(30,30,30,0.6)'
-                  : 'rgba(255,255,255,0.85)',
-              backdropFilter: 'blur(12px)',
-              borderTop: `1px solid ${theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.06)' : theme.palette.divider}`,
-            }}>
-            <Stack direction='row' spacing={1} alignItems='stretch'>
-              <TextField
-                fullWidth
-                multiline
-                minRows={2}
-                maxRows={8}
-                inputRef={inputRef}
-                placeholder={
-                  config.apiKey
-                    ? `質問を入力... (${submitShortcutLabel}で送信)`
-                    : `FAQモード: 質問を入力... (${submitShortcutLabel}で送信)`
-                }
-                value={message}
-                onChange={(e) => setMessage(e.target.value)}
-                onKeyDown={handleKeyDown}
-                disabled={isTyping}
-                sx={{ '& .MuiOutlinedInput-root': { borderRadius: 1.5 } }}
-              />
-              <IconButton
-                color='primary'
-                disabled={!message.trim() || isTyping}
-                onClick={handleSend}
-                sx={{
-                  alignSelf: 'stretch',
-                  width: 44,
-                  borderRadius: 1.5,
-                  bgcolor: message.trim() ? 'primary.main' : 'transparent',
-                  color: message.trim() ? 'primary.contrastText' : 'inherit',
-                  '&:hover': {
-                    bgcolor: message.trim() ? 'primary.dark' : 'action.hover',
-                  },
-                }}>
-                <Send size={18} />
-              </IconButton>
-            </Stack>
-          </Box>
+          <ChatMessageList
+            messages={messages}
+            isTyping={isTyping}
+            scrollRef={scrollRef}
+            storyGuide={storyGuide}
+            currentStory={currentStory}
+            hasUserMessages={hasUserMessages}
+            onSuggestionClick={handleSuggestionClick}
+          />
+          <ChatInput
+            message={message}
+            isTyping={isTyping}
+            submitShortcutLabel={submitShortcutLabel}
+            hasApiKey={!!config.apiKey}
+            inputRef={inputRef}
+            onMessageChange={setMessage}
+            onKeyDown={(e) => handleKeyDown(e, onSend)}
+            onSend={onSend}
+          />
         </>
       )}
     </Box>
@@ -1623,85 +156,49 @@ export const ChatSupport = ({ currentStory }: ChatSupportProps) => {
 
   return (
     <>
-      {/* サイドバーモード（オーバーレイなし） */}
-      <Slide
-        direction='left'
-        in={isOpen && config.uiMode === 'sidebar'}
-        mountOnEnter
-        unmountOnExit>
+      {/* サイドバーモード */}
+      <Slide direction='left' in={isOpen && config.uiMode === 'sidebar'} mountOnEnter unmountOnExit>
         <Paper
           elevation={8}
           sx={{
-            position: 'fixed',
-            top: 0,
-            right: 0,
-            bottom: 0,
+            position: 'fixed', top: 0, right: 0, bottom: 0,
             width: { xs: '100%', sm: config.sidebarWidth || 400 },
-            zIndex: 1200,
-            display: 'flex',
+            zIndex: 1200, display: 'flex',
             borderLeft: `1px solid ${theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.06)' : theme.palette.divider}`,
-            bgcolor:
-              theme.palette.mode === 'dark'
-                ? 'rgba(28,28,32,0.95)'
-                : 'rgba(255,255,255,0.98)',
+            bgcolor: theme.palette.mode === 'dark' ? 'rgba(28,28,32,0.95)' : 'rgba(255,255,255,0.98)',
             backdropFilter: 'blur(20px)',
           }}>
           <Box
             onMouseDown={handleSidebarResize}
             sx={{
-              width: 6,
-              flexShrink: 0,
-              cursor: 'ew-resize',
+              width: 6, flexShrink: 0, cursor: 'ew-resize',
               display: { xs: 'none', sm: 'flex' },
-              alignItems: 'center',
-              justifyContent: 'center',
+              alignItems: 'center', justifyContent: 'center',
               transition: 'background-color 0.2s',
               '&:hover': {
-                bgcolor:
-                  theme.palette.mode === 'dark'
-                    ? 'rgba(255,255,255,0.08)'
-                    : 'rgba(0,0,0,0.06)',
+                bgcolor: theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)',
               },
             }}
           />
-          <Box
-            sx={{
-              flex: 1,
-              minWidth: 0,
-              display: 'flex',
-              flexDirection: 'column',
-            }}>
+          <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
             {ChatContent}
           </Box>
         </Paper>
       </Slide>
 
-      {/* FABボタン + ウィジェットモード */}
+      {/* FAB + ウィジェットモード */}
       <Box sx={{ position: 'fixed', bottom: 24, right: 24, zIndex: 1200 }}>
         <Zoom in={!isOpen}>
           <Fab
             onClick={() => setIsOpen(true)}
             sx={{
-              bgcolor:
-                theme.palette.mode === 'dark'
-                  ? 'rgba(14,173,184,0.5)'
-                  : 'rgba(14,173,184,0.85)',
-              color: '#fff',
-              backdropFilter: 'blur(16px)',
-              boxShadow:
-                theme.palette.mode === 'dark'
-                  ? '0 8px 32px rgba(0,0,0,0.4)'
-                  : '0 8px 32px rgba(14,173,184,0.3)',
+              bgcolor: theme.palette.mode === 'dark' ? 'rgba(14,173,184,0.5)' : 'rgba(14,173,184,0.85)',
+              color: '#fff', backdropFilter: 'blur(16px)',
+              boxShadow: theme.palette.mode === 'dark' ? '0 8px 32px rgba(0,0,0,0.4)' : '0 8px 32px rgba(14,173,184,0.3)',
               border: `1px solid ${theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.1)' : 'rgba(255,255,255,0.18)'}`,
               '&:hover': {
-                bgcolor:
-                  theme.palette.mode === 'dark'
-                    ? 'rgba(14,173,184,0.65)'
-                    : 'rgba(14,173,184,0.95)',
-                boxShadow:
-                  theme.palette.mode === 'dark'
-                    ? '0 8px 32px rgba(0,0,0,0.5)'
-                    : '0 8px 32px rgba(14,173,184,0.45)',
+                bgcolor: theme.palette.mode === 'dark' ? 'rgba(14,173,184,0.65)' : 'rgba(14,173,184,0.95)',
+                boxShadow: theme.palette.mode === 'dark' ? '0 8px 32px rgba(0,0,0,0.5)' : '0 8px 32px rgba(14,173,184,0.45)',
               },
             }}>
             <BookConciergeIcon size={24} />
@@ -1712,83 +209,30 @@ export const ChatSupport = ({ currentStory }: ChatSupportProps) => {
             <Paper
               elevation={12}
               sx={{
-                position: 'absolute',
-                bottom: 0,
-                right: 0,
+                position: 'absolute', bottom: 0, right: 0,
                 width: { xs: 'calc(100vw - 48px)', sm: widgetSize.width },
                 height: widgetSize.height,
-                minWidth: 320,
-                minHeight: 400,
-                display: 'flex',
-                flexDirection: 'column',
-                overflow: 'hidden',
-                borderRadius: 2,
+                minWidth: 320, minHeight: 400,
+                display: 'flex', flexDirection: 'column',
+                overflow: 'hidden', borderRadius: 2,
                 border: `1px solid ${theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'}`,
-                bgcolor:
-                  theme.palette.mode === 'dark'
-                    ? 'rgba(28,28,32,0.92)'
-                    : 'rgba(255,255,255,0.92)',
+                bgcolor: theme.palette.mode === 'dark' ? 'rgba(28,28,32,0.92)' : 'rgba(255,255,255,0.92)',
                 backdropFilter: 'blur(20px)',
               }}>
               {/* リサイズハンドル: 上辺 */}
-              <Box
-                onMouseDown={handleResizeStart('top')}
-                sx={{
-                  position: 'absolute',
-                  top: 0,
-                  left: 16,
-                  right: 16,
-                  height: 6,
-                  cursor: 'n-resize',
-                  zIndex: 10,
-                }}
-              />
+              <Box onMouseDown={handleResizeStart('top')} sx={{ position: 'absolute', top: 0, left: 16, right: 16, height: 6, cursor: 'n-resize', zIndex: 10 }} />
               {/* リサイズハンドル: 左辺 */}
-              <Box
-                onMouseDown={handleResizeStart('left')}
-                sx={{
-                  position: 'absolute',
-                  left: 0,
-                  top: 16,
-                  bottom: 0,
-                  width: 6,
-                  cursor: 'ew-resize',
-                  zIndex: 10,
-                }}
-              />
+              <Box onMouseDown={handleResizeStart('left')} sx={{ position: 'absolute', left: 0, top: 16, bottom: 0, width: 6, cursor: 'ew-resize', zIndex: 10 }} />
               {/* リサイズハンドル: 左上角 */}
-              <Box
-                onMouseDown={handleResizeStart('top-left')}
-                sx={{
-                  position: 'absolute',
-                  left: 0,
-                  top: 0,
-                  width: 16,
-                  height: 16,
-                  cursor: 'nw-resize',
-                  zIndex: 11,
-                }}
-              />
-              {/* リサイズインジケーター（上部中央のバー） */}
+              <Box onMouseDown={handleResizeStart('top-left')} sx={{ position: 'absolute', left: 0, top: 0, width: 16, height: 16, cursor: 'nw-resize', zIndex: 11 }} />
+              {/* リサイズインジケーター */}
               <Box
                 onMouseDown={handleResizeStart('top')}
                 sx={{
-                  position: 'absolute',
-                  top: 4,
-                  left: '50%',
-                  transform: 'translateX(-50%)',
-                  width: 32,
-                  height: 4,
-                  borderRadius: 1,
-                  bgcolor:
-                    theme.palette.mode === 'dark'
-                      ? 'rgba(255,255,255,0.1)'
-                      : 'rgba(0,0,0,0.12)',
-                  cursor: 'n-resize',
-                  zIndex: 12,
-                  opacity: 0.5,
-                  transition: 'opacity 0.2s',
-                  '&:hover': { opacity: 1 },
+                  position: 'absolute', top: 4, left: '50%', transform: 'translateX(-50%)',
+                  width: 32, height: 4, borderRadius: 1, cursor: 'n-resize', zIndex: 12,
+                  bgcolor: theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.12)',
+                  opacity: 0.5, transition: 'opacity 0.2s', '&:hover': { opacity: 1 },
                 }}
               />
               {ChatContent}
@@ -1796,19 +240,17 @@ export const ChatSupport = ({ currentStory }: ChatSupportProps) => {
           </Zoom>
         )}
       </Box>
+
+      {/* 確認ダイアログ */}
       <ConfirmDialog
         open={confirmResetOpen}
         title='APIキーのリセット'
-        message='APIキーをリセットしてデフォルト(gpt-4.1-nano)に戻しますか?'
+        message={`APIキーをリセットしてデフォルト(${DEFAULT_MODEL})に戻しますか?`}
         confirmText='リセット'
         confirmColor='warning'
         onConfirm={() => {
           setApiKeyDraft('')
-          setConfig({
-            ...config,
-            apiKey: DEFAULT_API_KEY,
-            model: DEFAULT_MODEL,
-          })
+          setConfig((prev) => ({ ...prev, apiKey: DEFAULT_API_KEY, model: DEFAULT_MODEL }))
           setTestResult(null)
           setShowApiKey(false)
           setConfirmResetOpen(false)

--- a/src/components/ui/ChatSupport/README.md
+++ b/src/components/ui/ChatSupport/README.md
@@ -1,0 +1,218 @@
+# ChatSupport — Storybook AI コンシェルジュ
+
+Storybook 全ストーリーに自動注入される AI チャットウィジェット。
+kaze-ux / sdpf-theme / Matlens の 3 プロジェクト共通アーキテクチャ。
+
+---
+
+## ファイル構成
+
+```
+ChatSupport/
+  ChatSupport.tsx            # スリムコンテナ（~270行）— レイアウト構成のみ
+  chatSupportTypes.ts        # 型定義（CurrentStoryContext, Message, etc.）
+  chatSupportConstants.ts    # 定数・ショートカット・モデル設定
+  chatAiService.ts           # AI 呼び出し（AI SDK v6 ベース）
+  faqDatabase.ts             # FAQ データ + findFaqAnswer + QUICK_SUGGESTIONS
+  storyGuideMap.ts           # ページ別ガイドマップ
+  muiKnowledge.ts            # MUI 知識ベース
+  embeddingSearch.ts         # セマンティック検索（VectorIndex）
+  embeddingService.ts        # OpenAI Embedding API ラッパー
+  writingPatterns.ts         # 記述パターン知識ベース
+  useResize.ts               # リサイズ hook（widget / sidebar）
+  BookConciergeIcon.tsx      # FAB アイコン
+  CodeBlock.tsx              # Markdown コードブロック
+  hooks/
+    useChatState.ts          # isOpen / messages / scrollRef / clearChat
+    useChatConfig.ts         # config / API設定 / ショートカット設定
+    useChatMessage.ts        # 送信 / FAQ / AI / セマンティック検索
+    useChatShortcuts.ts      # グローバルキーボードショートカット
+  components/
+    ChatHeader.tsx           # タイトル行 / ツールバー / モデル名
+    ChatInput.tsx            # 入力欄 + 送信ボタン
+    ChatMessageList.tsx      # メッセージ / サジェスト / タイピング表示
+    ChatPageContextChip.tsx  # ページ解説トリガー（スティッキーチップ）
+    ChatSettings.tsx         # API設定 / モデル選択 / ショートカット設定
+```
+
+---
+
+## Storybook Decorator 注入パターン
+
+`.storybook/preview.tsx` の `Decorator` コンポーネントがすべての Story に自動注入します。
+
+```tsx
+// preview.tsx（抜粋）
+const argTypesRef = useRef(context.argTypes)
+const argsRef = useRef(context.args)
+argTypesRef.current = context.argTypes
+argsRef.current = context.args
+
+const currentStory = useMemo(
+  () => ({
+    title: context.title,
+    name: context.name,
+    description: context.parameters?.docs?.description?.component,
+    // argTypes / args は ref 経由で渡す（Controls 操作での再レンダリング防止）
+    argTypes: argTypesRef.current,
+    args: argsRef.current,
+  }),
+  [
+    context.title,
+    context.name,
+    context.parameters?.docs?.description?.component,
+  ]
+)
+
+{
+  context.viewMode !== 'docs' && !disableDecoratorChat && (
+    <ChatSupport currentStory={currentStory} />
+  )
+}
+```
+
+### なぜ `useRef` パターンを使うか
+
+`context.args` は Storybook Controls パネルの操作のたびに新しいオブジェクト参照が生成されます。
+これを `useMemo` の依存配列に含めると `currentStory` が頻繁に再生成され、
+ChatSupport 内の `storyGuide` メモ化や `contextualPrompt` 生成が不要に再実行されます。
+
+`useRef` で参照を保持しつつ毎レンダリングで `current` を更新することで、
+memo は安定しつつ最新値を保持できます。
+
+---
+
+## `disableDecoratorChat` — 二重レンダリング防止
+
+ChatSupport 専用の Story では、Decorator 側の注入を無効化する必要があります。
+
+```tsx
+// ChatSupport.stories.tsx
+const meta: Meta<typeof ChatSupport> = {
+  parameters: {
+    disableDecoratorChat: true, // Decorator の ChatSupport を無効化
+  },
+}
+```
+
+**なぜ必要か:** ChatSupport.stories.tsx は Story 自身が `<ChatSupport />` を描画します。
+`disableDecoratorChat: true` がない場合、Decorator 側と Story 側の 2 つのインスタンスが
+同じ `position: fixed` 座標に重なり、React の state や localStorage 操作が競合します。
+
+この parameter 名は **kaze-ux / sdpf-theme / Matlens の 3 プロジェクトで共通** です。
+
+---
+
+## `CurrentStoryContext` 型（3 プロジェクト共通）
+
+```ts
+export interface CurrentStoryContext {
+  title: string // Story のカテゴリ階層（例: "Components/UI/Button"）
+  name: string // Story 名（例: "Default"）
+  description?: string // meta の docs.description.component（あれば）
+  argTypes?: Record<string, unknown> // コンポーネントの props スキーマ
+  args?: Record<string, unknown> // 現在 Story で使用中の props 値
+}
+```
+
+`argTypes` / `args` は現在型定義のみ。AI プロンプトへの注入は今後の PR で実装予定。
+
+---
+
+## AI 呼び出しアーキテクチャ
+
+### 3 層フォールバック
+
+```
+ユーザー入力
+  ↓
+1. ページ文脈クエリ判定（「この画面は？」等）
+   → storyGuideMap から即時回答
+  ↓
+2. セマンティック検索（APIキーあり）
+   → VectorIndex で類似 FAQ を発見 → プロンプト補強
+  ↓
+3. AI 呼び出し（AI SDK v6 generateText）
+   → callAI(config, payload)
+  ↓
+エラー時フォールバック: セマンティック FAQ → キーワード FAQ → エラーメッセージ
+```
+
+### AI SDK v6 パターン（`chatAiService.ts`）
+
+```ts
+import { createOpenAI } from '@ai-sdk/openai'
+import { createGoogleGenerativeAI } from '@ai-sdk/google'
+import { generateText } from 'ai'
+
+const resolveModel = (config) => {
+  if (config.model.includes('gemini')) {
+    return createGoogleGenerativeAI({ apiKey: config.apiKey })(config.model)
+  }
+  return createOpenAI({ apiKey: config.apiKey })(config.model)
+}
+
+export const callAI = async (config, messages, isTest = false) => {
+  const result = await generateText({
+    model: resolveModel(config),
+    messages,
+    maxOutputTokens,
+    abortSignal: AbortSignal.timeout(60000),
+  })
+  return result.text
+}
+```
+
+---
+
+## セマンティック検索（`embeddingSearch.ts`）
+
+```
+text-embedding-3-small (512次元に短縮)
+  → インメモリ VectorIndex（バッチ 100 件単位で API 呼び出し）
+  → コサイン類似度: dot(a, b) / (norm_a * norm_b)
+  → threshold = 0.3, topK = 5
+```
+
+API キーがある場合のみ有効。キーなし時は FAQ キーワード検索にフォールバック。
+
+---
+
+## キーボードショートカット（デフォルト）
+
+| アクション       | Mac     | Windows    |
+| ---------------- | ------- | ---------- |
+| チャット開閉     | `⌘ K`   | `Ctrl K`   |
+| チャットを閉じる | `Esc`   | `Esc`      |
+| 入力欄フォーカス | `⌘ L`   | `Ctrl L`   |
+| 設定パネル切替   | `⌘ ,`   | `Ctrl ,`   |
+| 履歴ダウンロード | `⌘ D`   | `Ctrl D`   |
+| UI モード切替    | `⌘ \`   | `Ctrl \`   |
+| 履歴クリア       | `⌘ ⇧ K` | `Ctrl ⇧ K` |
+| メッセージ送信   | `⌘ ↵`   | `Ctrl ↵`   |
+
+すべてのショートカットは設定パネルからカスタマイズ可能。localStorage に永続化。
+
+---
+
+## バックエンドプロキシ（`api/ai.ts`）
+
+Vercel Function として `/api/ai` を提供。API キーをサーバー側で保持しブラウザに露出させない。
+
+- 共有プール（プロジェクト提供キー）: IP ベースのレート制限（Upstash Redis / in-memory フォールバック）
+- ユーザー自前キー（`X-User-API-Key` ヘッダー）: レート制限免除
+- `requiresUserKey` モデル（高コスト）: サーバー側でも自前キーを要求
+
+---
+
+## 3 プロジェクト共通パターン
+
+| 項目                             | kaze-ux     | sdpf-theme | Matlens |
+| -------------------------------- | ----------- | ---------- | ------- |
+| `disableDecoratorChat` parameter | ✅          | ✅         | ✅      |
+| `argTypes/args` 型定義           | ✅          | ✅         | ✅      |
+| useRef パターン                  | ✅          | ✅         | ✅      |
+| AI SDK v6                        | ✅          | 実装中     | ✅      |
+| バックエンドプロキシ             | ✅ (PR #28) | 予定       | ✅      |
+| Fuse.js                          | 予定        | ✅         | ✅      |
+| セマンティック検索               | ✅          | ✅         | —       |

--- a/src/components/ui/ChatSupport/components/ChatHeader.tsx
+++ b/src/components/ui/ChatSupport/components/ChatHeader.tsx
@@ -1,0 +1,135 @@
+// チャットヘッダーコンポーネント
+// - タイトル行（戻るボタン or アバター + タイトル/ページ名）
+// - ツールバー（UI切替 / 設定 / ダウンロード / クリア / 閉じる）
+// - モデル名表示
+
+import { Avatar, Box, IconButton, Stack, Typography, useTheme } from '@mui/material'
+import {
+  X, Bot, ChevronLeft, PanelRight, MessageSquare,
+  Settings, Download, Trash2,
+} from 'lucide-react'
+
+import { DEFAULT_API_KEY, DEFAULT_MODEL } from '../chatSupportConstants'
+
+import type { ChatSupportConfig, CurrentStoryContext } from '../chatSupportTypes'
+
+interface ChatHeaderProps {
+  showSettings: boolean
+  currentStory: CurrentStoryContext | null | undefined
+  config: ChatSupportConfig
+  onBack: () => void
+  onToggleUiMode: () => void
+  onToggleSettings: () => void
+  onDownload: () => void
+  onClearChat: () => void
+  onClose: () => void
+}
+
+export const ChatHeader = ({
+  showSettings,
+  currentStory,
+  config,
+  onBack,
+  onToggleUiMode,
+  onToggleSettings,
+  onDownload,
+  onClearChat,
+  onClose,
+}: ChatHeaderProps) => {
+  const theme = useTheme()
+
+  return (
+    <Box
+      sx={{
+        bgcolor:
+          theme.palette.mode === 'dark'
+            ? 'rgba(14,173,184,0.55)'
+            : 'primary.main',
+        color: '#ffffff',
+        backdropFilter: 'blur(12px)',
+      }}>
+      {/* タイトル行 */}
+      <Stack
+        direction='row'
+        justifyContent='space-between'
+        alignItems='center'
+        sx={{ px: 2, pt: 1.5, pb: 0.5 }}>
+        <Stack direction='row' spacing={1.5} alignItems='center'>
+          {showSettings ? (
+            <IconButton size='small' color='inherit' onClick={onBack}>
+              <ChevronLeft size={20} />
+            </IconButton>
+          ) : (
+            <Avatar sx={{ bgcolor: 'rgba(255,255,255,0.2)', width: 32, height: 32 }}>
+              <Bot size={20} />
+            </Avatar>
+          )}
+          <Box>
+            <Typography variant='subtitle2' sx={{ fontWeight: 600, lineHeight: 1.2 }}>
+              {showSettings
+                ? 'AI設定'
+                : currentStory
+                  ? currentStory.name
+                  : 'Concierge'}
+            </Typography>
+            {!showSettings && currentStory && (
+              <Typography
+                variant='caption'
+                sx={{ opacity: 0.8, display: 'block', lineHeight: 1.4 }}>
+                {currentStory.title}
+              </Typography>
+            )}
+          </Box>
+        </Stack>
+      </Stack>
+
+      {/* ツールバー + モデル名 */}
+      <Stack
+        direction='row'
+        justifyContent='space-between'
+        alignItems='center'
+        sx={{ px: 1.5, pb: 1, pt: 0.5 }}>
+        <Stack direction='row' alignItems='center'>
+          {!showSettings && (
+            <>
+              <IconButton
+                size='small'
+                color='inherit'
+                onClick={onToggleUiMode}
+                title={config.uiMode === 'widget' ? 'サイドバーに切替' : 'ウィジェットに切替'}>
+                {config.uiMode === 'widget' ? (
+                  <PanelRight size={18} />
+                ) : (
+                  <MessageSquare size={18} />
+                )}
+              </IconButton>
+              <IconButton size='small' color='inherit' onClick={onToggleSettings}>
+                <Settings size={18} />
+              </IconButton>
+              <IconButton
+                size='small'
+                color='inherit'
+                onClick={onDownload}
+                title='Markdownでダウンロード'>
+                <Download size={18} />
+              </IconButton>
+              <IconButton size='small' color='inherit' onClick={onClearChat} title='履歴クリア'>
+                <Trash2 size={18} />
+              </IconButton>
+            </>
+          )}
+          <IconButton size='small' color='inherit' onClick={onClose}>
+            <X size={18} />
+          </IconButton>
+        </Stack>
+        {!showSettings && (
+          <Typography sx={{ opacity: 0.6, fontSize: 12, whiteSpace: 'nowrap' }}>
+            {!config.apiKey && !DEFAULT_API_KEY
+              ? 'FAQモード'
+              : config.model || DEFAULT_MODEL}
+          </Typography>
+        )}
+      </Stack>
+    </Box>
+  )
+}

--- a/src/components/ui/ChatSupport/components/ChatInput.tsx
+++ b/src/components/ui/ChatSupport/components/ChatInput.tsx
@@ -1,0 +1,81 @@
+// チャット入力エリア（TextField + 送信ボタン）
+
+import { Box, IconButton, Stack, TextField, useTheme } from '@mui/material'
+import { Send } from 'lucide-react'
+
+interface ChatInputProps {
+  message: string
+  isTyping: boolean
+  submitShortcutLabel: string
+  hasApiKey: boolean
+  inputRef: React.RefObject<HTMLInputElement | null>
+  onMessageChange: (v: string) => void
+  onKeyDown: (e: React.KeyboardEvent) => void
+  onSend: () => void
+}
+
+export const ChatInput = ({
+  message,
+  isTyping,
+  submitShortcutLabel,
+  hasApiKey,
+  inputRef,
+  onMessageChange,
+  onKeyDown,
+  onSend,
+}: ChatInputProps) => {
+  const theme = useTheme()
+
+  return (
+    <Box
+      sx={{
+        pt: '16px', pr: '4px', pb: '10px', pl: '16px',
+        bgcolor:
+          theme.palette.mode === 'dark'
+            ? 'rgba(30,30,30,0.6)'
+            : 'rgba(255,255,255,0.85)',
+        backdropFilter: 'blur(12px)',
+        borderTop: `1px solid ${
+          theme.palette.mode === 'dark'
+            ? 'rgba(255,255,255,0.06)'
+            : theme.palette.divider
+        }`,
+      }}>
+      <Stack direction='row' spacing={1} alignItems='stretch'>
+        <TextField
+          fullWidth
+          multiline
+          minRows={2}
+          maxRows={8}
+          inputRef={inputRef}
+          placeholder={
+            hasApiKey
+              ? `質問を入力... (${submitShortcutLabel}で送信)`
+              : `FAQモード: 質問を入力... (${submitShortcutLabel}で送信)`
+          }
+          value={message}
+          onChange={(e) => onMessageChange(e.target.value)}
+          onKeyDown={onKeyDown}
+          disabled={isTyping}
+          sx={{ '& .MuiOutlinedInput-root': { borderRadius: 1.5 } }}
+        />
+        <IconButton
+          color='primary'
+          disabled={!message.trim() || isTyping}
+          onClick={onSend}
+          sx={{
+            alignSelf: 'stretch',
+            width: 44,
+            borderRadius: 1.5,
+            bgcolor: message.trim() ? 'primary.main' : 'transparent',
+            color: message.trim() ? 'primary.contrastText' : 'inherit',
+            '&:hover': {
+              bgcolor: message.trim() ? 'primary.dark' : 'action.hover',
+            },
+          }}>
+          <Send size={18} />
+        </IconButton>
+      </Stack>
+    </Box>
+  )
+}

--- a/src/components/ui/ChatSupport/components/ChatMessageList.tsx
+++ b/src/components/ui/ChatSupport/components/ChatMessageList.tsx
@@ -1,0 +1,255 @@
+// メッセージリスト + クイックサジェスト + タイピングインジケーター
+
+import {
+  Avatar, Box, Chip, CircularProgress, Typography, useTheme,
+} from '@mui/material'
+import { Bot, User } from 'lucide-react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+import CodeBlock, { CodeBlockPre } from '../CodeBlock'
+import { QUICK_SUGGESTIONS } from '../faqDatabase'
+
+import type { CurrentStoryContext, Message } from '../chatSupportTypes'
+import type { StoryGuideEntry } from '../storyGuideMap'
+
+interface ChatMessageListProps {
+  messages: Message[]
+  isTyping: boolean
+  scrollRef: React.RefObject<HTMLDivElement | null>
+  storyGuide: StoryGuideEntry | null
+  currentStory: CurrentStoryContext | null | undefined
+  hasUserMessages: boolean
+  onSuggestionClick: (query: string) => void
+}
+
+export const ChatMessageList = ({
+  messages,
+  isTyping,
+  scrollRef,
+  storyGuide,
+  hasUserMessages,
+  onSuggestionClick,
+}: ChatMessageListProps) => {
+  const theme = useTheme()
+
+  return (
+    <Box
+      ref={scrollRef}
+      sx={{
+        flexGrow: 1,
+        px: 1.5,
+        py: 1.5,
+        overflowY: 'auto',
+        bgcolor:
+          theme.palette.mode === 'dark'
+            ? 'rgba(255,255,255,0.03)'
+            : 'rgba(248,249,250,0.8)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 1.5,
+      }}>
+      {messages.map((msg) => {
+        const isUser = msg.sender === 'user'
+        return (
+          <Box
+            key={msg.id}
+            sx={{ display: 'flex', justifyContent: isUser ? 'flex-end' : 'flex-start' }}>
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: isUser ? 'row-reverse' : 'row',
+                alignItems: 'flex-start',
+                gap: 0.75,
+                maxWidth: '96%',
+              }}>
+              <Avatar
+                sx={{
+                  width: 28, height: 28, mt: 0.5, flexShrink: 0,
+                  bgcolor: isUser ? 'secondary.main' : 'primary.light',
+                  fontSize: 12,
+                }}>
+                {isUser ? <User size={14} /> : <Bot size={14} />}
+              </Avatar>
+              <Box
+                sx={{
+                  px: 2, pt: '5px', pb: '4px',
+                  minWidth: 0, overflow: 'hidden',
+                  borderRadius: '12px',
+                  borderTopLeftRadius: isUser ? '12px' : '2px',
+                  borderTopRightRadius: isUser ? '2px' : '12px',
+                  bgcolor: isUser
+                    ? theme.palette.mode === 'dark'
+                      ? 'rgba(14,173,184,0.45)'
+                      : 'primary.main'
+                    : theme.palette.mode === 'dark'
+                      ? 'rgba(255,255,255,0.06)'
+                      : 'background.paper',
+                  color: isUser ? 'primary.contrastText' : 'text.primary',
+                  boxShadow: 'none',
+                }}>
+                {isUser ? (
+                  <Typography
+                    variant='body2'
+                    sx={{ whiteSpace: 'pre-wrap', lineHeight: 1.7, fontSize: 14 }}>
+                    {msg.text}
+                  </Typography>
+                ) : (
+                  <Box
+                    sx={{
+                      fontSize: 14, lineHeight: 1.7, wordBreak: 'break-word',
+                      '& p': { m: 0, mb: 1, '&:last-child': { mb: 0 } },
+                      '& h1, & h2, & h3, & h4, & h5, & h6': {
+                        mt: 2, mb: 1, lineHeight: 1.5, fontWeight: 600,
+                      },
+                      '& h1': { fontSize: 18 },
+                      '& h2': { fontSize: 16 },
+                      '& h3': { fontSize: 14 },
+                      '& ul, & ol': { pl: 2.5, my: 1 },
+                      '& li': { mb: 0.5 },
+                      '& code': {
+                        bgcolor:
+                          theme.palette.mode === 'dark'
+                            ? 'rgba(255,255,255,0.07)'
+                            : 'rgba(0,0,0,0.06)',
+                        px: 0.5, py: 0.25, border: 'none',
+                        borderRadius: 0.5, fontSize: 12,
+                        fontFamily: '"Fira Code", "Consolas", monospace',
+                        lineHeight: 1.75,
+                      },
+                      '& pre': {
+                        bgcolor:
+                          theme.palette.mode === 'dark'
+                            ? 'rgba(0,0,0,0.2)'
+                            : 'rgba(0,0,0,0.04)',
+                        p: 1.5, border: 'none', borderRadius: 1,
+                        overflowX: 'auto', my: 1,
+                        '& code': { bgcolor: 'transparent', border: 'none', px: 0, py: 0 },
+                      },
+                      '& blockquote': {
+                        borderLeft: '3px solid', borderColor: 'divider',
+                        pl: 1.5, ml: 0, my: 1, opacity: 0.85,
+                      },
+                      '& a': { color: 'primary.main', textDecoration: 'underline' },
+                      '& table': {
+                        borderCollapse: 'collapse', my: 1, width: '100%',
+                        '& th, & td': {
+                          border: '1px solid', borderColor: 'divider',
+                          px: 1, py: 0.5, fontSize: 12,
+                        },
+                        '& th': {
+                          fontWeight: 600,
+                          bgcolor:
+                            theme.palette.mode === 'dark'
+                              ? 'rgba(255,255,255,0.04)'
+                              : 'rgba(0,0,0,0.03)',
+                        },
+                      },
+                    }}>
+                    <ReactMarkdown
+                      remarkPlugins={[remarkGfm]}
+                      components={{
+                        code: CodeBlock,
+                        pre: CodeBlockPre,
+                        a: ({ href, children: linkChildren }) => (
+                          <a href={href} target='_blank' rel='noopener noreferrer'>
+                            {linkChildren}
+                          </a>
+                        ),
+                      }}>
+                      {msg.text}
+                    </ReactMarkdown>
+                  </Box>
+                )}
+              </Box>
+            </Box>
+          </Box>
+        )
+      })}
+
+      {/* クイックサジェスト（初回 + 非タイピング時） */}
+      {!hasUserMessages && !isTyping && (
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75, mt: 0.5, ml: 4.5 }}>
+          {storyGuide && (
+            <>
+              <Chip
+                label='現在のページの解説'
+                size='small'
+                variant='outlined'
+                onClick={() => onSuggestionClick('この画面の解説をお願いします')}
+                sx={{
+                  cursor: 'pointer', fontSize: 12,
+                  borderColor: 'success.main', color: 'success.main',
+                  '&:hover': {
+                    bgcolor:
+                      theme.palette.mode === 'dark'
+                        ? 'rgba(76,175,80,0.08)'
+                        : 'rgba(76,175,80,0.06)',
+                    borderColor: 'success.main',
+                  },
+                }}
+              />
+              <Chip
+                label='実装のポイント'
+                size='small'
+                variant='outlined'
+                onClick={() => onSuggestionClick('この画面の実装のポイントを教えて')}
+                sx={{
+                  cursor: 'pointer', fontSize: 12,
+                  borderColor: 'info.main', color: 'info.main',
+                  '&:hover': {
+                    bgcolor:
+                      theme.palette.mode === 'dark'
+                        ? 'rgba(29,175,194,0.08)'
+                        : 'rgba(29,175,194,0.06)',
+                    borderColor: 'info.main',
+                  },
+                }}
+              />
+            </>
+          )}
+          {QUICK_SUGGESTIONS.map((s) => (
+            <Chip
+              key={s.label}
+              label={s.label}
+              size='small'
+              variant='outlined'
+              onClick={() => onSuggestionClick(s.query)}
+              sx={{
+                cursor: 'pointer', fontSize: 12,
+                borderColor:
+                  theme.palette.mode === 'dark'
+                    ? 'rgba(255,255,255,0.12)'
+                    : 'rgba(14,173,184,0.3)',
+                color:
+                  theme.palette.mode === 'dark'
+                    ? 'rgba(255,255,255,0.6)'
+                    : 'primary.main',
+                '&:hover': {
+                  bgcolor:
+                    theme.palette.mode === 'dark'
+                      ? 'rgba(255,255,255,0.06)'
+                      : 'rgba(14,173,184,0.06)',
+                  borderColor:
+                    theme.palette.mode === 'dark'
+                      ? 'rgba(255,255,255,0.25)'
+                      : 'primary.main',
+                },
+              }}
+            />
+          ))}
+        </Box>
+      )}
+
+      {/* タイピングインジケーター */}
+      {isTyping && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, ml: 1 }}>
+          <CircularProgress size={14} />
+          <Typography variant='caption' color='text.secondary'>
+            AI回答中...
+          </Typography>
+        </Box>
+      )}
+    </Box>
+  )
+}

--- a/src/components/ui/ChatSupport/components/ChatPageContextChip.tsx
+++ b/src/components/ui/ChatSupport/components/ChatPageContextChip.tsx
@@ -1,0 +1,69 @@
+// ページ解説トリガー（スティッキーチップ）
+// storyGuide が存在する時だけ表示し、クリックでページ解説をチャットに展開する
+
+import { Box, Chip, useTheme } from '@mui/material'
+import { Info } from 'lucide-react'
+
+import type { CurrentStoryContext } from '../chatSupportTypes'
+import type { StoryGuideEntry } from '../storyGuideMap'
+
+interface ChatPageContextChipProps {
+  storyGuide: StoryGuideEntry | null
+  currentStory: CurrentStoryContext | null | undefined
+  onExplain: () => void
+}
+
+export const ChatPageContextChip = ({
+  storyGuide,
+  currentStory,
+  onExplain,
+}: ChatPageContextChipProps) => {
+  const theme = useTheme()
+
+  if (!storyGuide || !currentStory) return null
+
+  return (
+    <Box
+      sx={{
+        px: 1.5,
+        py: 0.75,
+        bgcolor:
+          theme.palette.mode === 'dark'
+            ? 'rgba(14,173,184,0.3)'
+            : 'rgba(63,81,181,0.08)',
+        borderBottom: '1px solid',
+        borderColor: 'divider',
+        position: 'sticky',
+        top: 0,
+        zIndex: 1,
+      }}>
+      <Chip
+        icon={<Info size={14} />}
+        label={`${currentStory.title} の解説を見る`}
+        size='small'
+        variant='outlined'
+        onClick={onExplain}
+        sx={{
+          height: 28,
+          fontSize: '0.75rem',
+          cursor: 'pointer',
+          borderColor:
+            theme.palette.mode === 'dark'
+              ? 'rgba(255,255,255,0.2)'
+              : 'primary.light',
+          color:
+            theme.palette.mode === 'dark'
+              ? 'rgba(255,255,255,0.9)'
+              : 'primary.main',
+          '& .MuiChip-icon': { color: 'inherit' },
+          '&:hover': {
+            bgcolor:
+              theme.palette.mode === 'dark'
+                ? 'rgba(255,255,255,0.08)'
+                : 'rgba(63,81,181,0.12)',
+          },
+        }}
+      />
+    </Box>
+  )
+}

--- a/src/components/ui/ChatSupport/components/ChatSettings.tsx
+++ b/src/components/ui/ChatSupport/components/ChatSettings.tsx
@@ -1,0 +1,381 @@
+// 設定パネル
+// - 接続状態表示
+// - カスタム API キー入力（OpenAI / Gemini プロバイダータブ）
+// - モデル選択ドロップダウン
+// - 接続テストボタン
+// - キーボードショートカット設定テーブル
+
+import {
+  Alert, Box, Button, Chip, CircularProgress, Divider,
+  InputAdornment, Link, MenuItem, Stack, TextField, Typography, useTheme,
+} from '@mui/material'
+import {
+  AlertCircle, CheckCircle2, Eye, EyeOff, Keyboard, Lock, Sparkles,
+} from 'lucide-react'
+
+import {
+  DEFAULT_API_KEY,
+  DEFAULT_MODEL,
+  GEMINI_MODELS,
+  OPENAI_MODELS,
+  SHORTCUT_METADATA,
+  formatShortcutLabel,
+} from '../chatSupportConstants'
+
+import type {
+  ChatSupportConfig,
+  ShortcutActionId,
+} from '../chatSupportTypes'
+
+interface ChatSettingsProps {
+  config: ChatSupportConfig
+  setConfig: React.Dispatch<React.SetStateAction<ChatSupportConfig>>
+  apiKeyDraft: string
+  setApiKeyDraft: (v: string) => void
+  isUsingDefaultKey: boolean
+  showApiKey: boolean
+  setShowApiKey: (v: boolean) => void
+  testResult: { success: boolean; message: string } | null
+  setTestResult: (v: { success: boolean; message: string } | null) => void
+  isTesting: boolean
+  onTestConnection: () => void
+  onResetShortcuts: () => void
+  onShortcutInputKeyDown: (id: ShortcutActionId) => (e: React.KeyboardEvent<HTMLElement>) => void
+  onResetApiKey: () => void
+}
+
+export const ChatSettings = ({
+  config,
+  setConfig,
+  apiKeyDraft,
+  setApiKeyDraft,
+  isUsingDefaultKey,
+  showApiKey,
+  setShowApiKey,
+  testResult,
+  setTestResult,
+  isTesting,
+  onTestConnection,
+  onResetShortcuts,
+  onShortcutInputKeyDown,
+  onResetApiKey,
+}: ChatSettingsProps) => {
+  const theme = useTheme()
+
+  return (
+    <Box sx={{ p: 3, flexGrow: 1, overflowY: 'auto' }}>
+      <Stack spacing={3}>
+        {/* 現在の接続状態 */}
+        <Box
+          sx={{
+            bgcolor:
+              theme.palette.mode === 'dark'
+                ? 'rgba(255,255,255,0.05)'
+                : 'rgba(0,0,0,0.03)',
+            borderRadius: 1,
+            p: 2,
+          }}>
+          <Typography variant='caption' sx={{ fontWeight: 600, display: 'block', mb: 0.5 }}>
+            現在の設定
+          </Typography>
+          {isUsingDefaultKey ? (
+            DEFAULT_API_KEY ? (
+              <>
+                <Typography variant='caption' color='text.secondary' sx={{ display: 'block', lineHeight: 1.6 }}>
+                  {config.model} を使用中（プロジェクト提供）
+                </Typography>
+                <Stack direction='row' alignItems='center' spacing={0.5} sx={{ mt: 0.5 }}>
+                  <CheckCircle2 size={14} color={theme.palette.success.main} />
+                  <Typography variant='caption' color='success.main'>AI対話モード</Typography>
+                </Stack>
+              </>
+            ) : (
+              <>
+                <Typography variant='caption' color='text.secondary' sx={{ display: 'block', lineHeight: 1.6 }}>
+                  APIキー未設定
+                </Typography>
+                <Stack direction='row' alignItems='center' spacing={0.5} sx={{ mt: 0.5 }}>
+                  <AlertCircle size={14} color={theme.palette.warning.main} />
+                  <Typography variant='caption' color='warning.main'>
+                    FAQモードのみ（AI対話にはAPIキーが必要）
+                  </Typography>
+                </Stack>
+              </>
+            )
+          ) : (
+            <>
+              <Typography variant='caption' color='text.secondary' sx={{ display: 'block', lineHeight: 1.6 }}>
+                {config.model} を使用中（カスタムAPIキー）
+              </Typography>
+              <Stack direction='row' alignItems='center' spacing={0.5} sx={{ mt: 0.5 }}>
+                <CheckCircle2 size={14} color={theme.palette.success.main} />
+                <Typography variant='caption' color='success.main'>AI対話モード</Typography>
+              </Stack>
+            </>
+          )}
+        </Box>
+
+        <Divider />
+
+        {/* カスタム API 設定 */}
+        <Box>
+          <Typography variant='caption' sx={{ fontWeight: 600, display: 'block', mb: 0.5 }}>
+            カスタムAPI設定（任意）
+          </Typography>
+          <Typography variant='caption' color='text.secondary' sx={{ display: 'block', mb: 1.5, lineHeight: 1.6 }}>
+            自分のAPIキーを使うと、より高性能なモデルを選択できます。
+          </Typography>
+
+          {/* プロバイダー選択タブ */}
+          <Stack direction='row' spacing={1} sx={{ mb: 1.5 }}>
+            {(['openai', 'gemini'] as const).map((provider) => {
+              const isGemini = (config.model ?? '').includes('gemini')
+              const active =
+                (provider === 'gemini' && isGemini) ||
+                (provider === 'openai' && !isGemini)
+              return (
+                <Chip
+                  key={provider}
+                  label={provider === 'openai' ? 'OpenAI' : 'Google Gemini'}
+                  size='small'
+                  variant={active ? 'filled' : 'outlined'}
+                  color={active ? 'primary' : 'default'}
+                  onClick={() => {
+                    const models = provider === 'gemini' ? GEMINI_MODELS : OPENAI_MODELS
+                    const defaultModel = (
+                      models.find((m) => !m.requiresUserKey) ?? models[0]
+                    ).value
+                    setConfig({ ...config, model: defaultModel })
+                    setTestResult(null)
+                  }}
+                  sx={{ cursor: 'pointer', fontWeight: 500, fontSize: '0.75rem' }}
+                />
+              )
+            })}
+          </Stack>
+
+          {/* API キー入力 */}
+          <TextField
+            fullWidth
+            size='small'
+            autoComplete='off'
+            value={apiKeyDraft}
+            onChange={(e) => {
+              const v = e.target.value
+              setApiKeyDraft(v)
+              if (v) {
+                setConfig({ ...config, apiKey: v })
+              } else {
+                setConfig({ ...config, apiKey: DEFAULT_API_KEY, model: DEFAULT_MODEL })
+              }
+              setTestResult(null)
+            }}
+            placeholder={(config.model ?? '').includes('gemini') ? 'AIza...' : 'sk-proj-...'}
+            type={showApiKey ? 'text' : 'password'}
+            inputProps={{
+              style: {
+                fontFamily: 'monospace',
+                fontSize: 12,
+                letterSpacing: showApiKey ? 'normal' : '0.1em',
+              },
+            }}
+            InputProps={{
+              endAdornment: apiKeyDraft ? (
+                <InputAdornment position='end'>
+                  <Stack direction='row' spacing={0.5}>
+                    <Button
+                      size='small'
+                      variant='text'
+                      onClick={() => setShowApiKey(!showApiKey)}
+                      sx={{ minWidth: 0, p: 0.5 }}>
+                      {showApiKey ? <EyeOff size={14} /> : <Eye size={14} />}
+                    </Button>
+                    <Button
+                      size='small'
+                      variant='text'
+                      color='warning'
+                      onClick={onResetApiKey}
+                      sx={{ minWidth: 0, p: 0.5, fontSize: 11 }}>
+                      リセット
+                    </Button>
+                  </Stack>
+                </InputAdornment>
+              ) : undefined,
+            }}
+          />
+        </Box>
+
+        {/* モデル選択 */}
+        <Box>
+          <Typography variant='caption' color='text.secondary' sx={{ display: 'block', mb: 0.8, fontWeight: 600 }}>
+            AIモデル
+          </Typography>
+          <TextField
+            select
+            fullWidth
+            size='small'
+            value={config.model}
+            onChange={(e) => {
+              setConfig({ ...config, model: e.target.value })
+              setTestResult(null)
+            }}>
+            {((config.model ?? '').includes('gemini') ? GEMINI_MODELS : OPENAI_MODELS).map((opt) => {
+              const isLocked = isUsingDefaultKey && !!opt.requiresUserKey
+              return (
+                <MenuItem
+                  key={opt.value}
+                  value={opt.value}
+                  disabled={isLocked}
+                  title={isLocked ? '自分のAPIキーを設定すると使用できます' : undefined}
+                  sx={{ py: 1.5, alignItems: 'flex-start' }}>
+                  <Box sx={{ width: '100%' }}>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mb: 0.25 }}>
+                      {isLocked && <Lock size={12} />}
+                      <Typography variant='body2' sx={{ fontWeight: 600 }}>{opt.label}</Typography>
+                      <Chip
+                        label={
+                          opt.tier === 'premium' ? 'Premium'
+                            : opt.tier === 'economy' ? 'Economy'
+                            : 'Standard'
+                        }
+                        size='small'
+                        color={opt.tier === 'premium' ? 'primary' : opt.tier === 'economy' ? 'default' : 'info'}
+                        variant='outlined'
+                        sx={{ height: 18, fontSize: '0.6rem', '& .MuiChip-label': { px: 0.75 } }}
+                      />
+                    </Box>
+                    <Typography variant='caption' color='text.secondary' sx={{ display: 'block', lineHeight: 1.4, mb: 0.5 }}>
+                      {opt.description}
+                    </Typography>
+                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                      {opt.usecases.map((uc) => (
+                        <Typography
+                          key={uc}
+                          variant='caption'
+                          sx={{ fontSize: '0.65rem', color: 'text.disabled', lineHeight: 1.2, '&::before': { content: '"- "' } }}>
+                          {uc}
+                        </Typography>
+                      ))}
+                    </Box>
+                  </Box>
+                </MenuItem>
+              )
+            })}
+          </TextField>
+        </Box>
+
+        {/* 接続テスト（カスタムキー入力時のみ） */}
+        {!!apiKeyDraft && (
+          <>
+            <Button
+              fullWidth
+              variant='outlined'
+              size='medium'
+              onClick={onTestConnection}
+              disabled={isTesting || !config.apiKey}
+              sx={{ py: 1 }}
+              startIcon={
+                isTesting ? <CircularProgress size={16} color='inherit' /> : <Sparkles size={16} />
+              }>
+              {isTesting ? 'テスト中...' : 'API接続テスト'}
+            </Button>
+            {testResult && (
+              <Alert
+                severity={testResult.success ? 'success' : 'error'}
+                icon={testResult.success ? <CheckCircle2 size={18} /> : <AlertCircle size={18} />}>
+                <Typography variant='caption'>{testResult.message}</Typography>
+              </Alert>
+            )}
+          </>
+        )}
+
+        <Divider />
+        <Typography variant='caption' color='text.secondary'>
+          キーはブラウザにのみ保存されます。モデルを切り替えたらテストを推奨します。
+        </Typography>
+
+        {/* API キー取得方法 */}
+        <Box
+          sx={{
+            bgcolor:
+              theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.03)',
+            borderRadius: 1, p: 1.5,
+          }}>
+          <Typography variant='caption' sx={{ fontWeight: 600, display: 'block', mb: 0.5 }}>
+            APIキーの取得方法
+          </Typography>
+          <Typography variant='caption' color='text.secondary' component='div' sx={{ lineHeight: 1.7 }}>
+            <Box component='ul' sx={{ pl: 2, m: 0, '& li': { mb: 0.5 } }}>
+              <li>
+                <strong>OpenAI</strong>:{' '}
+                <Link href='https://platform.openai.com/api-keys' target='_blank' rel='noopener noreferrer' sx={{ fontSize: 'inherit' }}>
+                  platform.openai.com
+                </Link>{' '}
+                でアカウント作成後、API Keysページでキーを発行（従量課金制）
+              </li>
+              <li>
+                <strong>Google Gemini</strong>:{' '}
+                <Link href='https://aistudio.google.com/apikey' target='_blank' rel='noopener noreferrer' sx={{ fontSize: 'inherit' }}>
+                  aistudio.google.com
+                </Link>{' '}
+                でGoogleアカウントでログイン後、APIキーを発行（無料枠あり）
+              </li>
+            </Box>
+          </Typography>
+        </Box>
+
+        <Divider />
+
+        {/* ショートカット設定 */}
+        <Box>
+          <Stack direction='row' justifyContent='space-between' spacing={1} alignItems='center' sx={{ mb: 1 }}>
+            <Stack direction='row' spacing={1} alignItems='center'>
+              <Keyboard size={14} />
+              <Typography variant='caption' sx={{ fontWeight: 600 }}>
+                キーボードショートカット
+              </Typography>
+            </Stack>
+            <Button size='small' variant='text' onClick={onResetShortcuts}>
+              既定値に戻す
+            </Button>
+          </Stack>
+          <Typography variant='caption' color='text.secondary' sx={{ display: 'block', mb: 1.2 }}>
+            入力欄にフォーカスして希望のキーを押すと更新されます。
+          </Typography>
+          <Box
+            component='table'
+            sx={{
+              width: '100%',
+              borderCollapse: 'collapse',
+              '& td': { py: 0.6, fontSize: 11, verticalAlign: 'middle' },
+              '& td:first-of-type': { width: 160, pr: 1 },
+            }}>
+            <tbody>
+              {SHORTCUT_METADATA.map((s) => (
+                <tr key={s.id}>
+                  <td>
+                    <TextField
+                      size='small'
+                      value={formatShortcutLabel(config.shortcuts[s.id])}
+                      onKeyDown={onShortcutInputKeyDown(s.id)}
+                      InputProps={{
+                        readOnly: true,
+                        inputProps: {
+                          'aria-label': `${s.desc} のショートカット`,
+                          style: { fontFamily: 'monospace', fontSize: 10, textAlign: 'center', paddingTop: 4, paddingBottom: 4 },
+                        },
+                      }}
+                    />
+                  </td>
+                  <td>
+                    <Typography variant='caption' color='text.secondary'>{s.desc}</Typography>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </Box>
+        </Box>
+      </Stack>
+    </Box>
+  )
+}

--- a/src/components/ui/ChatSupport/hooks/useChatConfig.ts
+++ b/src/components/ui/ChatSupport/hooks/useChatConfig.ts
@@ -1,0 +1,136 @@
+// 設定状態管理 hook
+// - config: API キー/モデル/UI モード/ショートカット → localStorage 永続化
+// - 設定パネル UI 状態 (showSettings, showApiKey, testResult 等)
+// - handleTestConnection / handleShortcutInputKeyDown / resetShortcuts / toggleUiMode
+
+import { useState, useEffect, useCallback } from 'react'
+
+import { callAI } from '../chatAiService'
+import {
+  CONFIG_STORAGE_KEY,
+  DEFAULT_API_KEY,
+  DEFAULT_MODEL,
+  MODIFIER_ONLY_KEYS,
+  createDefaultShortcuts,
+  formatShortcutLabel,
+  isMac,
+  loadChatConfig,
+  normalizeShortcutKey,
+} from '../chatSupportConstants'
+
+import type {
+  ChatSupportConfig,
+  ShortcutActionId,
+  ShortcutBinding,
+} from '../chatSupportTypes'
+
+export const useChatConfig = () => {
+  const [config, setConfig] = useState<ChatSupportConfig>(() => loadChatConfig())
+
+  const [confirmResetOpen, setConfirmResetOpen] = useState(false)
+  const [showSettings, setShowSettings] = useState(false)
+  const [showApiKey, setShowApiKey] = useState(false)
+  const [testResult, setTestResult] = useState<{
+    success: boolean
+    message: string
+  } | null>(null)
+  const [isTesting, setIsTesting] = useState(false)
+
+  // APIキー入力欄のローカル state（paste 問題の回避）
+  const [apiKeyDraft, setApiKeyDraft] = useState(() => {
+    const c = loadChatConfig()
+    return !c.apiKey || c.apiKey === DEFAULT_API_KEY ? '' : c.apiKey
+  })
+
+  const isUsingDefaultKey = !config.apiKey || config.apiKey === DEFAULT_API_KEY
+
+  const submitShortcutLabel = formatShortcutLabel(config.shortcuts.sendMessage)
+
+  // config 変化時: localStorage 保存
+  useEffect(() => {
+    localStorage.setItem(CONFIG_STORAGE_KEY, JSON.stringify(config))
+  }, [config])
+
+  const handleTestConnection = async () => {
+    if (!config.apiKey) {
+      setTestResult({ success: false, message: 'APIキーを入力してください。' })
+      return
+    }
+    setIsTesting(true)
+    setTestResult(null)
+    try {
+      await callAI(config, [{ role: 'user', content: 'Say OK' }], true)
+      setTestResult({ success: true, message: '接続成功！AIと対話可能です。' })
+    } catch (error: unknown) {
+      setTestResult({
+        success: false,
+        message: `接続失敗: ${error instanceof Error ? error.message : String(error)}`,
+      })
+    } finally {
+      setIsTesting(false)
+    }
+  }
+
+  const handleShortcutInputKeyDown =
+    (shortcutId: ShortcutActionId) =>
+    (event: React.KeyboardEvent<HTMLElement>) => {
+      if (event.key === 'Tab') return
+      event.preventDefault()
+      event.stopPropagation()
+
+      const normalizedKey = normalizeShortcutKey(event.key)
+      if (MODIFIER_ONLY_KEYS.has(normalizedKey)) return
+
+      const nextShortcut: ShortcutBinding = {
+        key: normalizedKey,
+        mod: isMac ? event.metaKey : event.ctrlKey,
+        shift: event.shiftKey,
+        alt: event.altKey,
+      }
+      setConfig((prev) => ({
+        ...prev,
+        shortcuts: {
+          ...prev.shortcuts,
+          [shortcutId]: nextShortcut,
+        },
+      }))
+    }
+
+  const resetShortcuts = useCallback(() => {
+    setConfig((prev) => ({
+      ...prev,
+      shortcuts: createDefaultShortcuts(),
+    }))
+  }, [])
+
+  const toggleUiMode = useCallback(() => {
+    setConfig((prev) => ({
+      ...prev,
+      uiMode: prev.uiMode === 'widget' ? 'sidebar' : 'widget',
+    }))
+  }, [])
+
+  return {
+    config,
+    setConfig,
+    apiKeyDraft,
+    setApiKeyDraft,
+    isUsingDefaultKey,
+    showSettings,
+    setShowSettings,
+    showApiKey,
+    setShowApiKey,
+    testResult,
+    setTestResult,
+    isTesting,
+    confirmResetOpen,
+    setConfirmResetOpen,
+    submitShortcutLabel,
+    handleTestConnection,
+    handleShortcutInputKeyDown,
+    resetShortcuts,
+    toggleUiMode,
+    DEFAULT_API_KEY,
+    DEFAULT_MODEL,
+  }
+}

--- a/src/components/ui/ChatSupport/hooks/useChatMessage.ts
+++ b/src/components/ui/ChatSupport/hooks/useChatMessage.ts
@@ -1,0 +1,326 @@
+// メッセージ送受信 hook
+// - isTyping: AI 応答中フラグ
+// - storyGuide / contextualPrompt: ページ文脈 (memo)
+// - addBotMessage / handleSend / handleSuggestionClick
+// - handleDownload: Markdown エクスポート
+// - Embedding インデックス初期化 effect
+
+import { useState, useMemo, useEffect, useCallback } from 'react'
+
+import { callAI, extractContent } from '../chatAiService'
+import { DEFAULT_API_KEY, SYSTEM_PROMPT } from '../chatSupportConstants'
+import {
+  buildSemanticContext,
+  findSemanticFaqAnswer,
+  getEmbeddingIndex,
+  initEmbeddingIndex,
+  semanticSearch,
+} from '../embeddingSearch'
+import {
+  FAQ_DATABASE,
+  findFaqAnswer,
+  INITIAL_GREETING,
+} from '../faqDatabase'
+import { findStoryGuide } from '../storyGuideMap'
+
+import type {
+  ChatSupportConfig,
+  CurrentStoryContext,
+  Message,
+} from '../chatSupportTypes'
+import type { StoryGuideEntry } from '../storyGuideMap'
+
+interface UseChatMessageProps {
+  currentStory: CurrentStoryContext | null | undefined
+  messages: Message[]
+  setMessages: React.Dispatch<React.SetStateAction<Message[]>>
+  config: ChatSupportConfig
+}
+
+export const useChatMessage = ({
+  currentStory,
+  messages,
+  setMessages,
+  config,
+}: UseChatMessageProps) => {
+  const [isTyping, setIsTyping] = useState(false)
+
+  // 現在のページのガイド情報
+  const storyGuide: StoryGuideEntry | null = useMemo(
+    () => (currentStory ? findStoryGuide(currentStory.title) : null),
+    [currentStory]
+  )
+
+  // ページ文脈付きシステムプロンプト
+  const contextualPrompt = useMemo(() => {
+    if (!currentStory) return SYSTEM_PROMPT
+    const parts = [SYSTEM_PROMPT]
+    parts.push(
+      `\n\n## 現在のページ情報\nユーザーは現在「${currentStory.title}」の「${currentStory.name}」ストーリーを見ています。`
+    )
+    if (currentStory.description) {
+      parts.push(`ページ説明: ${currentStory.description}`)
+    }
+    if (storyGuide) {
+      parts.push(`概要: ${storyGuide.summary}`)
+      parts.push(
+        `実装コンテキスト:\n${storyGuide.codeContext.map((c) => `- ${c}`).join('\n')}`
+      )
+      if (storyGuide.references?.length) {
+        parts.push(
+          `参考リンク:\n${storyGuide.references.map((r) => `- ${r}`).join('\n')}`
+        )
+      }
+      if (storyGuide.related?.length) {
+        parts.push(`関連ページ: ${storyGuide.related.join(', ')}`)
+      }
+    }
+    parts.push(
+      'ユーザーが「この画面」「今見てるページ」等と言った場合、上記コンテキストを基に具体的に回答してください。参考リンクがあれば回答に含めてください。'
+    )
+    return parts.join('\n')
+  }, [currentStory, storyGuide])
+
+  // Embedding インデックス初期化（APIキーがある場合のみ、1回実行）
+  useEffect(() => {
+    if (!config.apiKey || config.apiKey === DEFAULT_API_KEY) return
+    if (getEmbeddingIndex()?.isReady()) return
+    initEmbeddingIndex(config.apiKey).catch(() => {
+      // エラーは initEmbeddingIndex 内でログ済み
+    })
+  }, [config.apiKey])
+
+  const addBotMessage = useCallback(
+    (text: string) => {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: (Date.now() + 1).toString(),
+          text,
+          sender: 'bot' as const,
+          timestamp: new Date(),
+        },
+      ])
+    },
+    [setMessages]
+  )
+
+  /** ページ文脈クエリ判定キーワード */
+  const isPageContextQuery = (q: string): boolean => {
+    const keywords = [
+      'この画面', 'このページ', '今見てる', '今見ている', '今のページ',
+      '今の画面', '何のページ', '何を見て', 'ここは何', 'ここって何',
+      'ここは', 'what is this', 'what page',
+    ]
+    return keywords.some((kw) => q.toLowerCase().includes(kw))
+  }
+
+  /** 現在のページに関する FAQ 回答を生成 */
+  const buildPageContextAnswer = useCallback(
+    (query?: string): string | null => {
+      if (!currentStory || !storyGuide) return null
+      const q = query?.toLowerCase() || ''
+      const isImplementation = q.includes('実装') || q.includes('コード')
+
+      const lines = [
+        `**${currentStory.title}** > ${currentStory.name}`,
+        '',
+        isImplementation ? '### 実装のポイント' : storyGuide.summary,
+        '',
+        ...storyGuide.codeContext.map((c) => `- ${c}`),
+      ]
+      if (storyGuide.references?.length) {
+        lines.push('', '**参考:**', ...storyGuide.references.map((r) => `- ${r}`))
+      }
+      if (storyGuide.related?.length) {
+        lines.push('', `関連: ${storyGuide.related.join(' / ')}`)
+      }
+      return lines.join('\n')
+    },
+    [currentStory, storyGuide]
+  )
+
+  /** FAQ 回答から「やるべきこと」セクションを除去し端的にする */
+  const trimFaqAnswer = (text: string): string =>
+    text.replace(/\n+## やるべきこと[\s\S]*$/, '').trimEnd()
+
+  const respondWithFaq = useCallback(
+    (query: string) => {
+      if (isPageContextQuery(query)) {
+        const pageAnswer = buildPageContextAnswer(query)
+        if (pageAnswer) {
+          addBotMessage(pageAnswer)
+          return
+        }
+      }
+      const answer = findFaqAnswer(query)
+      if (answer) {
+        addBotMessage(trimFaqAnswer(answer))
+      } else {
+        addBotMessage(
+          '該当するFAQが見つかりませんでした。以下のトピックをお試しください:\n\n' +
+            FAQ_DATABASE.map((f) => `- **${f.title}**`).join('\n') +
+            '\n\nAI接続すると自由な質問に対応できます。設定からAPIキーを入力してください。'
+        )
+      }
+    },
+    [addBotMessage, buildPageContextAnswer]
+  )
+
+  const handleDownload = useCallback(() => {
+    const lines = [
+      '# Concierge - チャット履歴',
+      `> ${new Date().toLocaleDateString('ja-JP')} エクスポート`,
+      '',
+    ]
+    for (const msg of messages) {
+      if (msg.sender === 'user') {
+        lines.push(`## Q: ${msg.text}`, '')
+      } else {
+        lines.push(msg.text, '')
+      }
+      lines.push('---', '')
+    }
+    const blob = new Blob([lines.join('\n')], {
+      type: 'text/markdown;charset=utf-8',
+    })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `concierge-${new Date().toISOString().slice(0, 10)}.md`
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+  }, [messages])
+
+  const handleSend = useCallback(
+    async (inputMessage: string, clearInput: () => void) => {
+      if (!inputMessage.trim() || isTyping) return
+      const userText = inputMessage
+      const newUserMessage: Message = {
+        id: Date.now().toString(),
+        text: userText,
+        sender: 'user',
+        timestamp: new Date(),
+      }
+      setMessages((prev) => [...prev, newUserMessage])
+      clearInput()
+
+      if (!config.apiKey) {
+        respondWithFaq(userText)
+        return
+      }
+
+      setIsTyping(true)
+      try {
+        let enrichedPrompt = contextualPrompt
+        const embeddingResults = await semanticSearch(config.apiKey, userText)
+        if (embeddingResults.length > 0) {
+          enrichedPrompt += buildSemanticContext(embeddingResults)
+        }
+        const payload = [
+          { role: 'system', content: enrichedPrompt },
+          ...messages.map((m) => ({
+            role: m.sender === 'user' ? 'user' : 'assistant',
+            content: m.text,
+          })),
+          { role: 'user', content: userText },
+        ]
+        const data = await callAI(config, payload)
+        addBotMessage(extractContent(data))
+      } catch (error: unknown) {
+        const errMsg =
+          error instanceof Error
+            ? error.name === 'AbortError'
+              ? 'タイムアウト: 応答に時間がかかりすぎています。'
+              : error.message
+            : String(error)
+        const embeddingFaq = await semanticSearch(config.apiKey, userText).catch(() => [])
+        const semanticAnswer = findSemanticFaqAnswer(embeddingFaq)
+        const faqAnswer = semanticAnswer ?? findFaqAnswer(userText)
+        if (faqAnswer) {
+          addBotMessage(
+            `*AI接続エラー: ${errMsg}*\n\n---\n\nFAQから回答します:\n\n${trimFaqAnswer(faqAnswer)}`
+          )
+        } else {
+          addBotMessage(`エラー: ${errMsg}`)
+        }
+      } finally {
+        setIsTyping(false)
+      }
+    },
+    [isTyping, config, messages, setMessages, contextualPrompt, addBotMessage, respondWithFaq]
+  )
+
+  const handleSuggestionClick = useCallback(
+    (query: string) => {
+      if (isTyping) return
+      const userMsg: Message = {
+        id: Date.now().toString(),
+        text: query,
+        sender: 'user',
+        timestamp: new Date(),
+      }
+      setMessages((prev) => [...prev, userMsg])
+
+      if (!config.apiKey) {
+        respondWithFaq(query)
+        return
+      }
+
+      setIsTyping(true)
+      semanticSearch(config.apiKey, query)
+        .catch(() => [])
+        .then((embeddingResults) => {
+          let enrichedPrompt = contextualPrompt
+          if (embeddingResults.length > 0) {
+            enrichedPrompt += buildSemanticContext(embeddingResults)
+          }
+          const payload = [
+            { role: 'system', content: enrichedPrompt },
+            ...messages.map((m) => ({
+              role: m.sender === 'user' ? 'user' : 'assistant',
+              content: m.text,
+            })),
+            { role: 'user', content: query },
+          ]
+          return callAI(config, payload)
+        })
+        .then((data) => {
+          addBotMessage(extractContent(data))
+        })
+        .catch((error: unknown) => {
+          const errMsg =
+            error instanceof Error
+              ? error.name === 'AbortError'
+                ? 'タイムアウト: 応答に時間がかかりすぎています。'
+                : error.message
+              : String(error)
+          const faqAnswer = findFaqAnswer(query)
+          if (faqAnswer) {
+            addBotMessage(`*AI接続エラー*\n\n---\n\n${trimFaqAnswer(faqAnswer)}`)
+          } else {
+            addBotMessage(`エラー: ${errMsg}`)
+          }
+        })
+        .finally(() => setIsTyping(false))
+    },
+    [isTyping, config, messages, setMessages, contextualPrompt, addBotMessage, respondWithFaq]
+  )
+
+  const hasUserMessages = messages.some((m) => m.sender === 'user')
+
+  return {
+    isTyping,
+    storyGuide,
+    contextualPrompt,
+    addBotMessage,
+    buildPageContextAnswer,
+    handleDownload,
+    handleSend,
+    handleSuggestionClick,
+    hasUserMessages,
+    INITIAL_GREETING,
+  }
+}

--- a/src/components/ui/ChatSupport/hooks/useChatShortcuts.ts
+++ b/src/components/ui/ChatSupport/hooks/useChatShortcuts.ts
@@ -1,0 +1,109 @@
+// グローバルキーボードショートカット hook
+// - グローバルハンドラ: document.addEventListener('keydown', ...)
+// - handleKeyDown: TextField レベルのショートカット（送信キー）
+
+import { useEffect } from 'react'
+
+import { isShortcutMatch } from '../chatSupportConstants'
+
+import type { ChatSupportConfig } from '../chatSupportTypes'
+
+interface UseChatShortcutsProps {
+  config: ChatSupportConfig
+  isOpen: boolean
+  setIsOpen: (v: boolean | ((prev: boolean) => boolean)) => void
+  setShowSettings: React.Dispatch<React.SetStateAction<boolean>>
+  clearChat: () => void
+  handleDownload: () => void
+  toggleUiMode: () => void
+  inputRef: React.RefObject<HTMLInputElement | null>
+}
+
+export const useChatShortcuts = ({
+  config,
+  isOpen,
+  setIsOpen,
+  setShowSettings,
+  clearChat,
+  handleDownload,
+  toggleUiMode,
+  inputRef,
+}: UseChatShortcutsProps) => {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.isComposing) return
+
+      const tag = (e.target as HTMLElement)?.tagName
+      const isInputFocused =
+        tag === 'INPUT' ||
+        tag === 'TEXTAREA' ||
+        (e.target as HTMLElement)?.isContentEditable
+
+      // チャット開閉（入力欄フォーカス中でも動作）
+      if (isShortcutMatch(e, config.shortcuts.toggleChat)) {
+        e.preventDefault()
+        setIsOpen((prev) => !prev)
+        return
+      }
+
+      if (!isOpen) return
+      if (isInputFocused) return
+
+      if (isShortcutMatch(e, config.shortcuts.closeChat)) {
+        setIsOpen(false)
+        return
+      }
+      if (isShortcutMatch(e, config.shortcuts.focusInput)) {
+        e.preventDefault()
+        inputRef.current?.focus()
+        return
+      }
+      if (isShortcutMatch(e, config.shortcuts.toggleSettings)) {
+        e.preventDefault()
+        setShowSettings((prev) => !prev)
+        return
+      }
+      if (isShortcutMatch(e, config.shortcuts.downloadHistory)) {
+        e.preventDefault()
+        handleDownload()
+        return
+      }
+      if (isShortcutMatch(e, config.shortcuts.toggleUiMode)) {
+        e.preventDefault()
+        toggleUiMode()
+        return
+      }
+      if (isShortcutMatch(e, config.shortcuts.clearHistory)) {
+        e.preventDefault()
+        clearChat()
+        return
+      }
+    }
+
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [
+    config.shortcuts,
+    isOpen,
+    setIsOpen,
+    setShowSettings,
+    clearChat,
+    handleDownload,
+    toggleUiMode,
+    inputRef,
+  ])
+
+  // TextField レベルのキーダウン（送信ショートカット）
+  const handleKeyDown = (
+    e: React.KeyboardEvent,
+    handleSendFn: () => void
+  ) => {
+    if (e.nativeEvent.isComposing) return
+    if (isShortcutMatch(e.nativeEvent, config.shortcuts.sendMessage)) {
+      e.preventDefault()
+      handleSendFn()
+    }
+  }
+
+  return { handleKeyDown }
+}

--- a/src/components/ui/ChatSupport/hooks/useChatState.ts
+++ b/src/components/ui/ChatSupport/hooks/useChatState.ts
@@ -1,0 +1,108 @@
+// チャットの基本状態管理 hook
+// - isOpen: sessionStorage に永続化
+// - messages: localStorage に永続化
+// - scrollRef / inputRef: DOM 参照
+// - clearChat / executeClearChat: 履歴クリア
+
+import { useState, useRef, useEffect, useCallback } from 'react'
+
+import { CHAT_STORAGE_KEY } from '../chatSupportConstants'
+import { INITIAL_GREETING } from '../faqDatabase'
+
+import type { Message } from '../chatSupportTypes'
+
+export const useChatState = () => {
+  const [isOpen, setIsOpenRaw] = useState(() => {
+    try {
+      return sessionStorage.getItem('chat_support_open') === '1'
+    } catch {
+      return false
+    }
+  })
+
+  const setIsOpen = useCallback((v: boolean | ((prev: boolean) => boolean)) => {
+    setIsOpenRaw((prev) => {
+      const next = typeof v === 'function' ? v(prev) : v
+      try {
+        sessionStorage.setItem('chat_support_open', next ? '1' : '0')
+      } catch {
+        // sessionStorage が無効な環境では無視
+      }
+      return next
+    })
+  }, [])
+
+  const [message, setMessage] = useState('')
+  const [messages, setMessages] = useState<Message[]>(() => {
+    const defaultMsg: Message[] = [
+      {
+        id: '1',
+        text: INITIAL_GREETING,
+        sender: 'bot',
+        timestamp: new Date(),
+      },
+    ]
+    const saved = localStorage.getItem(CHAT_STORAGE_KEY)
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved)
+        const restored = parsed.map((m: Message & { timestamp: string }) => ({
+          ...m,
+          timestamp: new Date(m.timestamp),
+        }))
+        // 初回メッセージが古い挨拶文なら新しいものに差し替え
+        if (restored[0]?.sender === 'bot' && restored[0]?.text !== INITIAL_GREETING) {
+          restored[0] = { ...restored[0], text: INITIAL_GREETING }
+        }
+        return restored
+      } catch (e) {
+        console.error(e)
+      }
+    }
+    return defaultMsg
+  })
+
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // messages 変化時: localStorage 保存 + 自動スクロール
+  useEffect(() => {
+    localStorage.setItem(CHAT_STORAGE_KEY, JSON.stringify(messages))
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+    }
+  }, [messages])
+
+  const [confirmClearOpen, setConfirmClearOpen] = useState(false)
+
+  const clearChat = useCallback(() => {
+    setConfirmClearOpen(true)
+  }, [])
+
+  const executeClearChat = useCallback(() => {
+    setMessages([
+      {
+        id: '1',
+        text: INITIAL_GREETING,
+        sender: 'bot',
+        timestamp: new Date(),
+      },
+    ])
+    setConfirmClearOpen(false)
+  }, [])
+
+  return {
+    isOpen,
+    setIsOpen,
+    message,
+    setMessage,
+    messages,
+    setMessages,
+    scrollRef,
+    inputRef,
+    confirmClearOpen,
+    setConfirmClearOpen,
+    clearChat,
+    executeClearChat,
+  }
+}


### PR DESCRIPTION
## Summary

- `ChatSupport.tsx` 1831行 → **273行**（コンテナのみ）
- `hooks/` 4ファイル: `useChatState` / `useChatConfig` / `useChatMessage` / `useChatShortcuts`
- `components/` 5ファイル: `ChatHeader` / `ChatInput` / `ChatMessageList` / `ChatPageContextChip` / `ChatSettings`

sdpf-theme(222行) / Matlens(177行) との足並み揃えの一環。

## ファイル構成

```
ChatSupport/
  ChatSupport.tsx          273行  ← 1831行から削減
  hooks/
    useChatState.ts        108行  isOpen/messages/scrollRef/clearChat
    useChatConfig.ts       136行  config/API設定/ショートカット設定
    useChatMessage.ts      326行  送信/FAQ/AI/セマンティック検索
    useChatShortcuts.ts    109行  グローバルキーボードショートカット
  components/
    ChatHeader.tsx         135行  タイトル/ツールバー/モデル名
    ChatInput.tsx           81行  入力欄/送信ボタン
    ChatMessageList.tsx    255行  メッセージ/サジェスト/タイピング
    ChatPageContextChip.tsx 69行  ページ解説トリガー
    ChatSettings.tsx       381行  API設定/モデル/ショートカット
```

## 動作変更なし

既存の全機能（ウィジェット/サイドバー切替、リサイズ、FAQ、セマンティック検索、ショートカット、Markdown、設定パネル）をそのまま維持。

## Test plan

- [x] `pnpm test:run` — 294/294 passed
- [x] `pnpm lint` — clean
- [x] `pnpm exec tsc --noEmit` — ChatSupport関連エラーなし
- [ ] Storybook canvas で ChatSupport が正常動作することを目視確認
- [ ] ウィジェット/サイドバー切替、リサイズ、設定パネル、ショートカットの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * チャットサポートコンポーネントを複数の小規模なサブコンポーネントとカスタムフックに再構成しました。チャットヘッダー、メッセージリスト、入力フィールド、設定パネルなどの機能が個別のモジュールに分割されました。ユーザーに対する外部的な動作に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->