### PR TITLE
fix(ChatSupport): Fuse.js を sdpf-theme 標準仕様に統一 + favicon K 変更

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,4 +1,5 @@
 <!-- Kaze Design System - Manager Head -->
+<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <style>
   /* 選択中のストーリー: 背景がティールなので白文字にする */
   [data-selected='true'] {

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -14,8 +14,7 @@
     text-anchor="middle"
     fill="white"
     font-family="Inter, system-ui, sans-serif"
-    font-size="13"
+    font-size="19"
     font-weight="700"
-    letter-spacing="0.5"
-  >Kz</text>
+  >K</text>
 </svg>

--- a/src/components/ui/ChatSupport/faqDatabase.ts
+++ b/src/components/ui/ChatSupport/faqDatabase.ts
@@ -1379,10 +1379,12 @@ const getFuse = (): Fuse<FaqEntry> => {
   if (!fuseInstance) {
     fuseInstance = new Fuse(FAQ_DATABASE, {
       keys: [
-        { name: 'keywords', weight: 0.7 },
-        { name: 'title', weight: 0.3 },
+        { name: 'keywords', weight: 2 },
+        { name: 'title', weight: 1.5 },
+        { name: 'answer', weight: 0.5 },
       ],
-      threshold: 0.4,
+      threshold: 0.6,
+      ignoreLocation: true,
       includeScore: true,
     })
   }
@@ -1417,8 +1419,8 @@ export const findFaqAnswer = (query: string): string | null => {
   const fuse = getFuse()
   const results = fuse.search(query)
   if (results.length > 0 && results[0].score !== undefined) {
-    // Fuse.jsのスコアは0に近いほど良い
-    if (results[0].score < 0.5) {
+    // Fuse.jsのスコアは0に近いほど良い（canonical threshold: 0.45）
+    if (results[0].score < 0.45) {
       return results[0].item.answer
     }
   }


### PR DESCRIPTION
## Summary

- **Fuse.js canonical spec 統一** (sdpf-theme / Matlens 標準に合わせる)
  - `ignoreLocation: true` 追加 — 長い `answer` 文字列の途中にあるキーワードもマッチ
  - `answer` フィールドを検索対象に追加 (weight 0.5) — 回答本文からの逆引きが可能に
  - `threshold` 0.4 → 0.6 (Fuse 内部マッチ許容度を緩和)、外部信頼度フィルタ `< 0.5` → `< 0.45` (tighter)
  - keys weight を数値形式に統一: `keywords: 2`, `title: 1.5`, `answer: 0.5`
- **Storybook favicon**: `Kz` → `K` (font-size 13 → 19) — 複数タブ間の識別性向上
  - `manager-head.html` に `<link rel="icon">` を明示追加してマネージャーフレームにも適用

## Test plan
- [ ] `pnpm test:run` — 324/324 pass (確認済み)
- [ ] Storybook タブのファビコンが "K" になること
- [ ] FAQ検索で長文回答内のキーワードがマッチすること（例: "isLoading" → Props設計FAQ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)