### PR TITLE
feat(styles): Kaze フォント + CSS 変数をグローバル opt-in で提供

### DIFF
--- a/design-tokens/tokens.json
+++ b/design-tokens/tokens.json
@@ -2559,5 +2559,122 @@
         "$description": "矢印の表示"
       }
     }
+  },
+  "kaze": {
+    "$description": "Kaze 骨格トークン v0 — 『墨で書かれ、風で運ばれる』。既存トークンとは独立した additive namespace。",
+    "color": {
+      "kaze-teal": {
+        "$value": "#0EADB8",
+        "$type": "color",
+        "$description": "Primary / Action。ブランドの主役"
+      },
+      "sumi": {
+        "$value": "#0A0A0A",
+        "$type": "color",
+        "$description": "墨 — text / structure"
+      },
+      "washi": {
+        "$value": "#F7F4EE",
+        "$type": "color",
+        "$description": "和紙 — surface / rest。pure white 禁止の理由"
+      },
+      "asagi": {
+        "$value": "#5B8FB9",
+        "$type": "color",
+        "$description": "浅葱 — info / link。画面 5% 未満に制限"
+      },
+      "beni": {
+        "$value": "#E34E3A",
+        "$type": "color",
+        "$description": "紅 — alert / accent。画面 5% 未満に制限"
+      }
+    },
+    "ink": {
+      "primary": {
+        "$value": "rgba(10, 10, 10, 0.88)",
+        "$type": "color",
+        "$description": "washi 背景上の本文色"
+      },
+      "muted": {
+        "$value": "rgba(10, 10, 10, 0.54)",
+        "$type": "color",
+        "$description": "washi 背景上のミュート色"
+      },
+      "hair": {
+        "$value": "rgba(10, 10, 10, 0.12)",
+        "$type": "color",
+        "$description": "区切り線 (hair line)"
+      },
+      "mist": {
+        "$value": "rgba(10, 10, 10, 0.04)",
+        "$type": "color",
+        "$description": "背景上のうっすらした面 (mist)"
+      }
+    },
+    "radius": {
+      "sharp": {
+        "$value": "2px",
+        "$type": "dimension",
+        "$description": "button / input / chip / tab"
+      },
+      "soft": {
+        "$value": "8px",
+        "$type": "dimension",
+        "$description": "card / panel / popover"
+      },
+      "gen": {
+        "$value": "24px",
+        "$type": "dimension",
+        "$description": "modal / hero / section"
+      },
+      "full": {
+        "$value": "9999px",
+        "$type": "dimension",
+        "$description": "avatar / tag / pill のみ"
+      }
+    },
+    "motion": {
+      "ease": {
+        "kaze": {
+          "$value": "cubic-bezier(0.33, 0, 0, 1)",
+          "$type": "cubicBezier",
+          "$description": "単一採用。spring / bounce / overshoot は禁止"
+        }
+      },
+      "duration": {
+        "micro": {
+          "$value": "120ms",
+          "$type": "duration",
+          "$description": "hover / focus / toggle"
+        },
+        "macro": {
+          "$value": "240ms",
+          "$type": "duration",
+          "$description": "panel / tab / drawer"
+        },
+        "scene": {
+          "$value": "480ms",
+          "$type": "duration",
+          "$description": "modal / route / hero"
+        }
+      }
+    },
+    "font": {
+      "display": {
+        "$value": "'Fraunces', 'Shippori Mincho B1', 'Noto Serif JP', Georgia, serif",
+        "$type": "fontFamily",
+        "$description": "Variable axis: opsz 9-144, wght 300-900, SOFT 0-100, WONK 0-1"
+      },
+      "body": {
+        "$value": "'IBM Plex Sans', 'IBM Plex Sans JP', 'Hiragino Kaku Gothic ProN', sans-serif",
+        "$type": "fontFamily",
+        "$description": "日本語 + 英語 本文。line-height 1.7 推奨"
+      },
+      "mono": {
+        "$value": "'IBM Plex Mono', 'SFMono-Regular', Menlo, monospace",
+        "$type": "fontFamily",
+        "$description": "コード表示・メタデータ"
+      }
+    }
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,8 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Noto+Sans+JP:wght@400;500;700&display=swap');
 
+/* Kaze 骨格フォント (v0) — 既存 Inter/Noto と並行ロード。opt-in で使う */
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT,WONK@9..144,300..900,0..100,0..1&family=IBM+Plex+Sans:wght@300;400;500;600;700&family=IBM+Plex+Sans+JP:wght@300;400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap');
+
 @import 'tailwindcss/base';
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
@@ -48,6 +51,44 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  /* === Kaze 骨格 CSS 変数 (v0) ===
+   * 値の TypeScript ミラー: src/themes/kazeTokens.ts
+   * 既存 --color-* とは独立した additive な namespace。
+   * opt-in で使用: var(--kaze-teal), var(--kaze-r-sharp), etc.
+   */
+  --kaze-teal: #0eadb8;
+  --kaze-sumi: #0a0a0a;
+  --kaze-washi: #f7f4ee;
+  --kaze-asagi: #5b8fb9;
+  --kaze-beni: #e34e3a;
+  --kaze-ink: rgba(10, 10, 10, 0.88);
+  --kaze-ink-muted: rgba(10, 10, 10, 0.54);
+  --kaze-ink-hair: rgba(10, 10, 10, 0.12);
+  --kaze-ink-mist: rgba(10, 10, 10, 0.04);
+  --kaze-r-sharp: 2px;
+  --kaze-r-soft: 8px;
+  --kaze-r-gen: 24px;
+  --kaze-r-full: 9999px;
+  --kaze-ease: cubic-bezier(0.33, 0, 0, 1);
+  --kaze-dur-micro: 120ms;
+  --kaze-dur-macro: 240ms;
+  --kaze-dur-scene: 480ms;
+  --kaze-font-display:
+    'Fraunces', 'Shippori Mincho B1', 'Noto Serif JP', Georgia, serif;
+  --kaze-font-body:
+    'IBM Plex Sans', 'IBM Plex Sans JP', 'Hiragino Kaku Gothic ProN', sans-serif;
+  --kaze-font-mono: 'IBM Plex Mono', 'SFMono-Regular', Menlo, monospace;
+}
+
+/* Dark モードの ink/washi 反転（Kaze 骨格 dark 対応） */
+.dark {
+  --kaze-washi: #0a0a0a;
+  --kaze-sumi: #f7f4ee;
+  --kaze-ink: rgba(247, 244, 238, 0.88);
+  --kaze-ink-muted: rgba(247, 244, 238, 0.54);
+  --kaze-ink-hair: rgba(247, 244, 238, 0.12);
+  --kaze-ink-mist: rgba(247, 244, 238, 0.04);
 }
 
 /* Dark Theme Colors — colorToken.ts (Dracula scheme) と同期 */

--- a/src/themes/kazeTokens.ts
+++ b/src/themes/kazeTokens.ts
@@ -1,0 +1,92 @@
+/**
+ * Kaze 骨格トークン (v0)
+ *
+ * 「墨で書かれ、風で運ばれる」世界観を 4 軸で固定する single source of truth。
+ * 既存 MUI テーマ（primary/secondary/...）には触れず、additive に共存する。
+ * 新規コンポーネント・refresh 済み画面はこれを参照する。
+ *
+ * 参照: src/stories/01-DesignPhilosophy/KazeSkeleton.stories.tsx
+ */
+
+export const kazeTokens = {
+  color: {
+    kazeTeal: '#0EADB8',
+    sumi: '#0A0A0A',
+    washi: '#F7F4EE',
+    asagi: '#5B8FB9',
+    beni: '#E34E3A',
+  },
+  ink: {
+    primary: 'rgba(10, 10, 10, 0.88)',
+    muted: 'rgba(10, 10, 10, 0.54)',
+    hair: 'rgba(10, 10, 10, 0.12)',
+    mist: 'rgba(10, 10, 10, 0.04)',
+  },
+  radius: {
+    sharp: 2,
+    soft: 8,
+    gen: 24,
+    full: 9999,
+  },
+  motion: {
+    ease: {
+      kaze: 'cubic-bezier(0.33, 0, 0, 1)',
+    },
+    duration: {
+      micro: 120,
+      macro: 240,
+      scene: 480,
+    },
+  },
+  font: {
+    display:
+      "'Fraunces', 'Shippori Mincho B1', 'Noto Serif JP', Georgia, serif",
+    body: "'IBM Plex Sans', 'IBM Plex Sans JP', 'Hiragino Kaku Gothic ProN', sans-serif",
+    mono: "'IBM Plex Mono', 'SFMono-Regular', Menlo, monospace",
+  },
+  fontAxis: {
+    displayDefault: "'opsz' 144, 'wght' 380, 'SOFT' 30, 'WONK' 0",
+    displayEmphasis: "'opsz' 144, 'wght' 420, 'SOFT' 70, 'WONK' 1",
+  },
+} as const
+
+export type KazeTokens = typeof kazeTokens
+
+/**
+ * Google Fonts URL。Storybook preview-head / LP <head> / アプリ _document で
+ * 同一ソースを使う。
+ */
+export const KAZE_GOOGLE_FONTS_HREF =
+  'https://fonts.googleapis.com/css2' +
+  '?family=Fraunces:opsz,wght,SOFT,WONK@9..144,300..900,0..100,0..1' +
+  '&family=IBM+Plex+Sans:wght@300;400;500;600;700' +
+  '&family=IBM+Plex+Sans+JP:wght@300;400;500;600;700' +
+  '&family=IBM+Plex+Mono:wght@400;500;600' +
+  '&display=swap'
+
+/**
+ * CSS カスタムプロパティとして注入するための key-value マップ。
+ * :root や scope element に展開して使う。
+ */
+export const kazeCssVars: Record<string, string> = {
+  '--kaze-teal': kazeTokens.color.kazeTeal,
+  '--kaze-sumi': kazeTokens.color.sumi,
+  '--kaze-washi': kazeTokens.color.washi,
+  '--kaze-asagi': kazeTokens.color.asagi,
+  '--kaze-beni': kazeTokens.color.beni,
+  '--kaze-ink': kazeTokens.ink.primary,
+  '--kaze-ink-muted': kazeTokens.ink.muted,
+  '--kaze-ink-hair': kazeTokens.ink.hair,
+  '--kaze-ink-mist': kazeTokens.ink.mist,
+  '--kaze-r-sharp': `${kazeTokens.radius.sharp}px`,
+  '--kaze-r-soft': `${kazeTokens.radius.soft}px`,
+  '--kaze-r-gen': `${kazeTokens.radius.gen}px`,
+  '--kaze-r-full': `${kazeTokens.radius.full}px`,
+  '--kaze-ease': kazeTokens.motion.ease.kaze,
+  '--kaze-dur-micro': `${kazeTokens.motion.duration.micro}ms`,
+  '--kaze-dur-macro': `${kazeTokens.motion.duration.macro}ms`,
+  '--kaze-dur-scene': `${kazeTokens.motion.duration.scene}ms`,
+  '--kaze-font-display': kazeTokens.font.display,
+  '--kaze-font-body': kazeTokens.font.body,
+  '--kaze-font-mono': kazeTokens.font.mono,
+}


### PR DESCRIPTION
## 概要

Kaze 骨格の **フォント（Fraunces / IBM Plex）** と **CSS 変数 (\`--kaze-*\`)** を LP・Storybook の両方でグローバルに利用可能にする。既存の Inter/Noto、\`--color-*\` は**温存**。**opt-in で使える状態**を作るだけの最小 PR。

## 依存

このブランチは [PR #38 (kaze-tokens)](https://github.com/BoxPistols/kaze-ux/pull/38) から派生。
PR 差分に \`kazeTokens.ts\` と \`tokens.json\` の変更が見えるのはそのため。**#38 マージ後に rebase すれば、この PR の diff は \`src/index.css\` 1 ファイルに縮小する**。

## 変更

\`src/index.css\` に以下を追加:

\`\`\`css
/* 1. Kaze 骨格フォントを並行ロード */
@import url('...family=Fraunces...IBM+Plex+Sans+JP...');

/* 2. :root に --kaze-* 変数を追加 (既存 --color-* は無変更) */
:root {
  --kaze-teal: #0eadb8;
  --kaze-sumi: #0a0a0a;
  --kaze-washi: #f7f4ee;
  --kaze-asagi: #5b8fb9;
  --kaze-beni: #e34e3a;
  --kaze-ink: rgba(10, 10, 10, 0.88);
  /* ...ink-muted/hair/mist */
  --kaze-r-sharp: 2px;
  --kaze-r-soft: 8px;
  --kaze-r-gen: 24px;
  --kaze-r-full: 9999px;
  --kaze-ease: cubic-bezier(0.33, 0, 0, 1);
  --kaze-dur-micro: 120ms;
  --kaze-dur-macro: 240ms;
  --kaze-dur-scene: 480ms;
  --kaze-font-display: 'Fraunces', ...;
  --kaze-font-body: 'IBM Plex Sans', ...;
  --kaze-font-mono: 'IBM Plex Mono', ...;
}

/* 3. .dark で washi/sumi を反転 */
.dark {
  --kaze-washi: #0a0a0a;
  --kaze-sumi: #f7f4ee;
  /* ...ink 反転 */
}
\`\`\`

値の TS ミラーは \`src/themes/kazeTokens.ts\`（#38）。今後はその両方を single source として扱う（v1 でビルド時同期に移行予定）。

## これで何ができるか

任意のコンポーネント・スタイルから opt-in で使える:

\`\`\`tsx
<Button sx={{
  bgcolor: 'var(--kaze-teal)',
  borderRadius: 'var(--kaze-r-sharp)',
  transition: \`background-color var(--kaze-dur-micro) var(--kaze-ease)\`,
  fontFamily: 'var(--kaze-font-display)',
}}>Request</Button>
\`\`\`

\`\`\`css
.hero-title {
  font-family: var(--kaze-font-display);
  font-variation-settings: 'opsz' 144, 'wght' 380, 'SOFT' 30;
}
\`\`\`

## Test plan

- [x] \`pnpm build-sandbox\`: 3.06s 成功 (CSS サイズ 22.61 → 23.78 kB / gzip 5.36 → 5.77)
- [x] \`pnpm build-storybook\`: 成功
- [x] 既存 MUI テーマ・\`--color-*\` は無変更（\`Inter\` 強制も維持）
- [ ] ブラウザで \`<html class="dark">\` 時に \`--kaze-washi\` / \`--kaze-sumi\` が反転することを目視確認

## 次の PR 候補

1. **#40**: Skeleton Story (\`KazeSkeleton.stories.tsx\`) を \`var(--kaze-*)\` 経由に refactor（内部ハードコード撤去）
2. **#41**: LP Hero を Fraunces 化、既存 framer-motion ガラは維持
3. **#42**: Button / Card / Typography に \`variant='kaze-*'\` または \`useKaze\` prop を opt-in で追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* **デザインシステム拡張**
  * Kazeデザイントークンセット（カラーパレット、タイポグラフィ、スペーシング、モーション）を追加
  * ダークモード対応で、トークンの色が自動的に反転
  * 新しいフォントファミリーを統合し、デザイン柔軟性を向上

<!-- end of auto-generated comment: release notes by coderabbit.ai -->