### PR TITLE
feat(lp): Hero を Fraunces + Plex に寄せて骨格統一

### DIFF
--- a/design-tokens/tokens.json
+++ b/design-tokens/tokens.json
@@ -2559,5 +2559,122 @@
         "$description": "矢印の表示"
       }
     }
+  },
+  "kaze": {
+    "$description": "Kaze 骨格トークン v0 — 『墨で書かれ、風で運ばれる』。既存トークンとは独立した additive namespace。",
+    "color": {
+      "kaze-teal": {
+        "$value": "#0EADB8",
+        "$type": "color",
+        "$description": "Primary / Action。ブランドの主役"
+      },
+      "sumi": {
+        "$value": "#0A0A0A",
+        "$type": "color",
+        "$description": "墨 — text / structure"
+      },
+      "washi": {
+        "$value": "#F7F4EE",
+        "$type": "color",
+        "$description": "和紙 — surface / rest。pure white 禁止の理由"
+      },
+      "asagi": {
+        "$value": "#5B8FB9",
+        "$type": "color",
+        "$description": "浅葱 — info / link。画面 5% 未満に制限"
+      },
+      "beni": {
+        "$value": "#E34E3A",
+        "$type": "color",
+        "$description": "紅 — alert / accent。画面 5% 未満に制限"
+      }
+    },
+    "ink": {
+      "primary": {
+        "$value": "rgba(10, 10, 10, 0.88)",
+        "$type": "color",
+        "$description": "washi 背景上の本文色"
+      },
+      "muted": {
+        "$value": "rgba(10, 10, 10, 0.54)",
+        "$type": "color",
+        "$description": "washi 背景上のミュート色"
+      },
+      "hair": {
+        "$value": "rgba(10, 10, 10, 0.12)",
+        "$type": "color",
+        "$description": "区切り線 (hair line)"
+      },
+      "mist": {
+        "$value": "rgba(10, 10, 10, 0.04)",
+        "$type": "color",
+        "$description": "背景上のうっすらした面 (mist)"
+      }
+    },
+    "radius": {
+      "sharp": {
+        "$value": "2px",
+        "$type": "dimension",
+        "$description": "button / input / chip / tab"
+      },
+      "soft": {
+        "$value": "8px",
+        "$type": "dimension",
+        "$description": "card / panel / popover"
+      },
+      "gen": {
+        "$value": "24px",
+        "$type": "dimension",
+        "$description": "modal / hero / section"
+      },
+      "full": {
+        "$value": "9999px",
+        "$type": "dimension",
+        "$description": "avatar / tag / pill のみ"
+      }
+    },
+    "motion": {
+      "ease": {
+        "kaze": {
+          "$value": "cubic-bezier(0.33, 0, 0, 1)",
+          "$type": "cubicBezier",
+          "$description": "単一採用。spring / bounce / overshoot は禁止"
+        }
+      },
+      "duration": {
+        "micro": {
+          "$value": "120ms",
+          "$type": "duration",
+          "$description": "hover / focus / toggle"
+        },
+        "macro": {
+          "$value": "240ms",
+          "$type": "duration",
+          "$description": "panel / tab / drawer"
+        },
+        "scene": {
+          "$value": "480ms",
+          "$type": "duration",
+          "$description": "modal / route / hero"
+        }
+      }
+    },
+    "font": {
+      "display": {
+        "$value": "'Fraunces', 'Shippori Mincho B1', 'Noto Serif JP', Georgia, serif",
+        "$type": "fontFamily",
+        "$description": "Variable axis: opsz 9-144, wght 300-900, SOFT 0-100, WONK 0-1"
+      },
+      "body": {
+        "$value": "'IBM Plex Sans', 'IBM Plex Sans JP', 'Hiragino Kaku Gothic ProN', sans-serif",
+        "$type": "fontFamily",
+        "$description": "日本語 + 英語 本文。line-height 1.7 推奨"
+      },
+      "mono": {
+        "$value": "'IBM Plex Mono', 'SFMono-Regular', Menlo, monospace",
+        "$type": "fontFamily",
+        "$description": "コード表示・メタデータ"
+      }
+    }
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,8 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Noto+Sans+JP:wght@400;500;700&display=swap');
 
+/* Kaze 骨格フォント (v0) — 既存 Inter/Noto と並行ロード。opt-in で使う */
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT,WONK@9..144,300..900,0..100,0..1&family=IBM+Plex+Sans:wght@300;400;500;600;700&family=IBM+Plex+Sans+JP:wght@300;400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap');
+
 @import 'tailwindcss/base';
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
@@ -48,6 +51,44 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  /* === Kaze 骨格 CSS 変数 (v0) ===
+   * 値の TypeScript ミラー: src/themes/kazeTokens.ts
+   * 既存 --color-* とは独立した additive な namespace。
+   * opt-in で使用: var(--kaze-teal), var(--kaze-r-sharp), etc.
+   */
+  --kaze-teal: #0eadb8;
+  --kaze-sumi: #0a0a0a;
+  --kaze-washi: #f7f4ee;
+  --kaze-asagi: #5b8fb9;
+  --kaze-beni: #e34e3a;
+  --kaze-ink: rgba(10, 10, 10, 0.88);
+  --kaze-ink-muted: rgba(10, 10, 10, 0.54);
+  --kaze-ink-hair: rgba(10, 10, 10, 0.12);
+  --kaze-ink-mist: rgba(10, 10, 10, 0.04);
+  --kaze-r-sharp: 2px;
+  --kaze-r-soft: 8px;
+  --kaze-r-gen: 24px;
+  --kaze-r-full: 9999px;
+  --kaze-ease: cubic-bezier(0.33, 0, 0, 1);
+  --kaze-dur-micro: 120ms;
+  --kaze-dur-macro: 240ms;
+  --kaze-dur-scene: 480ms;
+  --kaze-font-display:
+    'Fraunces', 'Shippori Mincho B1', 'Noto Serif JP', Georgia, serif;
+  --kaze-font-body:
+    'IBM Plex Sans', 'IBM Plex Sans JP', 'Hiragino Kaku Gothic ProN', sans-serif;
+  --kaze-font-mono: 'IBM Plex Mono', 'SFMono-Regular', Menlo, monospace;
+}
+
+/* Dark モードの ink/washi 反転（Kaze 骨格 dark 対応） */
+.dark {
+  --kaze-washi: #0a0a0a;
+  --kaze-sumi: #f7f4ee;
+  --kaze-ink: rgba(247, 244, 238, 0.88);
+  --kaze-ink-muted: rgba(247, 244, 238, 0.54);
+  --kaze-ink-hair: rgba(247, 244, 238, 0.12);
+  --kaze-ink-mist: rgba(247, 244, 238, 0.04);
 }
 
 /* Dark Theme Colors — colorToken.ts (Dracula scheme) と同期 */

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -743,13 +743,14 @@ export const LandingPage = () => {
                   </Box>
                   <Typography
                     sx={{
-                      fontSize: '0.95rem',
-                      fontWeight: 700,
-                      letterSpacing: '0.12em',
+                      fontFamily: 'var(--kaze-font-mono)',
+                      fontSize: '0.75rem',
+                      fontWeight: 500,
+                      letterSpacing: '0.24em',
                       textTransform: 'uppercase',
                       color: 'primary.main',
                     }}>
-                    Kaze Design System
+                    Kaze Design System · v0
                   </Typography>
                 </Box>
               </motion.div>
@@ -765,23 +766,37 @@ export const LandingPage = () => {
                 }}>
                 <Typography
                   sx={{
-                    fontSize: { xs: '2.5rem', sm: '3.5rem', md: '4.2rem' },
-                    fontWeight: 800,
-                    lineHeight: 1.1,
-                    letterSpacing: '-0.04em',
+                    fontFamily: 'var(--kaze-font-display)',
+                    fontSize: { xs: '3rem', sm: '4.5rem', md: '5.5rem' },
+                    fontWeight: 380,
+                    lineHeight: 0.98,
+                    letterSpacing: '-0.035em',
+                    fontVariationSettings:
+                      "'opsz' 144, 'wght' 380, 'SOFT' 30, 'WONK' 0",
                     mb: 2,
                   }}>
                   One System,
                   <br />
-                  <Box component='span' sx={{ color: 'primary.main' }}>
+                  <Box
+                    component='span'
+                    sx={{
+                      color: 'primary.main',
+                      fontStyle: 'italic',
+                      fontVariationSettings:
+                        "'opsz' 144, 'wght' 420, 'SOFT' 70, 'WONK' 1",
+                    }}>
                     Infinite
                   </Box>{' '}
-                  Interfaces
+                  Interfaces.
                 </Typography>
                 <Typography
                   sx={{
-                    fontSize: { xs: '0.85rem', md: '0.95rem' },
+                    fontFamily: 'var(--kaze-font-body)',
+                    fontSize: { xs: '0.9rem', md: '1rem' },
+                    fontWeight: 400,
                     color: 'text.secondary',
+                    letterSpacing: '0.02em',
+                    lineHeight: 1.7,
                     mb: 3,
                   }}>
                   コンポーネント・トークン・テーマをひとつの基盤で管理
@@ -799,9 +814,12 @@ export const LandingPage = () => {
                 }}>
                 <Typography
                   sx={{
+                    fontFamily: 'var(--kaze-font-body)',
                     fontSize: { xs: '0.95rem', md: '1.05rem' },
+                    fontWeight: 400,
                     color: 'text.secondary',
-                    lineHeight: 1.8,
+                    letterSpacing: '0.02em',
+                    lineHeight: 1.75,
                     maxWidth: 520,
                     mb: 5,
                   }}>

--- a/src/themes/kazeTokens.ts
+++ b/src/themes/kazeTokens.ts
@@ -1,0 +1,92 @@
+/**
+ * Kaze 骨格トークン (v0)
+ *
+ * 「墨で書かれ、風で運ばれる」世界観を 4 軸で固定する single source of truth。
+ * 既存 MUI テーマ（primary/secondary/...）には触れず、additive に共存する。
+ * 新規コンポーネント・refresh 済み画面はこれを参照する。
+ *
+ * 参照: src/stories/01-DesignPhilosophy/KazeSkeleton.stories.tsx
+ */
+
+export const kazeTokens = {
+  color: {
+    kazeTeal: '#0EADB8',
+    sumi: '#0A0A0A',
+    washi: '#F7F4EE',
+    asagi: '#5B8FB9',
+    beni: '#E34E3A',
+  },
+  ink: {
+    primary: 'rgba(10, 10, 10, 0.88)',
+    muted: 'rgba(10, 10, 10, 0.54)',
+    hair: 'rgba(10, 10, 10, 0.12)',
+    mist: 'rgba(10, 10, 10, 0.04)',
+  },
+  radius: {
+    sharp: 2,
+    soft: 8,
+    gen: 24,
+    full: 9999,
+  },
+  motion: {
+    ease: {
+      kaze: 'cubic-bezier(0.33, 0, 0, 1)',
+    },
+    duration: {
+      micro: 120,
+      macro: 240,
+      scene: 480,
+    },
+  },
+  font: {
+    display:
+      "'Fraunces', 'Shippori Mincho B1', 'Noto Serif JP', Georgia, serif",
+    body: "'IBM Plex Sans', 'IBM Plex Sans JP', 'Hiragino Kaku Gothic ProN', sans-serif",
+    mono: "'IBM Plex Mono', 'SFMono-Regular', Menlo, monospace",
+  },
+  fontAxis: {
+    displayDefault: "'opsz' 144, 'wght' 380, 'SOFT' 30, 'WONK' 0",
+    displayEmphasis: "'opsz' 144, 'wght' 420, 'SOFT' 70, 'WONK' 1",
+  },
+} as const
+
+export type KazeTokens = typeof kazeTokens
+
+/**
+ * Google Fonts URL。Storybook preview-head / LP <head> / アプリ _document で
+ * 同一ソースを使う。
+ */
+export const KAZE_GOOGLE_FONTS_HREF =
+  'https://fonts.googleapis.com/css2' +
+  '?family=Fraunces:opsz,wght,SOFT,WONK@9..144,300..900,0..100,0..1' +
+  '&family=IBM+Plex+Sans:wght@300;400;500;600;700' +
+  '&family=IBM+Plex+Sans+JP:wght@300;400;500;600;700' +
+  '&family=IBM+Plex+Mono:wght@400;500;600' +
+  '&display=swap'
+
+/**
+ * CSS カスタムプロパティとして注入するための key-value マップ。
+ * :root や scope element に展開して使う。
+ */
+export const kazeCssVars: Record<string, string> = {
+  '--kaze-teal': kazeTokens.color.kazeTeal,
+  '--kaze-sumi': kazeTokens.color.sumi,
+  '--kaze-washi': kazeTokens.color.washi,
+  '--kaze-asagi': kazeTokens.color.asagi,
+  '--kaze-beni': kazeTokens.color.beni,
+  '--kaze-ink': kazeTokens.ink.primary,
+  '--kaze-ink-muted': kazeTokens.ink.muted,
+  '--kaze-ink-hair': kazeTokens.ink.hair,
+  '--kaze-ink-mist': kazeTokens.ink.mist,
+  '--kaze-r-sharp': `${kazeTokens.radius.sharp}px`,
+  '--kaze-r-soft': `${kazeTokens.radius.soft}px`,
+  '--kaze-r-gen': `${kazeTokens.radius.gen}px`,
+  '--kaze-r-full': `${kazeTokens.radius.full}px`,
+  '--kaze-ease': kazeTokens.motion.ease.kaze,
+  '--kaze-dur-micro': `${kazeTokens.motion.duration.micro}ms`,
+  '--kaze-dur-macro': `${kazeTokens.motion.duration.macro}ms`,
+  '--kaze-dur-scene': `${kazeTokens.motion.duration.scene}ms`,
+  '--kaze-font-display': kazeTokens.font.display,
+  '--kaze-font-body': kazeTokens.font.body,
+  '--kaze-font-mono': kazeTokens.font.mono,
+}


### PR DESCRIPTION
## 概要

LP Hero の 3 要素を Kaze 骨格（PR #38 / #39）に **opt-in** で移行。framer-motion オーブ・アニメーション・CTA はすべて温存。\`var(--kaze-font-*)\` 経由なので、骨格トークン変更時に自動追従。

## 依存

このブランチは [PR #39 (fonts-global)](https://github.com/BoxPistols/kaze-ux/pull/39) から派生。**#39 マージ後に rebase すれば、この PR の diff は \`LandingPage.tsx\` 1 ファイル・30 行に縮小**。

## 変更

### Before（Inter 800weight）
\`\`\`
KAZE DESIGN SYSTEM (0.95rem / 700)
One System, [Infinite] Interfaces (Inter 800 / -0.04em)
コンポーネント・トークン・テーマを... (Inter)
\`\`\`

### After（Fraunces Variable + Plex）
\`\`\`
KAZE DESIGN SYSTEM · V0      ← Plex Mono 500 / 0.24em tracking
One System,                  ← Fraunces: opsz 144, wght 380, SOFT 30
[Infinite] Interfaces.        ← Infinite は italic: wght 420, SOFT 70, WONK 1
  ↑ -0.035em tracking, 3→5.5rem
コンポーネント・トークン・テーマを... ← Plex Sans JP: 0.02em / 1.7
\`\`\`

3 つの Typography だけ差し替え、周辺の motion・layout・色は無変更。

## なぜこの変更で印象が変わるか

1. **Fraunces Variable axis** — メインコピーが「活字」ではなく「書」になる。特に Infinite の italic + WONK=1 が Inter の量産感から脱却
2. **Plex Mono ブランドラベル** — \`v0\` 付与で editorial な「版」を感じさせる
3. **Plex Sans JP body** — 日本語の呼吸（line-height 1.7）が editorial に整う
4. **サイズ大型化** — 3→5.5rem で hero らしい存在感に

## 既存機能への影響

- ❌ framer-motion オーブ / ドリフト: 無変更
- ❌ CTA ボタン (Storybook/GitHub): 無変更
- ❌ レスポンシブ breakpoints: 無変更
- ❌ ダークモード: 無変更（Plex も Fraunces も両対応）

## Test plan

- [x] \`pnpm build-sandbox\`: 2.58s 成功
- [ ] ブラウザで \`pnpm dev\` → LP hero の Fraunces Variable axis が適用されていることを目視確認
- [ ] Italic \`Infinite\` が WONK で個性が出ていることを確認
- [ ] モバイル (xs) / デスクトップ (md) で typography scale が崩れないこと
- [ ] ダークモードで可読性に問題がないこと

## 後続候補

- **#42**: Products / Features / Architecture の section 見出しも同じパターンに移植
- **#43**: BauhausDivider の色を asagi/beni で再配色
- **#44**: DS コンポーネント (Button/Card/Typography) に \`useKaze\` opt-in 追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)