### PR TITLE
feat(lp): 全 section 見出しを 骨格 SX に統一

### DIFF
--- a/design-tokens/tokens.json
+++ b/design-tokens/tokens.json
@@ -2559,5 +2559,122 @@
         "$description": "矢印の表示"
       }
     }
+  },
+  "kaze": {
+    "$description": "Kaze 骨格トークン v0 — 『墨で書かれ、風で運ばれる』。既存トークンとは独立した additive namespace。",
+    "color": {
+      "kaze-teal": {
+        "$value": "#0EADB8",
+        "$type": "color",
+        "$description": "Primary / Action。ブランドの主役"
+      },
+      "sumi": {
+        "$value": "#0A0A0A",
+        "$type": "color",
+        "$description": "墨 — text / structure"
+      },
+      "washi": {
+        "$value": "#F7F4EE",
+        "$type": "color",
+        "$description": "和紙 — surface / rest。pure white 禁止の理由"
+      },
+      "asagi": {
+        "$value": "#5B8FB9",
+        "$type": "color",
+        "$description": "浅葱 — info / link。画面 5% 未満に制限"
+      },
+      "beni": {
+        "$value": "#E34E3A",
+        "$type": "color",
+        "$description": "紅 — alert / accent。画面 5% 未満に制限"
+      }
+    },
+    "ink": {
+      "primary": {
+        "$value": "rgba(10, 10, 10, 0.88)",
+        "$type": "color",
+        "$description": "washi 背景上の本文色"
+      },
+      "muted": {
+        "$value": "rgba(10, 10, 10, 0.54)",
+        "$type": "color",
+        "$description": "washi 背景上のミュート色"
+      },
+      "hair": {
+        "$value": "rgba(10, 10, 10, 0.12)",
+        "$type": "color",
+        "$description": "区切り線 (hair line)"
+      },
+      "mist": {
+        "$value": "rgba(10, 10, 10, 0.04)",
+        "$type": "color",
+        "$description": "背景上のうっすらした面 (mist)"
+      }
+    },
+    "radius": {
+      "sharp": {
+        "$value": "2px",
+        "$type": "dimension",
+        "$description": "button / input / chip / tab"
+      },
+      "soft": {
+        "$value": "8px",
+        "$type": "dimension",
+        "$description": "card / panel / popover"
+      },
+      "gen": {
+        "$value": "24px",
+        "$type": "dimension",
+        "$description": "modal / hero / section"
+      },
+      "full": {
+        "$value": "9999px",
+        "$type": "dimension",
+        "$description": "avatar / tag / pill のみ"
+      }
+    },
+    "motion": {
+      "ease": {
+        "kaze": {
+          "$value": "cubic-bezier(0.33, 0, 0, 1)",
+          "$type": "cubicBezier",
+          "$description": "単一採用。spring / bounce / overshoot は禁止"
+        }
+      },
+      "duration": {
+        "micro": {
+          "$value": "120ms",
+          "$type": "duration",
+          "$description": "hover / focus / toggle"
+        },
+        "macro": {
+          "$value": "240ms",
+          "$type": "duration",
+          "$description": "panel / tab / drawer"
+        },
+        "scene": {
+          "$value": "480ms",
+          "$type": "duration",
+          "$description": "modal / route / hero"
+        }
+      }
+    },
+    "font": {
+      "display": {
+        "$value": "'Fraunces', 'Shippori Mincho B1', 'Noto Serif JP', Georgia, serif",
+        "$type": "fontFamily",
+        "$description": "Variable axis: opsz 9-144, wght 300-900, SOFT 0-100, WONK 0-1"
+      },
+      "body": {
+        "$value": "'IBM Plex Sans', 'IBM Plex Sans JP', 'Hiragino Kaku Gothic ProN', sans-serif",
+        "$type": "fontFamily",
+        "$description": "日本語 + 英語 本文。line-height 1.7 推奨"
+      },
+      "mono": {
+        "$value": "'IBM Plex Mono', 'SFMono-Regular', Menlo, monospace",
+        "$type": "fontFamily",
+        "$description": "コード表示・メタデータ"
+      }
+    }
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,8 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Noto+Sans+JP:wght@400;500;700&display=swap');
 
+/* Kaze 骨格フォント (v0) — 既存 Inter/Noto と並行ロード。opt-in で使う */
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT,WONK@9..144,300..900,0..100,0..1&family=IBM+Plex+Sans:wght@300;400;500;600;700&family=IBM+Plex+Sans+JP:wght@300;400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap');
+
 @import 'tailwindcss/base';
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
@@ -48,6 +51,44 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  /* === Kaze 骨格 CSS 変数 (v0) ===
+   * 値の TypeScript ミラー: src/themes/kazeTokens.ts
+   * 既存 --color-* とは独立した additive な namespace。
+   * opt-in で使用: var(--kaze-teal), var(--kaze-r-sharp), etc.
+   */
+  --kaze-teal: #0eadb8;
+  --kaze-sumi: #0a0a0a;
+  --kaze-washi: #f7f4ee;
+  --kaze-asagi: #5b8fb9;
+  --kaze-beni: #e34e3a;
+  --kaze-ink: rgba(10, 10, 10, 0.88);
+  --kaze-ink-muted: rgba(10, 10, 10, 0.54);
+  --kaze-ink-hair: rgba(10, 10, 10, 0.12);
+  --kaze-ink-mist: rgba(10, 10, 10, 0.04);
+  --kaze-r-sharp: 2px;
+  --kaze-r-soft: 8px;
+  --kaze-r-gen: 24px;
+  --kaze-r-full: 9999px;
+  --kaze-ease: cubic-bezier(0.33, 0, 0, 1);
+  --kaze-dur-micro: 120ms;
+  --kaze-dur-macro: 240ms;
+  --kaze-dur-scene: 480ms;
+  --kaze-font-display:
+    'Fraunces', 'Shippori Mincho B1', 'Noto Serif JP', Georgia, serif;
+  --kaze-font-body:
+    'IBM Plex Sans', 'IBM Plex Sans JP', 'Hiragino Kaku Gothic ProN', sans-serif;
+  --kaze-font-mono: 'IBM Plex Mono', 'SFMono-Regular', Menlo, monospace;
+}
+
+/* Dark モードの ink/washi 反転（Kaze 骨格 dark 対応） */
+.dark {
+  --kaze-washi: #0a0a0a;
+  --kaze-sumi: #f7f4ee;
+  --kaze-ink: rgba(247, 244, 238, 0.88);
+  --kaze-ink-muted: rgba(247, 244, 238, 0.54);
+  --kaze-ink-hair: rgba(247, 244, 238, 0.12);
+  --kaze-ink-mist: rgba(247, 244, 238, 0.04);
 }
 
 /* Dark Theme Colors — colorToken.ts (Dracula scheme) と同期 */

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -609,6 +609,39 @@ const CONTAINER_SX = {
   px: { xs: 2.5, sm: 3, md: 4 },
 } as const
 
+// Kaze 骨格 — section eyebrow (小さい uppercase ラベル、Plex Mono)
+const EYEBROW_SX = {
+  fontFamily: 'var(--kaze-font-mono)',
+  fontSize: '0.75rem',
+  fontWeight: 500,
+  letterSpacing: '0.24em',
+  textTransform: 'uppercase',
+  color: 'primary.main',
+  mb: 2,
+} as const
+
+// Kaze 骨格 — section display (大型見出し、Fraunces Variable)
+const DISPLAY_SX = {
+  fontFamily: 'var(--kaze-font-display)',
+  fontSize: { xs: '2.5rem', md: '3.6rem' },
+  fontWeight: 380,
+  letterSpacing: '-0.03em',
+  lineHeight: 1.02,
+  fontVariationSettings: "'opsz' 144, 'wght' 380, 'SOFT' 30, 'WONK' 0",
+  mb: 1.5,
+} as const
+
+// Kaze 骨格 — section sub-copy (日本語 / 英語 lead)
+const SECTION_LEAD_SX = {
+  fontFamily: 'var(--kaze-font-body)',
+  fontSize: { xs: '0.9rem', md: '0.95rem' },
+  fontWeight: 400,
+  color: 'text.secondary',
+  letterSpacing: '0.02em',
+  lineHeight: 1.7,
+  mb: 6,
+} as const
+
 // メインLPコンポーネント
 export const LandingPage = () => {
   const theme = useTheme()
@@ -903,33 +936,9 @@ export const LandingPage = () => {
             initial={{ opacity: 0 }}
             whileInView={{ opacity: 1 }}
             viewport={{ once: true }}>
-            <Typography
-              sx={{
-                fontSize: '1rem',
-                fontWeight: 700,
-                letterSpacing: '0.15em',
-                textTransform: 'uppercase',
-                color: 'primary.main',
-                mb: 2,
-              }}>
-              Products
-            </Typography>
-            <Typography
-              sx={{
-                fontSize: { xs: '2rem', md: '2.8rem' },
-                fontWeight: 800,
-                letterSpacing: '-0.04em',
-                lineHeight: 1.1,
-                mb: 1.5,
-              }}>
-              Built with Kaze
-            </Typography>
-            <Typography
-              sx={{
-                fontSize: '0.9rem',
-                color: 'text.secondary',
-                mb: 6,
-              }}>
+            <Typography sx={EYEBROW_SX}>Products</Typography>
+            <Typography sx={DISPLAY_SX}>Built with Kaze</Typography>
+            <Typography sx={SECTION_LEAD_SX}>
               同じコンポーネント基盤で構築したプロダクト
             </Typography>
           </motion.div>
@@ -964,34 +973,9 @@ export const LandingPage = () => {
                 initial={{ opacity: 0 }}
                 whileInView={{ opacity: 1 }}
                 viewport={{ once: true }}>
-                <Typography
-                  sx={{
-                    fontSize: '1rem',
-                    fontWeight: 700,
-                    letterSpacing: '0.15em',
-                    textTransform: 'uppercase',
-                    color: 'primary.main',
-                    mb: 2,
-                  }}>
-                  Architecture
-                </Typography>
-                <Typography
-                  sx={{
-                    fontSize: { xs: '2rem', md: '2.8rem' },
-                    fontWeight: 800,
-                    letterSpacing: '-0.04em',
-                    lineHeight: 1.1,
-                    mb: 1.5,
-                  }}>
-                  Architecture
-                </Typography>
-                <Typography
-                  sx={{
-                    fontSize: '0.9rem',
-                    color: 'text.secondary',
-                    lineHeight: 1.8,
-                    mb: 4,
-                  }}>
+                <Typography sx={EYEBROW_SX}>Architecture</Typography>
+                <Typography sx={DISPLAY_SX}>Architecture</Typography>
+                <Typography sx={{ ...SECTION_LEAD_SX, mb: 4 }}>
                   トークン・テーマ・AIチャットで構成する設計基盤
                 </Typography>
               </motion.div>
@@ -1015,33 +999,9 @@ export const LandingPage = () => {
             initial={{ opacity: 0 }}
             whileInView={{ opacity: 1 }}
             viewport={{ once: true }}>
-            <Typography
-              sx={{
-                fontSize: '1rem',
-                fontWeight: 700,
-                letterSpacing: '0.15em',
-                textTransform: 'uppercase',
-                color: 'primary.main',
-                mb: 2,
-              }}>
-              Tech Stack
-            </Typography>
-            <Typography
-              sx={{
-                fontSize: { xs: '2rem', md: '2.8rem' },
-                fontWeight: 800,
-                letterSpacing: '-0.04em',
-                lineHeight: 1.1,
-                mb: 1.5,
-              }}>
-              Tech Stack
-            </Typography>
-            <Typography
-              sx={{
-                fontSize: '0.9rem',
-                color: 'text.secondary',
-                mb: 4,
-              }}>
+            <Typography sx={EYEBROW_SX}>Tech Stack</Typography>
+            <Typography sx={DISPLAY_SX}>Tech Stack</Typography>
+            <Typography sx={{ ...SECTION_LEAD_SX, mb: 4 }}>
               使用している技術とツール
             </Typography>
           </motion.div>
@@ -1112,33 +1072,9 @@ export const LandingPage = () => {
             initial={{ opacity: 0 }}
             whileInView={{ opacity: 1 }}
             viewport={{ once: true }}>
-            <Typography
-              sx={{
-                fontSize: '1rem',
-                fontWeight: 700,
-                letterSpacing: '0.15em',
-                textTransform: 'uppercase',
-                color: 'primary.main',
-                mb: 2,
-              }}>
-              Getting Started
-            </Typography>
-            <Typography
-              sx={{
-                fontSize: { xs: '2rem', md: '2.8rem' },
-                fontWeight: 800,
-                letterSpacing: '-0.04em',
-                lineHeight: 1.1,
-                mb: 1.5,
-              }}>
-              Getting Started
-            </Typography>
-            <Typography
-              sx={{
-                fontSize: '0.9rem',
-                color: 'text.secondary',
-                mb: 4,
-              }}>
+            <Typography sx={EYEBROW_SX}>Getting Started</Typography>
+            <Typography sx={DISPLAY_SX}>Getting Started</Typography>
+            <Typography sx={{ ...SECTION_LEAD_SX, mb: 4 }}>
               3ステップではじめる
             </Typography>
           </motion.div>
@@ -1255,27 +1191,8 @@ export const LandingPage = () => {
               initial={{ opacity: 0 }}
               whileInView={{ opacity: 1 }}
               viewport={{ once: true }}>
-              <Typography
-                sx={{
-                  fontSize: '1rem',
-                  fontWeight: 700,
-                  letterSpacing: '0.15em',
-                  textTransform: 'uppercase',
-                  color: 'primary.main',
-                  mb: 2,
-                }}>
-                Storybook AI Chat
-              </Typography>
-              <Typography
-                sx={{
-                  fontSize: { xs: '2rem', md: '2.8rem' },
-                  fontWeight: 800,
-                  letterSpacing: '-0.04em',
-                  lineHeight: 1.1,
-                  mb: 1.5,
-                }}>
-                AI Concierge
-              </Typography>
+              <Typography sx={EYEBROW_SX}>Storybook AI Chat</Typography>
+              <Typography sx={DISPLAY_SX}>AI Concierge</Typography>
               <Typography
                 sx={{
                   fontSize: '1rem',

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -743,13 +743,14 @@ export const LandingPage = () => {
                   </Box>
                   <Typography
                     sx={{
-                      fontSize: '0.95rem',
-                      fontWeight: 700,
-                      letterSpacing: '0.12em',
+                      fontFamily: 'var(--kaze-font-mono)',
+                      fontSize: '0.75rem',
+                      fontWeight: 500,
+                      letterSpacing: '0.24em',
                       textTransform: 'uppercase',
                       color: 'primary.main',
                     }}>
-                    Kaze Design System
+                    Kaze Design System · v0
                   </Typography>
                 </Box>
               </motion.div>
@@ -765,23 +766,37 @@ export const LandingPage = () => {
                 }}>
                 <Typography
                   sx={{
-                    fontSize: { xs: '2.5rem', sm: '3.5rem', md: '4.2rem' },
-                    fontWeight: 800,
-                    lineHeight: 1.1,
-                    letterSpacing: '-0.04em',
+                    fontFamily: 'var(--kaze-font-display)',
+                    fontSize: { xs: '3rem', sm: '4.5rem', md: '5.5rem' },
+                    fontWeight: 380,
+                    lineHeight: 0.98,
+                    letterSpacing: '-0.035em',
+                    fontVariationSettings:
+                      "'opsz' 144, 'wght' 380, 'SOFT' 30, 'WONK' 0",
                     mb: 2,
                   }}>
                   One System,
                   <br />
-                  <Box component='span' sx={{ color: 'primary.main' }}>
+                  <Box
+                    component='span'
+                    sx={{
+                      color: 'primary.main',
+                      fontStyle: 'italic',
+                      fontVariationSettings:
+                        "'opsz' 144, 'wght' 420, 'SOFT' 70, 'WONK' 1",
+                    }}>
                     Infinite
                   </Box>{' '}
-                  Interfaces
+                  Interfaces.
                 </Typography>
                 <Typography
                   sx={{
-                    fontSize: { xs: '0.85rem', md: '0.95rem' },
+                    fontFamily: 'var(--kaze-font-body)',
+                    fontSize: { xs: '0.9rem', md: '1rem' },
+                    fontWeight: 400,
                     color: 'text.secondary',
+                    letterSpacing: '0.02em',
+                    lineHeight: 1.7,
                     mb: 3,
                   }}>
                   コンポーネント・トークン・テーマをひとつの基盤で管理
@@ -799,9 +814,12 @@ export const LandingPage = () => {
                 }}>
                 <Typography
                   sx={{
+                    fontFamily: 'var(--kaze-font-body)',
                     fontSize: { xs: '0.95rem', md: '1.05rem' },
+                    fontWeight: 400,
                     color: 'text.secondary',
-                    lineHeight: 1.8,
+                    letterSpacing: '0.02em',
+                    lineHeight: 1.75,
                     maxWidth: 520,
                     mb: 5,
                   }}>

--- a/src/themes/kazeTokens.ts
+++ b/src/themes/kazeTokens.ts
@@ -1,0 +1,92 @@
+/**
+ * Kaze 骨格トークン (v0)
+ *
+ * 「墨で書かれ、風で運ばれる」世界観を 4 軸で固定する single source of truth。
+ * 既存 MUI テーマ（primary/secondary/...）には触れず、additive に共存する。
+ * 新規コンポーネント・refresh 済み画面はこれを参照する。
+ *
+ * 参照: src/stories/01-DesignPhilosophy/KazeSkeleton.stories.tsx
+ */
+
+export const kazeTokens = {
+  color: {
+    kazeTeal: '#0EADB8',
+    sumi: '#0A0A0A',
+    washi: '#F7F4EE',
+    asagi: '#5B8FB9',
+    beni: '#E34E3A',
+  },
+  ink: {
+    primary: 'rgba(10, 10, 10, 0.88)',
+    muted: 'rgba(10, 10, 10, 0.54)',
+    hair: 'rgba(10, 10, 10, 0.12)',
+    mist: 'rgba(10, 10, 10, 0.04)',
+  },
+  radius: {
+    sharp: 2,
+    soft: 8,
+    gen: 24,
+    full: 9999,
+  },
+  motion: {
+    ease: {
+      kaze: 'cubic-bezier(0.33, 0, 0, 1)',
+    },
+    duration: {
+      micro: 120,
+      macro: 240,
+      scene: 480,
+    },
+  },
+  font: {
+    display:
+      "'Fraunces', 'Shippori Mincho B1', 'Noto Serif JP', Georgia, serif",
+    body: "'IBM Plex Sans', 'IBM Plex Sans JP', 'Hiragino Kaku Gothic ProN', sans-serif",
+    mono: "'IBM Plex Mono', 'SFMono-Regular', Menlo, monospace",
+  },
+  fontAxis: {
+    displayDefault: "'opsz' 144, 'wght' 380, 'SOFT' 30, 'WONK' 0",
+    displayEmphasis: "'opsz' 144, 'wght' 420, 'SOFT' 70, 'WONK' 1",
+  },
+} as const
+
+export type KazeTokens = typeof kazeTokens
+
+/**
+ * Google Fonts URL。Storybook preview-head / LP <head> / アプリ _document で
+ * 同一ソースを使う。
+ */
+export const KAZE_GOOGLE_FONTS_HREF =
+  'https://fonts.googleapis.com/css2' +
+  '?family=Fraunces:opsz,wght,SOFT,WONK@9..144,300..900,0..100,0..1' +
+  '&family=IBM+Plex+Sans:wght@300;400;500;600;700' +
+  '&family=IBM+Plex+Sans+JP:wght@300;400;500;600;700' +
+  '&family=IBM+Plex+Mono:wght@400;500;600' +
+  '&display=swap'
+
+/**
+ * CSS カスタムプロパティとして注入するための key-value マップ。
+ * :root や scope element に展開して使う。
+ */
+export const kazeCssVars: Record<string, string> = {
+  '--kaze-teal': kazeTokens.color.kazeTeal,
+  '--kaze-sumi': kazeTokens.color.sumi,
+  '--kaze-washi': kazeTokens.color.washi,
+  '--kaze-asagi': kazeTokens.color.asagi,
+  '--kaze-beni': kazeTokens.color.beni,
+  '--kaze-ink': kazeTokens.ink.primary,
+  '--kaze-ink-muted': kazeTokens.ink.muted,
+  '--kaze-ink-hair': kazeTokens.ink.hair,
+  '--kaze-ink-mist': kazeTokens.ink.mist,
+  '--kaze-r-sharp': `${kazeTokens.radius.sharp}px`,
+  '--kaze-r-soft': `${kazeTokens.radius.soft}px`,
+  '--kaze-r-gen': `${kazeTokens.radius.gen}px`,
+  '--kaze-r-full': `${kazeTokens.radius.full}px`,
+  '--kaze-ease': kazeTokens.motion.ease.kaze,
+  '--kaze-dur-micro': `${kazeTokens.motion.duration.micro}ms`,
+  '--kaze-dur-macro': `${kazeTokens.motion.duration.macro}ms`,
+  '--kaze-dur-scene': `${kazeTokens.motion.duration.scene}ms`,
+  '--kaze-font-display': kazeTokens.font.display,
+  '--kaze-font-body': kazeTokens.font.body,
+  '--kaze-font-mono': kazeTokens.font.mono,
+}


### PR DESCRIPTION
## 概要

PR #40 の Hero に続けて、LP の残り 5 section (Products / Architecture / Tech Stack / Getting Started / Storybook AI Chat) の見出しを骨格に統一。インライン sx を共有定数に集約し、次回の微調整を **1 箇所** で済ませられる構造にした。

## 依存

[PR #40 (lp-hero-fraunces)](https://github.com/BoxPistols/kaze-ux/pull/40) から派生。**#40 マージ後に rebase すれば、この PR の diff は \`LandingPage.tsx\` 1 ファイル・+47 / -130 行に縮小**。

## 変更点

### 1. 共有 SX 定数を追加

\`CONTAINER_SX\` の隣に 3 つ追加:

\`\`\`ts
const EYEBROW_SX = {
  fontFamily: 'var(--kaze-font-mono)',
  fontSize: '0.75rem',
  fontWeight: 500,
  letterSpacing: '0.24em',
  textTransform: 'uppercase',
  color: 'primary.main',
  mb: 2,
} as const

const DISPLAY_SX = {
  fontFamily: 'var(--kaze-font-display)',
  fontSize: { xs: '2.5rem', md: '3.6rem' },
  fontWeight: 380,
  letterSpacing: '-0.03em',
  lineHeight: 1.02,
  fontVariationSettings: "'opsz' 144, 'wght' 380, 'SOFT' 30, 'WONK' 0",
  mb: 1.5,
} as const

const SECTION_LEAD_SX = {
  fontFamily: 'var(--kaze-font-body)',
  fontSize: { xs: '0.9rem', md: '0.95rem' },
  fontWeight: 400,
  color: 'text.secondary',
  letterSpacing: '0.02em',
  lineHeight: 1.7,
  mb: 6,
} as const
\`\`\`

### 2. 5 section を置換

Before (各 section 共通):
\`\`\`tsx
<Typography sx={{ fontSize: '1rem', fontWeight: 700, letterSpacing: '0.15em', ... }}>
  Products
</Typography>
<Typography sx={{ fontSize: { xs: '2rem', md: '2.8rem' }, fontWeight: 800, letterSpacing: '-0.04em', ... }}>
  Built with Kaze
</Typography>
<Typography sx={{ fontSize: '0.9rem', color: 'text.secondary', mb: 6 }}>
  同じコンポーネント基盤で構築したプロダクト
</Typography>
\`\`\`

After:
\`\`\`tsx
<Typography sx={EYEBROW_SX}>Products</Typography>
<Typography sx={DISPLAY_SX}>Built with Kaze</Typography>
<Typography sx={SECTION_LEAD_SX}>
  同じコンポーネント基盤で構築したプロダクト
</Typography>
\`\`\`

各 section でわずかに違う \`mb\` は \`sx={{ ...SECTION_LEAD_SX, mb: 4 }}\` で override 可能。

## 変化

- **Fraunces Variable** で全見出しが「活字」から「書」に統一
- **Plex Mono eyebrow** で editorial な版感
- **Plex Sans JP lead** で日本語の呼吸が整う
- **+47 / -130 行** で可読性も向上（section 定義が圧縮）

## 既存への影響

- motion・layout・hover・color (primary.main) はすべて温存
- BauhausDivider / ProductCard / FeatureItem 内部は未変更
- 各 section の \`mb: 4\` など微調整は override で保持

## Test plan

- [x] \`pnpm build-sandbox\`: 2.39s 成功
- [ ] ブラウザで LP スクロール → 5 section すべてで Fraunces + Plex が適用されている
- [ ] mb (margin-bottom) の section ごとの差が保持されている
- [ ] モバイル・デスクトップで typography scale が崩れない

## 次の候補

- **#42**: BauhausDivider を asagi/beni で再配色
- **#43**: DS コンポーネント (Button/Card/Typography) に \`useKaze\` opt-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)