### PR TITLE
feat(button): kaze boolean prop を opt-in で追加

### DIFF
--- a/design-tokens/tokens.json
+++ b/design-tokens/tokens.json
@@ -2559,5 +2559,122 @@
         "$description": "矢印の表示"
       }
     }
+  },
+  "kaze": {
+    "$description": "Kaze 骨格トークン v0 — 『墨で書かれ、風で運ばれる』。既存トークンとは独立した additive namespace。",
+    "color": {
+      "kaze-teal": {
+        "$value": "#0EADB8",
+        "$type": "color",
+        "$description": "Primary / Action。ブランドの主役"
+      },
+      "sumi": {
+        "$value": "#0A0A0A",
+        "$type": "color",
+        "$description": "墨 — text / structure"
+      },
+      "washi": {
+        "$value": "#F7F4EE",
+        "$type": "color",
+        "$description": "和紙 — surface / rest。pure white 禁止の理由"
+      },
+      "asagi": {
+        "$value": "#5B8FB9",
+        "$type": "color",
+        "$description": "浅葱 — info / link。画面 5% 未満に制限"
+      },
+      "beni": {
+        "$value": "#E34E3A",
+        "$type": "color",
+        "$description": "紅 — alert / accent。画面 5% 未満に制限"
+      }
+    },
+    "ink": {
+      "primary": {
+        "$value": "rgba(10, 10, 10, 0.88)",
+        "$type": "color",
+        "$description": "washi 背景上の本文色"
+      },
+      "muted": {
+        "$value": "rgba(10, 10, 10, 0.54)",
+        "$type": "color",
+        "$description": "washi 背景上のミュート色"
+      },
+      "hair": {
+        "$value": "rgba(10, 10, 10, 0.12)",
+        "$type": "color",
+        "$description": "区切り線 (hair line)"
+      },
+      "mist": {
+        "$value": "rgba(10, 10, 10, 0.04)",
+        "$type": "color",
+        "$description": "背景上のうっすらした面 (mist)"
+      }
+    },
+    "radius": {
+      "sharp": {
+        "$value": "2px",
+        "$type": "dimension",
+        "$description": "button / input / chip / tab"
+      },
+      "soft": {
+        "$value": "8px",
+        "$type": "dimension",
+        "$description": "card / panel / popover"
+      },
+      "gen": {
+        "$value": "24px",
+        "$type": "dimension",
+        "$description": "modal / hero / section"
+      },
+      "full": {
+        "$value": "9999px",
+        "$type": "dimension",
+        "$description": "avatar / tag / pill のみ"
+      }
+    },
+    "motion": {
+      "ease": {
+        "kaze": {
+          "$value": "cubic-bezier(0.33, 0, 0, 1)",
+          "$type": "cubicBezier",
+          "$description": "単一採用。spring / bounce / overshoot は禁止"
+        }
+      },
+      "duration": {
+        "micro": {
+          "$value": "120ms",
+          "$type": "duration",
+          "$description": "hover / focus / toggle"
+        },
+        "macro": {
+          "$value": "240ms",
+          "$type": "duration",
+          "$description": "panel / tab / drawer"
+        },
+        "scene": {
+          "$value": "480ms",
+          "$type": "duration",
+          "$description": "modal / route / hero"
+        }
+      }
+    },
+    "font": {
+      "display": {
+        "$value": "'Fraunces', 'Shippori Mincho B1', 'Noto Serif JP', Georgia, serif",
+        "$type": "fontFamily",
+        "$description": "Variable axis: opsz 9-144, wght 300-900, SOFT 0-100, WONK 0-1"
+      },
+      "body": {
+        "$value": "'IBM Plex Sans', 'IBM Plex Sans JP', 'Hiragino Kaku Gothic ProN', sans-serif",
+        "$type": "fontFamily",
+        "$description": "日本語 + 英語 本文。line-height 1.7 推奨"
+      },
+      "mono": {
+        "$value": "'IBM Plex Mono', 'SFMono-Regular', Menlo, monospace",
+        "$type": "fontFamily",
+        "$description": "コード表示・メタデータ"
+      }
+    }
   }
 }

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -42,13 +42,44 @@ export interface ButtonProps
     React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean
+  /**
+   * Kaze 骨格を opt-in で適用（#38-#39 の token を参照）。
+   * - border-radius: var(--kaze-r-sharp) (2px)
+   * - transition: var(--kaze-dur-micro) var(--kaze-ease)
+   * - font-family: var(--kaze-font-mono) + letter-spacing + uppercase
+   * 既存デザインを壊さないため default は false。
+   */
+  kaze?: boolean
+}
+
+// Kaze opt-in 時のスタイル上書き。CSS vars は :root / .dark で定義済み (#39)
+const kazeStyle: React.CSSProperties = {
+  borderRadius: 'var(--kaze-r-sharp)',
+  fontFamily: 'var(--kaze-font-mono)',
+  transitionProperty: 'background-color, color, border-color, transform',
+  transitionDuration: 'var(--kaze-dur-micro)',
+  transitionTimingFunction: 'var(--kaze-ease)',
+  letterSpacing: '0.08em',
+  textTransform: 'uppercase',
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild: _asChild = false, ...props }, ref) => {
+  (
+    {
+      className,
+      variant,
+      size,
+      asChild: _asChild = false,
+      kaze = false,
+      style,
+      ...props
+    },
+    ref
+  ) => {
     return (
       <button
         className={cn(buttonVariants({ variant, size, className }))}
+        style={kaze ? { ...kazeStyle, ...style } : style}
         ref={ref}
         {...props}
       />

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,8 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Noto+Sans+JP:wght@400;500;700&display=swap');
 
+/* Kaze 骨格フォント (v0) — 既存 Inter/Noto と並行ロード。opt-in で使う */
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT,WONK@9..144,300..900,0..100,0..1&family=IBM+Plex+Sans:wght@300;400;500;600;700&family=IBM+Plex+Sans+JP:wght@300;400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap');
+
 @import 'tailwindcss/base';
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
@@ -48,6 +51,44 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  /* === Kaze 骨格 CSS 変数 (v0) ===
+   * 値の TypeScript ミラー: src/themes/kazeTokens.ts
+   * 既存 --color-* とは独立した additive な namespace。
+   * opt-in で使用: var(--kaze-teal), var(--kaze-r-sharp), etc.
+   */
+  --kaze-teal: #0eadb8;
+  --kaze-sumi: #0a0a0a;
+  --kaze-washi: #f7f4ee;
+  --kaze-asagi: #5b8fb9;
+  --kaze-beni: #e34e3a;
+  --kaze-ink: rgba(10, 10, 10, 0.88);
+  --kaze-ink-muted: rgba(10, 10, 10, 0.54);
+  --kaze-ink-hair: rgba(10, 10, 10, 0.12);
+  --kaze-ink-mist: rgba(10, 10, 10, 0.04);
+  --kaze-r-sharp: 2px;
+  --kaze-r-soft: 8px;
+  --kaze-r-gen: 24px;
+  --kaze-r-full: 9999px;
+  --kaze-ease: cubic-bezier(0.33, 0, 0, 1);
+  --kaze-dur-micro: 120ms;
+  --kaze-dur-macro: 240ms;
+  --kaze-dur-scene: 480ms;
+  --kaze-font-display:
+    'Fraunces', 'Shippori Mincho B1', 'Noto Serif JP', Georgia, serif;
+  --kaze-font-body:
+    'IBM Plex Sans', 'IBM Plex Sans JP', 'Hiragino Kaku Gothic ProN', sans-serif;
+  --kaze-font-mono: 'IBM Plex Mono', 'SFMono-Regular', Menlo, monospace;
+}
+
+/* Dark モードの ink/washi 反転（Kaze 骨格 dark 対応） */
+.dark {
+  --kaze-washi: #0a0a0a;
+  --kaze-sumi: #f7f4ee;
+  --kaze-ink: rgba(247, 244, 238, 0.88);
+  --kaze-ink-muted: rgba(247, 244, 238, 0.54);
+  --kaze-ink-hair: rgba(247, 244, 238, 0.12);
+  --kaze-ink-mist: rgba(247, 244, 238, 0.04);
 }
 
 /* Dark Theme Colors — colorToken.ts (Dracula scheme) と同期 */

--- a/src/stories/04-Components/UI/Button/TailwindButton.stories.tsx
+++ b/src/stories/04-Components/UI/Button/TailwindButton.stories.tsx
@@ -29,6 +29,11 @@ const meta: Meta<typeof Button> = {
       options: ['default', 'sm', 'lg', 'icon'],
       description: 'ボタンのサイズ',
     },
+    kaze: {
+      control: 'boolean',
+      description:
+        'Kaze 骨格を opt-in で適用（sharp radius / mono font / ease-kaze）',
+    },
   },
   parameters: {
     layout: 'centered',
@@ -100,4 +105,58 @@ export const Icon: Story = {
     children: '🔔',
     size: 'icon',
   },
+}
+
+/**
+ * Kaze 骨格を opt-in で適用した Button。
+ * 既存 variant (default/outline/secondary/...) と直交して動き、
+ * 色はそのまま、radius / motion / font だけ骨格トークンに差し替わる。
+ *
+ * 適用される差分:
+ * - borderRadius: var(--kaze-r-sharp) → 2px (sharp)
+ * - fontFamily: var(--kaze-font-mono) → IBM Plex Mono
+ * - letterSpacing: 0.08em + textTransform: uppercase
+ * - transition: var(--kaze-dur-micro) var(--kaze-ease) → 120ms / cubic-bezier(0.33, 0, 0, 1)
+ */
+export const Kaze: Story = {
+  args: {
+    children: 'Request demo',
+    variant: 'default',
+    kaze: true,
+  },
+}
+
+/**
+ * kaze opt-in × 各 variant のマトリクス。
+ * 色軸と骨格軸が orthogonal に組める。
+ */
+export const KazeMatrix: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(3, auto)',
+        gap: 12,
+        alignItems: 'center',
+      }}>
+      <Button variant='default' kaze>
+        Default
+      </Button>
+      <Button variant='outline' kaze>
+        Outline
+      </Button>
+      <Button variant='secondary' kaze>
+        Secondary
+      </Button>
+      <Button variant='destructive' kaze>
+        Destructive
+      </Button>
+      <Button variant='ghost' kaze>
+        Ghost
+      </Button>
+      <Button variant='link' kaze>
+        Link
+      </Button>
+    </div>
+  ),
 }

--- a/src/themes/kazeTokens.ts
+++ b/src/themes/kazeTokens.ts
@@ -1,0 +1,92 @@
+/**
+ * Kaze 骨格トークン (v0)
+ *
+ * 「墨で書かれ、風で運ばれる」世界観を 4 軸で固定する single source of truth。
+ * 既存 MUI テーマ（primary/secondary/...）には触れず、additive に共存する。
+ * 新規コンポーネント・refresh 済み画面はこれを参照する。
+ *
+ * 参照: src/stories/01-DesignPhilosophy/KazeSkeleton.stories.tsx
+ */
+
+export const kazeTokens = {
+  color: {
+    kazeTeal: '#0EADB8',
+    sumi: '#0A0A0A',
+    washi: '#F7F4EE',
+    asagi: '#5B8FB9',
+    beni: '#E34E3A',
+  },
+  ink: {
+    primary: 'rgba(10, 10, 10, 0.88)',
+    muted: 'rgba(10, 10, 10, 0.54)',
+    hair: 'rgba(10, 10, 10, 0.12)',
+    mist: 'rgba(10, 10, 10, 0.04)',
+  },
+  radius: {
+    sharp: 2,
+    soft: 8,
+    gen: 24,
+    full: 9999,
+  },
+  motion: {
+    ease: {
+      kaze: 'cubic-bezier(0.33, 0, 0, 1)',
+    },
+    duration: {
+      micro: 120,
+      macro: 240,
+      scene: 480,
+    },
+  },
+  font: {
+    display:
+      "'Fraunces', 'Shippori Mincho B1', 'Noto Serif JP', Georgia, serif",
+    body: "'IBM Plex Sans', 'IBM Plex Sans JP', 'Hiragino Kaku Gothic ProN', sans-serif",
+    mono: "'IBM Plex Mono', 'SFMono-Regular', Menlo, monospace",
+  },
+  fontAxis: {
+    displayDefault: "'opsz' 144, 'wght' 380, 'SOFT' 30, 'WONK' 0",
+    displayEmphasis: "'opsz' 144, 'wght' 420, 'SOFT' 70, 'WONK' 1",
+  },
+} as const
+
+export type KazeTokens = typeof kazeTokens
+
+/**
+ * Google Fonts URL。Storybook preview-head / LP <head> / アプリ _document で
+ * 同一ソースを使う。
+ */
+export const KAZE_GOOGLE_FONTS_HREF =
+  'https://fonts.googleapis.com/css2' +
+  '?family=Fraunces:opsz,wght,SOFT,WONK@9..144,300..900,0..100,0..1' +
+  '&family=IBM+Plex+Sans:wght@300;400;500;600;700' +
+  '&family=IBM+Plex+Sans+JP:wght@300;400;500;600;700' +
+  '&family=IBM+Plex+Mono:wght@400;500;600' +
+  '&display=swap'
+
+/**
+ * CSS カスタムプロパティとして注入するための key-value マップ。
+ * :root や scope element に展開して使う。
+ */
+export const kazeCssVars: Record<string, string> = {
+  '--kaze-teal': kazeTokens.color.kazeTeal,
+  '--kaze-sumi': kazeTokens.color.sumi,
+  '--kaze-washi': kazeTokens.color.washi,
+  '--kaze-asagi': kazeTokens.color.asagi,
+  '--kaze-beni': kazeTokens.color.beni,
+  '--kaze-ink': kazeTokens.ink.primary,
+  '--kaze-ink-muted': kazeTokens.ink.muted,
+  '--kaze-ink-hair': kazeTokens.ink.hair,
+  '--kaze-ink-mist': kazeTokens.ink.mist,
+  '--kaze-r-sharp': `${kazeTokens.radius.sharp}px`,
+  '--kaze-r-soft': `${kazeTokens.radius.soft}px`,
+  '--kaze-r-gen': `${kazeTokens.radius.gen}px`,
+  '--kaze-r-full': `${kazeTokens.radius.full}px`,
+  '--kaze-ease': kazeTokens.motion.ease.kaze,
+  '--kaze-dur-micro': `${kazeTokens.motion.duration.micro}ms`,
+  '--kaze-dur-macro': `${kazeTokens.motion.duration.macro}ms`,
+  '--kaze-dur-scene': `${kazeTokens.motion.duration.scene}ms`,
+  '--kaze-font-display': kazeTokens.font.display,
+  '--kaze-font-body': kazeTokens.font.body,
+  '--kaze-font-mono': kazeTokens.font.mono,
+}


### PR DESCRIPTION
## 概要

TailwindButton (\`src/components/ui/Button.tsx\`) に Kaze 骨格を opt-in で適用する boolean prop \`kaze\` を追加。**色/size と直交する軸**なので既存 variant と自由に組み合わせできる。default は false、既存呼び出しは全て無変更。

## 依存

[PR #39 (fonts-global)](https://github.com/BoxPistols/kaze-ux/pull/39) から派生（\`--kaze-*\` CSS vars を参照するため）。

## 設計判断

3 つの候補から boolean prop を選択:

| 案 | 評価 |
|---|---|
| ❌ \`variant='kaze'\` | 色軸 (default/outline/secondary) と衝突。「outline + kaze」が表現できない |
| ❌ \`<KazeButton />\` 別コンポーネント | 既存 API (asChild, size, variant) の重複実装コスト |
| ✅ \`kaze\` boolean prop | 既存 API そのまま、差分 6 行、段階移行中はノーリスク |

色/size と radius/motion/font は本質的に orthogonal な軸なので、flag で分離するのが自然。

## 実装

\`\`\`tsx
export interface ButtonProps extends ... {
  kaze?: boolean  // default false
}

const kazeStyle: React.CSSProperties = {
  borderRadius: 'var(--kaze-r-sharp)',
  fontFamily: 'var(--kaze-font-mono)',
  transitionProperty: 'background-color, color, border-color, transform',
  transitionDuration: 'var(--kaze-dur-micro)',
  transitionTimingFunction: 'var(--kaze-ease)',
  letterSpacing: '0.08em',
  textTransform: 'uppercase',
}

// ...
<button
  className={cn(buttonVariants({ variant, size, className }))}
  style={kaze ? { ...kazeStyle, ...style } : style}
/>
\`\`\`

CSS vars は \`:root\` / \`.dark\` で定義済み (PR #39) → dark mode も自動追従。

## 使用例

\`\`\`tsx
// 既存コード — 無変更
<Button variant='default'>Save</Button>

// 骨格 opt-in — 色はそのまま、radius/motion/font だけ骨格に
<Button variant='default' kaze>Request demo</Button>
<Button variant='outline' kaze>View docs</Button>
<Button variant='destructive' kaze size='sm'>Delete</Button>
\`\`\`

## Story 追加

- \`export const Kaze\`: 単体デモ（argTypes に kaze 追加）
- \`export const KazeMatrix\`: 6 variant × kaze のマトリクス確認

## 余談 — peer と並走でえた知見

別セッション（Matlens aeros-design-system）で MUI v9 wrapper に同じ悩みが出ており、向こうは **theme の \`styleOverrides.root.variants\` + \`props\` matcher** で Button 本体に触らず解決する方向。

\`\`\`ts
// MUI v9 構成での等価解
MuiButton: {
  styleOverrides: {
    root: {
      variants: [
        { props: { kaze: true }, style: { borderRadius: 'var(--kaze-r-sharp)', ... } },
      ]
    }
  }
}

declare module '@mui/material/Button' {
  interface ButtonPropsVariantOverrides { kaze: true }
}
\`\`\`

こちらは shadcn ベースで theme 層がないので直接追記したが、設計哲学は同じ（orthogonal boolean prop）。

## Test plan

- [x] \`pnpm build-storybook\`: 17.21s 成功
- [x] \`pnpm build-sandbox\`: 2.36s 成功
- [ ] Storybook の \`Components/UI/Button/TailwindButton\` で \`Kaze\` / \`KazeMatrix\` を開いて視覚確認
- [ ] dark mode で \`--kaze-r-sharp\` / transition が正常適用されていること

## 次の候補

- **#44**: Card / Typography にも同じ \`kaze\` opt-in
- **#45**: IconButton / ToggleButton / Chip への展開
- **#46 (preventive)**: \`.storybook/main.cjs\` の viteFinal に \`file://\` resolve plugin を追加（peer と共有した pnpm + SB10 MDX 回避）

🤖 Generated with [Claude Code](https://claude.com/claude-code)