### PR TITLE
fix(vite): LP と全 app ビルドの destructuring エラーを解消

### DIFF
--- a/apps/saas-dashboard/vite.config.ts
+++ b/apps/saas-dashboard/vite.config.ts
@@ -17,6 +17,8 @@ export default defineConfig(({ mode }) => {
     ],
     base: isGitHubPages ? '/kaze-ux/saas/' : (process.env.VITE_BASE_PATH || '/'),
     build: {
+      // esbuild の destructuring 降格エラーを回避
+      target: 'esnext',
       outDir: isGitHubPages ? '../../gh-pages/saas' : 'dist',
       emptyOutDir: true,
       sourcemap: !isGitHubPages,

--- a/apps/sky-kaze/vite.config.ts
+++ b/apps/sky-kaze/vite.config.ts
@@ -19,6 +19,8 @@ export default defineConfig(({ mode }) => {
       ? '/kaze-ux/sky-kaze/'
       : process.env.VITE_BASE_PATH || '/',
     build: {
+      // esbuild の destructuring 降格エラーを回避
+      target: 'esnext',
       outDir: isGitHubPages ? '../../gh-pages/sky-kaze' : 'dist',
       emptyOutDir: true,
       sourcemap: !isGitHubPages,

--- a/apps/ubereats-clone/vite.config.ts
+++ b/apps/ubereats-clone/vite.config.ts
@@ -17,6 +17,8 @@ export default defineConfig(({ mode }) => {
     ],
     base: isGitHubPages ? '/kaze-ux/ubereats/' : (process.env.VITE_BASE_PATH || '/'),
     build: {
+      // esbuild の destructuring 降格エラーを回避
+      target: 'esnext',
       outDir: isGitHubPages ? '../../gh-pages/ubereats' : 'dist',
       emptyOutDir: true,
       sourcemap: !isGitHubPages,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,6 +44,9 @@ export default defineConfig(({ mode }) => {
     // 環境変数 VITE_BASE_PATH が設定されていればそれを使用、なければリポジトリ名
     base: isGitHubPages ? (process.env.VITE_BASE_PATH || '/kaze-ux/') : '/',
     build: {
+      // esbuild の target を esnext に固定して、
+      // MUI/framer-motion 等の destructuring が降格でエラーになるのを回避
+      target: 'esnext',
       // Webアプリモードとライブラリモードで異なる設定
       ...(isWebApp
         ? {


### PR DESCRIPTION
## 概要

PR #34 で Storybook の Vercel ビルド失敗は直したが、同じ destructuring エラーが LP(build-sandbox) と 3 apps のビルドでも発生していた。全 vite.config に \`build.target: 'esnext'\` を追加して一挙に解消。

## 背景

Vercel の \`scripts/vercel-build.mjs\` は 5 ビルドを順次実行:

1. \`pnpm build-sandbox\` (LP) — \`vite.config.ts\`
2. \`pnpm build-storybook\` — \`.storybook/main.cjs\` ✅ PR #34 で修正済み
3. saas-dashboard — \`apps/saas-dashboard/vite.config.ts\`
4. ubereats-clone — \`apps/ubereats-clone/vite.config.ts\`
5. sky-kaze — \`apps/sky-kaze/vite.config.ts\`

PR #34 は #2 だけ修正した結果、#1 で 414 destructuring エラーが出て失敗していた。

## 修正

- \`vite.config.ts\`: \`build.target: 'esnext'\`
- \`apps/saas-dashboard/vite.config.ts\`: 同上
- \`apps/ubereats-clone/vite.config.ts\`: 同上
- \`apps/sky-kaze/vite.config.ts\`: 同上

## Test plan

- [x] \`node scripts/vercel-build.mjs\` をローカル実行 → 全 5 ビルド成功
  - LP: 2.55s / Storybook: 19.73s / saas: 5.13s / ubereats: 4.xxs / sky-kaze: 3.49s
- [ ] Vercel preview デプロイ成功
- [ ] 各 URL が正しく表示される (\`/\`, \`/storybook/\`, \`/saas/\`, \`/ubereats/\`, \`/sky-kaze/\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)