### PR TITLE
fix(storybook): file:// URL 解決で pnpm + MDX の latent dev クラッシュを予防

### DIFF
--- a/.storybook/main.cjs
+++ b/.storybook/main.cjs
@@ -1,6 +1,29 @@
 const path = require('path')
+const { fileURLToPath } = require('node:url')
 
 const { mergeConfig, loadEnv } = require('vite')
+
+/**
+ * preventive: pnpm + Storybook 10 + MDX で addon-docs の MDX loader が
+ * `file:///...@storybook/addon-docs/dist/mdx-react-shim.js` のような
+ * file:// 絶対 URL で import を emit することがあり、Vite の
+ * `vite:import-analysis` がこれを解決できず dev server でクラッシュする
+ * (「Failed to fetch dynamically imported module」/「Failed to resolve import」)。
+ * build は Rollup 経由で通るので CI 緑のまま dev だけ死ぬ latent bug。
+ *
+ * 対処: resolveId フックで file:// prefix を fileURLToPath で通常パスに変換。
+ * 参考: Matlens (aeros-design-system) 並走診断 2026-04-20。
+ */
+const fileUrlResolvePlugin = {
+  name: 'kaze:resolve-file-url',
+  enforce: 'pre',
+  resolveId(source) {
+    if (typeof source === 'string' && source.startsWith('file://')) {
+      return fileURLToPath(source)
+    }
+    return null
+  },
+}
 
 // 環境変数を読み込む（.envファイルとprocess.envの両方から）
 const envFromFile = loadEnv(
@@ -50,6 +73,7 @@ const config = {
     const freshEnv = loadEnv(configType, path.resolve(__dirname, '..'), 'VITE_')
 
     return mergeConfig(config, {
+      plugins: [fileUrlResolvePlugin],
       resolve: {
         alias: {
           '@': path.resolve(__dirname, '../src'),


### PR DESCRIPTION
## 概要

Storybook 10 + pnpm + MDX の組み合わせで発生する latent バグを**踏む前に**塞ぐ preventive PR。Matlens (aeros-design-system) 並走診断 (2026-04-20) で得た知見を予防措置として kaze-ux にも適用する。

main ベースで独立、骨格 refactor stack とは無依存。

## 背景

### 症状
\`.mdx\` 入り Storybook を \`storybook dev\` で起動して MDX ページを開くと:
\`\`\`
Failed to fetch dynamically imported module:
http://localhost:6006/src/stories/Introduction.mdx?t=...

[plugin:vite:import-analysis] Failed to resolve import
"file:///.../node_modules/.pnpm/@storybook+addon-docs@10.3.5_.../mdx-react-shim.js"
from "src/stories/Introduction.mdx"
\`\`\`

### 原因
Storybook 10 の \`@storybook/addon-docs\` が pnpm の symlink 解決で **\`file:///\` 絶対 URL scheme の import** を emit する。Vite の \`vite:import-analysis\` plugin は \`file://\` を remote URL 扱いで解決を拒否する。

### build は通るが dev は死ぬ (非対称性)
- **build**: Rollup 経由 → \`file://\` を扱える、もしくは MDX loader が別経路
- **dev**: Vite ESM HMR server → \`import-analysis\` を厳密適用

結果: CI 緑 + 開発者も MDX タブを開いていないと永遠に気付かない latent バグ。

## 現状の kaze-ux

\`.mdx\` は **5 ファイル存在**:
- \`src/components/Table/index.mdx\`
- \`src/stories/02-DesignTokens/Breakpoints.mdx\`
- \`src/stories/02-DesignTokens/Spacing.mdx\`
- \`src/stories/02-DesignTokens/TokenList.mdx\`
- \`src/stories/02-DesignTokens/DarkMode.mdx\`

build は通るが、開発者が dev で MDX タブを開いたかどうかは未確認 (latent 可能性あり)。

## 修正

\`.storybook/main.cjs\` の viteFinal に resolveId フックを差し込み、\`file://\` prefix を \`fileURLToPath\` で通常パスに変換:

\`\`\`js
const { fileURLToPath } = require('node:url')

const fileUrlResolvePlugin = {
  name: 'kaze:resolve-file-url',
  enforce: 'pre',
  resolveId(source) {
    if (typeof source === 'string' && source.startsWith('file://')) {
      return fileURLToPath(source)
    }
    return null
  },
}

// viteFinal 内
return mergeConfig(config, {
  plugins: [fileUrlResolvePlugin],
  ...
})
\`\`\`

正規表現 alias 案ではなく resolveId フックにしたのは、addon-docs のバージョン変化や他プラグインが \`file://\` を emit した場合にも耐えるため (path-specific でなく URL scheme レベルで解決)。

## 既存への影響

- \`file://\` で始まる import が入っていないケースでは \`resolveId\` は null を返すだけで noop
- \`enforce: 'pre'\` なので他のプラグインより先に評価されるが、返り値 null ならスキップ
- 既存の \`build.target: 'esnext'\` / resolve.alias / define 設定はすべて温存

## Test plan

- [x] \`pnpm build-storybook\`: 成功 (plugin 無し状態と同じビルド結果)
- [ ] \`pnpm storybook\` dev で DesignTokens の MDX ページを開いて crash なく描画
- [ ] addon-docs 関連の dev HMR が通常動作
- [ ] 手元で \`rm -rf node_modules/.cache .vite\` しても再起動後 MDX が描画される

## 参考

peer (Matlens aeros-design-system) による確定診断:
- MDX loader の path emit 挙動
- build/dev 非対称性 (Rollup vs Vite import-analysis)
- resolveId フック解決策

詳細は memory \`reference_storybook_pnpm_mdx_file_url.md\` に保存済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)