### PR TITLE
feat(card): kaze opt-in と Context による子部品への自動波及

### DIFF
--- a/design-tokens/tokens.json
+++ b/design-tokens/tokens.json
@@ -2559,5 +2559,122 @@
         "$description": "矢印の表示"
       }
     }
+  },
+  "kaze": {
+    "$description": "Kaze 骨格トークン v0 — 『墨で書かれ、風で運ばれる』。既存トークンとは独立した additive namespace。",
+    "color": {
+      "kaze-teal": {
+        "$value": "#0EADB8",
+        "$type": "color",
+        "$description": "Primary / Action。ブランドの主役"
+      },
+      "sumi": {
+        "$value": "#0A0A0A",
+        "$type": "color",
+        "$description": "墨 — text / structure"
+      },
+      "washi": {
+        "$value": "#F7F4EE",
+        "$type": "color",
+        "$description": "和紙 — surface / rest。pure white 禁止の理由"
+      },
+      "asagi": {
+        "$value": "#5B8FB9",
+        "$type": "color",
+        "$description": "浅葱 — info / link。画面 5% 未満に制限"
+      },
+      "beni": {
+        "$value": "#E34E3A",
+        "$type": "color",
+        "$description": "紅 — alert / accent。画面 5% 未満に制限"
+      }
+    },
+    "ink": {
+      "primary": {
+        "$value": "rgba(10, 10, 10, 0.88)",
+        "$type": "color",
+        "$description": "washi 背景上の本文色"
+      },
+      "muted": {
+        "$value": "rgba(10, 10, 10, 0.54)",
+        "$type": "color",
+        "$description": "washi 背景上のミュート色"
+      },
+      "hair": {
+        "$value": "rgba(10, 10, 10, 0.12)",
+        "$type": "color",
+        "$description": "区切り線 (hair line)"
+      },
+      "mist": {
+        "$value": "rgba(10, 10, 10, 0.04)",
+        "$type": "color",
+        "$description": "背景上のうっすらした面 (mist)"
+      }
+    },
+    "radius": {
+      "sharp": {
+        "$value": "2px",
+        "$type": "dimension",
+        "$description": "button / input / chip / tab"
+      },
+      "soft": {
+        "$value": "8px",
+        "$type": "dimension",
+        "$description": "card / panel / popover"
+      },
+      "gen": {
+        "$value": "24px",
+        "$type": "dimension",
+        "$description": "modal / hero / section"
+      },
+      "full": {
+        "$value": "9999px",
+        "$type": "dimension",
+        "$description": "avatar / tag / pill のみ"
+      }
+    },
+    "motion": {
+      "ease": {
+        "kaze": {
+          "$value": "cubic-bezier(0.33, 0, 0, 1)",
+          "$type": "cubicBezier",
+          "$description": "単一採用。spring / bounce / overshoot は禁止"
+        }
+      },
+      "duration": {
+        "micro": {
+          "$value": "120ms",
+          "$type": "duration",
+          "$description": "hover / focus / toggle"
+        },
+        "macro": {
+          "$value": "240ms",
+          "$type": "duration",
+          "$description": "panel / tab / drawer"
+        },
+        "scene": {
+          "$value": "480ms",
+          "$type": "duration",
+          "$description": "modal / route / hero"
+        }
+      }
+    },
+    "font": {
+      "display": {
+        "$value": "'Fraunces', 'Shippori Mincho B1', 'Noto Serif JP', Georgia, serif",
+        "$type": "fontFamily",
+        "$description": "Variable axis: opsz 9-144, wght 300-900, SOFT 0-100, WONK 0-1"
+      },
+      "body": {
+        "$value": "'IBM Plex Sans', 'IBM Plex Sans JP', 'Hiragino Kaku Gothic ProN', sans-serif",
+        "$type": "fontFamily",
+        "$description": "日本語 + 英語 本文。line-height 1.7 推奨"
+      },
+      "mono": {
+        "$value": "'IBM Plex Mono', 'SFMono-Regular', Menlo, monospace",
+        "$type": "fontFamily",
+        "$description": "コード表示・メタデータ"
+      }
+    }
   }
 }

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -14,17 +14,42 @@ import * as React from 'react'
 
 import { cn } from '@/utils/className'
 
-const Card = React.forwardRef<HTMLDivElement, PaperProps>(
-  ({ className, ...props }, ref) => (
-    <Paper
-      ref={ref}
-      className={cn(
-        'rounded-lg border border-border bg-card text-card-foreground shadow-sm',
-        className
-      )}
-      elevation={0}
-      {...props}
-    />
+// Card 配下の subcomponent (Title/Description/etc) が kaze mode を
+// 明示 prop なしで参照できるようにする context。<Card kaze> だけ
+// で子要素全部が骨格タイポに切り替わる。
+const KazeContext = React.createContext(false)
+
+export interface CardProps extends PaperProps {
+  /**
+   * Kaze 骨格を opt-in で適用（token は #38-#39 参照）。
+   * - border-radius: var(--kaze-r-soft) (8px, card に適切)
+   * - transition: var(--kaze-dur-macro) var(--kaze-ease)
+   * - 配下の CardTitle / CardDescription も自動で Fraunces / Plex に切替
+   */
+  kaze?: boolean
+}
+
+const kazeCardStyle: React.CSSProperties = {
+  borderRadius: 'var(--kaze-r-soft)',
+  transitionProperty: 'border-color, box-shadow, transform',
+  transitionDuration: 'var(--kaze-dur-macro)',
+  transitionTimingFunction: 'var(--kaze-ease)',
+}
+
+const Card = React.forwardRef<HTMLDivElement, CardProps>(
+  ({ className, kaze = false, style, ...props }, ref) => (
+    <KazeContext.Provider value={kaze}>
+      <Paper
+        ref={ref}
+        className={cn(
+          'rounded-lg border border-border bg-card text-card-foreground shadow-sm',
+          className
+        )}
+        style={kaze ? { ...kazeCardStyle, ...style } : style}
+        elevation={0}
+        {...props}
+      />
+    </KazeContext.Provider>
   )
 )
 Card.displayName = 'Card'
@@ -41,30 +66,51 @@ const CardHeader = React.forwardRef<
 ))
 CardHeader.displayName = 'CardHeader'
 
+const kazeTitleStyle: React.CSSProperties = {
+  fontFamily: 'var(--kaze-font-display)',
+  fontWeight: 380,
+  letterSpacing: '-0.02em',
+  fontVariationSettings: "'opsz' 144, 'wght' 380, 'SOFT' 30, 'WONK' 0",
+}
+
 const CardTitle = React.forwardRef<HTMLParagraphElement, TypographyProps>(
-  ({ className, variant = 'h3', ...props }, ref) => (
-    <Typography
-      ref={ref}
-      variant={variant}
-      className={cn(
-        'text-2xl font-semibold leading-none tracking-tight',
-        className
-      )}
-      {...props}
-    />
-  )
+  ({ className, variant = 'h3', style, ...props }, ref) => {
+    const kaze = React.useContext(KazeContext)
+    return (
+      <Typography
+        ref={ref}
+        variant={variant}
+        className={cn(
+          'text-2xl font-semibold leading-none tracking-tight',
+          className
+        )}
+        style={kaze ? { ...kazeTitleStyle, ...style } : style}
+        {...props}
+      />
+    )
+  }
 )
 CardTitle.displayName = 'CardTitle'
 
+const kazeDescStyle: React.CSSProperties = {
+  fontFamily: 'var(--kaze-font-body)',
+  letterSpacing: '0.01em',
+  lineHeight: 1.65,
+}
+
 const CardDescription = React.forwardRef<HTMLParagraphElement, TypographyProps>(
-  ({ className, variant = 'body2', ...props }, ref) => (
-    <Typography
-      ref={ref}
-      variant={variant}
-      className={cn('text-sm text-muted-foreground', className)}
-      {...props}
-    />
-  )
+  ({ className, variant = 'body2', style, ...props }, ref) => {
+    const kaze = React.useContext(KazeContext)
+    return (
+      <Typography
+        ref={ref}
+        variant={variant}
+        className={cn('text-sm text-muted-foreground', className)}
+        style={kaze ? { ...kazeDescStyle, ...style } : style}
+        {...props}
+      />
+    )
+  }
 )
 CardDescription.displayName = 'CardDescription'
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,8 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Noto+Sans+JP:wght@400;500;700&display=swap');
 
+/* Kaze 骨格フォント (v0) — 既存 Inter/Noto と並行ロード。opt-in で使う */
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT,WONK@9..144,300..900,0..100,0..1&family=IBM+Plex+Sans:wght@300;400;500;600;700&family=IBM+Plex+Sans+JP:wght@300;400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap');
+
 @import 'tailwindcss/base';
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
@@ -48,6 +51,44 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  /* === Kaze 骨格 CSS 変数 (v0) ===
+   * 値の TypeScript ミラー: src/themes/kazeTokens.ts
+   * 既存 --color-* とは独立した additive な namespace。
+   * opt-in で使用: var(--kaze-teal), var(--kaze-r-sharp), etc.
+   */
+  --kaze-teal: #0eadb8;
+  --kaze-sumi: #0a0a0a;
+  --kaze-washi: #f7f4ee;
+  --kaze-asagi: #5b8fb9;
+  --kaze-beni: #e34e3a;
+  --kaze-ink: rgba(10, 10, 10, 0.88);
+  --kaze-ink-muted: rgba(10, 10, 10, 0.54);
+  --kaze-ink-hair: rgba(10, 10, 10, 0.12);
+  --kaze-ink-mist: rgba(10, 10, 10, 0.04);
+  --kaze-r-sharp: 2px;
+  --kaze-r-soft: 8px;
+  --kaze-r-gen: 24px;
+  --kaze-r-full: 9999px;
+  --kaze-ease: cubic-bezier(0.33, 0, 0, 1);
+  --kaze-dur-micro: 120ms;
+  --kaze-dur-macro: 240ms;
+  --kaze-dur-scene: 480ms;
+  --kaze-font-display:
+    'Fraunces', 'Shippori Mincho B1', 'Noto Serif JP', Georgia, serif;
+  --kaze-font-body:
+    'IBM Plex Sans', 'IBM Plex Sans JP', 'Hiragino Kaku Gothic ProN', sans-serif;
+  --kaze-font-mono: 'IBM Plex Mono', 'SFMono-Regular', Menlo, monospace;
+}
+
+/* Dark モードの ink/washi 反転（Kaze 骨格 dark 対応） */
+.dark {
+  --kaze-washi: #0a0a0a;
+  --kaze-sumi: #f7f4ee;
+  --kaze-ink: rgba(247, 244, 238, 0.88);
+  --kaze-ink-muted: rgba(247, 244, 238, 0.54);
+  --kaze-ink-hair: rgba(247, 244, 238, 0.12);
+  --kaze-ink-mist: rgba(247, 244, 238, 0.04);
 }
 
 /* Dark Theme Colors — colorToken.ts (Dracula scheme) と同期 */

--- a/src/themes/kazeTokens.ts
+++ b/src/themes/kazeTokens.ts
@@ -1,0 +1,92 @@
+/**
+ * Kaze 骨格トークン (v0)
+ *
+ * 「墨で書かれ、風で運ばれる」世界観を 4 軸で固定する single source of truth。
+ * 既存 MUI テーマ（primary/secondary/...）には触れず、additive に共存する。
+ * 新規コンポーネント・refresh 済み画面はこれを参照する。
+ *
+ * 参照: src/stories/01-DesignPhilosophy/KazeSkeleton.stories.tsx
+ */
+
+export const kazeTokens = {
+  color: {
+    kazeTeal: '#0EADB8',
+    sumi: '#0A0A0A',
+    washi: '#F7F4EE',
+    asagi: '#5B8FB9',
+    beni: '#E34E3A',
+  },
+  ink: {
+    primary: 'rgba(10, 10, 10, 0.88)',
+    muted: 'rgba(10, 10, 10, 0.54)',
+    hair: 'rgba(10, 10, 10, 0.12)',
+    mist: 'rgba(10, 10, 10, 0.04)',
+  },
+  radius: {
+    sharp: 2,
+    soft: 8,
+    gen: 24,
+    full: 9999,
+  },
+  motion: {
+    ease: {
+      kaze: 'cubic-bezier(0.33, 0, 0, 1)',
+    },
+    duration: {
+      micro: 120,
+      macro: 240,
+      scene: 480,
+    },
+  },
+  font: {
+    display:
+      "'Fraunces', 'Shippori Mincho B1', 'Noto Serif JP', Georgia, serif",
+    body: "'IBM Plex Sans', 'IBM Plex Sans JP', 'Hiragino Kaku Gothic ProN', sans-serif",
+    mono: "'IBM Plex Mono', 'SFMono-Regular', Menlo, monospace",
+  },
+  fontAxis: {
+    displayDefault: "'opsz' 144, 'wght' 380, 'SOFT' 30, 'WONK' 0",
+    displayEmphasis: "'opsz' 144, 'wght' 420, 'SOFT' 70, 'WONK' 1",
+  },
+} as const
+
+export type KazeTokens = typeof kazeTokens
+
+/**
+ * Google Fonts URL。Storybook preview-head / LP <head> / アプリ _document で
+ * 同一ソースを使う。
+ */
+export const KAZE_GOOGLE_FONTS_HREF =
+  'https://fonts.googleapis.com/css2' +
+  '?family=Fraunces:opsz,wght,SOFT,WONK@9..144,300..900,0..100,0..1' +
+  '&family=IBM+Plex+Sans:wght@300;400;500;600;700' +
+  '&family=IBM+Plex+Sans+JP:wght@300;400;500;600;700' +
+  '&family=IBM+Plex+Mono:wght@400;500;600' +
+  '&display=swap'
+
+/**
+ * CSS カスタムプロパティとして注入するための key-value マップ。
+ * :root や scope element に展開して使う。
+ */
+export const kazeCssVars: Record<string, string> = {
+  '--kaze-teal': kazeTokens.color.kazeTeal,
+  '--kaze-sumi': kazeTokens.color.sumi,
+  '--kaze-washi': kazeTokens.color.washi,
+  '--kaze-asagi': kazeTokens.color.asagi,
+  '--kaze-beni': kazeTokens.color.beni,
+  '--kaze-ink': kazeTokens.ink.primary,
+  '--kaze-ink-muted': kazeTokens.ink.muted,
+  '--kaze-ink-hair': kazeTokens.ink.hair,
+  '--kaze-ink-mist': kazeTokens.ink.mist,
+  '--kaze-r-sharp': `${kazeTokens.radius.sharp}px`,
+  '--kaze-r-soft': `${kazeTokens.radius.soft}px`,
+  '--kaze-r-gen': `${kazeTokens.radius.gen}px`,
+  '--kaze-r-full': `${kazeTokens.radius.full}px`,
+  '--kaze-ease': kazeTokens.motion.ease.kaze,
+  '--kaze-dur-micro': `${kazeTokens.motion.duration.micro}ms`,
+  '--kaze-dur-macro': `${kazeTokens.motion.duration.macro}ms`,
+  '--kaze-dur-scene': `${kazeTokens.motion.duration.scene}ms`,
+  '--kaze-font-display': kazeTokens.font.display,
+  '--kaze-font-body': kazeTokens.font.body,
+  '--kaze-font-mono': kazeTokens.font.mono,
+}


### PR DESCRIPTION
## 概要

shadcn-style Card (\`src/components/ui/Card.tsx\`) に Kaze 骨格を opt-in で適用する boolean prop \`kaze\` を追加。Card は compound 構造 (Card / CardHeader / CardTitle / CardDescription / CardContent / CardFooter) なので、**React Context で kaze モードを伝播**し、子部品が自動で骨格タイポに切り替わる。

## 依存

[PR #39 (fonts-global)](https://github.com/BoxPistols/kaze-ux/pull/39) から派生（\`--kaze-*\` CSS vars を参照）。

## 設計判断 — Button (#43) との違い

| コンポーネント | 設計 | 理由 |
|---|---|---|
| Button | 独立 boolean prop | 単一要素、Context 不要 |
| Card | \`kaze\` prop + KazeContext Provider | compound 構造、子 (Title/Desc) も骨格に寄せたい |

\`<Card kaze>\` と書くだけで、内側の \`<CardTitle>\` \`<CardDescription>\` が自動で Fraunces / Plex に変わる。これを独立 prop で書くと:

```tsx
// Context なしだと各子に毎回 kaze を渡す必要がある
<Card kaze>
  <CardHeader>
    <CardTitle kaze>...</CardTitle>
    <CardDescription kaze>...</CardDescription>
  </CardHeader>
</Card>
```

Context で kaze=true ひとつで波及:

```tsx
<Card kaze>
  <CardHeader>
    <CardTitle>...</CardTitle>   {/* 自動で Fraunces */}
    <CardDescription>...</CardDescription>  {/* 自動で Plex */}
  </CardHeader>
</Card>
```

## 実装

### Context（module-private）

\`\`\`tsx
const KazeContext = React.createContext(false)
\`\`\`

### Card wrapper

\`\`\`tsx
const kazeCardStyle = {
  borderRadius: 'var(--kaze-r-soft)',       // 8px
  transitionProperty: 'border-color, box-shadow, transform',
  transitionDuration: 'var(--kaze-dur-macro)', // 240ms
  transitionTimingFunction: 'var(--kaze-ease)',
}

<KazeContext.Provider value={kaze}>
  <Paper
    style={kaze ? { ...kazeCardStyle, ...style } : style}
    {...props}
  />
</KazeContext.Provider>
\`\`\`

### CardTitle（Context を読む）

\`\`\`tsx
const kazeTitleStyle = {
  fontFamily: 'var(--kaze-font-display)',   // Fraunces
  fontWeight: 380,
  letterSpacing: '-0.02em',
  fontVariationSettings: "'opsz' 144, 'wght' 380, 'SOFT' 30, 'WONK' 0",
}

const kaze = React.useContext(KazeContext)
<Typography
  style={kaze ? { ...kazeTitleStyle, ...style } : style}
  {...props}
/>
\`\`\`

### CardDescription

\`\`\`tsx
const kazeDescStyle = {
  fontFamily: 'var(--kaze-font-body)',      // Plex Sans JP
  letterSpacing: '0.01em',
  lineHeight: 1.65,
}
\`\`\`

## 既存への影響

- \`<Card>\` 呼び出しは全て無変更（\`kaze\` default false）
- CardHeader / CardContent / CardFooter は Context を無視、padding のみ担当
- Typography 型シグネチャ維持（既存テストすべて pass）
- KazeContext は module-private なので外部 API に影響しない

## Test plan

- [x] \`pnpm build-storybook\`: 成功
- [x] \`pnpm test:run\`: 324/324 pass (pre-push hook で検証)
- [ ] \`<Card kaze>\` で radius が 8px に、transition が 240ms ease-kaze になることを目視確認
- [ ] \`<CardTitle>\` が Fraunces variable axis で描画されていること
- [ ] \`<CardDescription>\` が Plex Sans JP になっていること
- [ ] dark mode で radius / transition が正常継承

## 次の候補

- **#45**: Typography / Input / IconButton への同パターン展開
- **#46 (preventive)**: Storybook MDX の \`file://\` resolve plugin 導入（peer 並走で発見した latent bug 予防）
- **#47**: Card 専用 story (\`TailwindCard.stories.tsx\`) を新規作成

🤖 Generated with [Claude Code](https://claude.com/claude-code)