### PR TITLE
feat(tag): StatusTag に kaze opt-in を追加

### DIFF
--- a/design-tokens/tokens.json
+++ b/design-tokens/tokens.json
@@ -2559,5 +2559,122 @@
         "$description": "矢印の表示"
       }
     }
+  },
+  "kaze": {
+    "$description": "Kaze 骨格トークン v0 — 『墨で書かれ、風で運ばれる』。既存トークンとは独立した additive namespace。",
+    "color": {
+      "kaze-teal": {
+        "$value": "#0EADB8",
+        "$type": "color",
+        "$description": "Primary / Action。ブランドの主役"
+      },
+      "sumi": {
+        "$value": "#0A0A0A",
+        "$type": "color",
+        "$description": "墨 — text / structure"
+      },
+      "washi": {
+        "$value": "#F7F4EE",
+        "$type": "color",
+        "$description": "和紙 — surface / rest。pure white 禁止の理由"
+      },
+      "asagi": {
+        "$value": "#5B8FB9",
+        "$type": "color",
+        "$description": "浅葱 — info / link。画面 5% 未満に制限"
+      },
+      "beni": {
+        "$value": "#E34E3A",
+        "$type": "color",
+        "$description": "紅 — alert / accent。画面 5% 未満に制限"
+      }
+    },
+    "ink": {
+      "primary": {
+        "$value": "rgba(10, 10, 10, 0.88)",
+        "$type": "color",
+        "$description": "washi 背景上の本文色"
+      },
+      "muted": {
+        "$value": "rgba(10, 10, 10, 0.54)",
+        "$type": "color",
+        "$description": "washi 背景上のミュート色"
+      },
+      "hair": {
+        "$value": "rgba(10, 10, 10, 0.12)",
+        "$type": "color",
+        "$description": "区切り線 (hair line)"
+      },
+      "mist": {
+        "$value": "rgba(10, 10, 10, 0.04)",
+        "$type": "color",
+        "$description": "背景上のうっすらした面 (mist)"
+      }
+    },
+    "radius": {
+      "sharp": {
+        "$value": "2px",
+        "$type": "dimension",
+        "$description": "button / input / chip / tab"
+      },
+      "soft": {
+        "$value": "8px",
+        "$type": "dimension",
+        "$description": "card / panel / popover"
+      },
+      "gen": {
+        "$value": "24px",
+        "$type": "dimension",
+        "$description": "modal / hero / section"
+      },
+      "full": {
+        "$value": "9999px",
+        "$type": "dimension",
+        "$description": "avatar / tag / pill のみ"
+      }
+    },
+    "motion": {
+      "ease": {
+        "kaze": {
+          "$value": "cubic-bezier(0.33, 0, 0, 1)",
+          "$type": "cubicBezier",
+          "$description": "単一採用。spring / bounce / overshoot は禁止"
+        }
+      },
+      "duration": {
+        "micro": {
+          "$value": "120ms",
+          "$type": "duration",
+          "$description": "hover / focus / toggle"
+        },
+        "macro": {
+          "$value": "240ms",
+          "$type": "duration",
+          "$description": "panel / tab / drawer"
+        },
+        "scene": {
+          "$value": "480ms",
+          "$type": "duration",
+          "$description": "modal / route / hero"
+        }
+      }
+    },
+    "font": {
+      "display": {
+        "$value": "'Fraunces', 'Shippori Mincho B1', 'Noto Serif JP', Georgia, serif",
+        "$type": "fontFamily",
+        "$description": "Variable axis: opsz 9-144, wght 300-900, SOFT 0-100, WONK 0-1"
+      },
+      "body": {
+        "$value": "'IBM Plex Sans', 'IBM Plex Sans JP', 'Hiragino Kaku Gothic ProN', sans-serif",
+        "$type": "fontFamily",
+        "$description": "日本語 + 英語 本文。line-height 1.7 推奨"
+      },
+      "mono": {
+        "$value": "'IBM Plex Mono', 'SFMono-Regular', Menlo, monospace",
+        "$type": "fontFamily",
+        "$description": "コード表示・メタデータ"
+      }
+    }
   }
 }

--- a/src/components/ui/chip/customChip.tsx
+++ b/src/components/ui/chip/customChip.tsx
@@ -1,11 +1,31 @@
 import { Chip, type ChipProps } from '@mui/material'
 
-export type CustomChipProps = ChipProps
+import { KAZE_MONO_LABEL, KAZE_SHARP_UI } from '@/themes/kazeMixins'
+
+export interface CustomChipProps extends ChipProps {
+  /**
+   * Kaze 骨格を opt-in で適用（token は #38-#39 参照）。
+   * - border-radius: var(--kaze-r-sharp) (2px, skeleton 定義どおり)
+   * - transition: var(--kaze-dur-micro) var(--kaze-ease)
+   * - font: Plex Mono + letter-spacing + uppercase
+   */
+  kaze?: boolean
+}
 
 /**
  * カスタムチップコンポーネント
  * テーマスタイルを適用したシンプルなChipラッパー
  */
-export const CustomChip = ({ ...props }: CustomChipProps) => {
-  return <Chip size='medium' {...props} />
+export const CustomChip = ({
+  kaze = false,
+  sx,
+  ...props
+}: CustomChipProps) => {
+  return (
+    <Chip
+      size='medium'
+      sx={kaze ? [{ ...KAZE_SHARP_UI, ...KAZE_MONO_LABEL }, sx ?? false] : sx}
+      {...props}
+    />
+  )
 }

--- a/src/components/ui/tag/statusTag.tsx
+++ b/src/components/ui/tag/statusTag.tsx
@@ -2,6 +2,8 @@
 // StatusTagコンポーネント
 import { Chip, type SxProps, type Theme } from '@mui/material'
 
+import { KAZE_MONO_LABEL, KAZE_SHARP_UI } from '@/themes/kazeMixins'
+
 /** ステータスの種類 */
 export type StatusType =
   | 'draft'
@@ -19,6 +21,12 @@ export interface StatusTagProps {
   status: StatusType
   /** カスタムスタイル */
   sx?: SxProps<Theme>
+  /**
+   * Kaze 骨格を opt-in で適用（token は #38-#39 参照）。
+   * - border-radius: var(--kaze-r-sharp) (2px, pill から角に)
+   * - font: Plex Mono + letter-spacing + uppercase
+   */
+  kaze?: boolean
 }
 
 // ステータスごとのスタイル定義（テーマパレット参照）
@@ -63,26 +71,27 @@ const statusStyles: Record<
   },
 }
 
-export const StatusTag = ({ text, status, sx }: StatusTagProps) => {
+export const StatusTag = ({ text, status, sx, kaze = false }: StatusTagProps) => {
   const style = statusStyles[status] || statusStyles.draft
+
+  const baseSx = {
+    ...style,
+    borderRadius: kaze ? 'var(--kaze-r-sharp)' : '16px',
+    borderWidth: '1px',
+    fontSize: '10px',
+    fontWeight: 'bold',
+    height: 'auto',
+    '& .MuiChip-label': {
+      padding: '1px 6px',
+    },
+  }
 
   return (
     <Chip
       label={text}
       size='small'
       variant='outlined'
-      sx={{
-        ...style,
-        borderRadius: '16px',
-        borderWidth: '1px',
-        fontSize: '10px',
-        fontWeight: 'bold',
-        height: 'auto',
-        '& .MuiChip-label': {
-          padding: '1px 6px',
-        },
-        ...sx,
-      }}
+      sx={kaze ? [baseSx, KAZE_SHARP_UI, KAZE_MONO_LABEL, sx ?? false] : { ...baseSx, ...sx }}
     />
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,8 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Noto+Sans+JP:wght@400;500;700&display=swap');
 
+/* Kaze 骨格フォント (v0) — 既存 Inter/Noto と並行ロード。opt-in で使う */
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT,WONK@9..144,300..900,0..100,0..1&family=IBM+Plex+Sans:wght@300;400;500;600;700&family=IBM+Plex+Sans+JP:wght@300;400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap');
+
 @import 'tailwindcss/base';
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
@@ -48,6 +51,44 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  /* === Kaze 骨格 CSS 変数 (v0) ===
+   * 値の TypeScript ミラー: src/themes/kazeTokens.ts
+   * 既存 --color-* とは独立した additive な namespace。
+   * opt-in で使用: var(--kaze-teal), var(--kaze-r-sharp), etc.
+   */
+  --kaze-teal: #0eadb8;
+  --kaze-sumi: #0a0a0a;
+  --kaze-washi: #f7f4ee;
+  --kaze-asagi: #5b8fb9;
+  --kaze-beni: #e34e3a;
+  --kaze-ink: rgba(10, 10, 10, 0.88);
+  --kaze-ink-muted: rgba(10, 10, 10, 0.54);
+  --kaze-ink-hair: rgba(10, 10, 10, 0.12);
+  --kaze-ink-mist: rgba(10, 10, 10, 0.04);
+  --kaze-r-sharp: 2px;
+  --kaze-r-soft: 8px;
+  --kaze-r-gen: 24px;
+  --kaze-r-full: 9999px;
+  --kaze-ease: cubic-bezier(0.33, 0, 0, 1);
+  --kaze-dur-micro: 120ms;
+  --kaze-dur-macro: 240ms;
+  --kaze-dur-scene: 480ms;
+  --kaze-font-display:
+    'Fraunces', 'Shippori Mincho B1', 'Noto Serif JP', Georgia, serif;
+  --kaze-font-body:
+    'IBM Plex Sans', 'IBM Plex Sans JP', 'Hiragino Kaku Gothic ProN', sans-serif;
+  --kaze-font-mono: 'IBM Plex Mono', 'SFMono-Regular', Menlo, monospace;
+}
+
+/* Dark モードの ink/washi 反転（Kaze 骨格 dark 対応） */
+.dark {
+  --kaze-washi: #0a0a0a;
+  --kaze-sumi: #f7f4ee;
+  --kaze-ink: rgba(247, 244, 238, 0.88);
+  --kaze-ink-muted: rgba(247, 244, 238, 0.54);
+  --kaze-ink-hair: rgba(247, 244, 238, 0.12);
+  --kaze-ink-mist: rgba(247, 244, 238, 0.04);
 }
 
 /* Dark Theme Colors — colorToken.ts (Dracula scheme) と同期 */

--- a/src/themes/kazeMixins.ts
+++ b/src/themes/kazeMixins.ts
@@ -1,0 +1,83 @@
+/**
+ * Kaze 骨格スタイル mixin 集
+ *
+ * 各コンポーネントの kaze opt-in 実装で import してスプレッドで使う。
+ * 同じ style object を 3 回以上書く前にここに集約する。
+ *
+ * CSS 変数は src/index.css の :root / .dark で定義済み (PR #39)。
+ * 値の TS ミラーは src/themes/kazeTokens.ts (PR #38)。
+ */
+
+import type { CSSProperties } from 'react'
+
+// ============================================================
+// radius + transition セット — UI 階層別
+// ============================================================
+
+/** button / input / chip / tab 用: sharp radius + micro duration */
+export const KAZE_SHARP_UI: CSSProperties = {
+  borderRadius: 'var(--kaze-r-sharp)',
+  transitionProperty: 'background-color, color, border-color, transform',
+  transitionDuration: 'var(--kaze-dur-micro)',
+  transitionTimingFunction: 'var(--kaze-ease)',
+}
+
+/** card / panel / popover 用: soft radius + macro duration */
+export const KAZE_SOFT_CARD: CSSProperties = {
+  borderRadius: 'var(--kaze-r-soft)',
+  transitionProperty: 'border-color, box-shadow, transform',
+  transitionDuration: 'var(--kaze-dur-macro)',
+  transitionTimingFunction: 'var(--kaze-ease)',
+}
+
+/** modal / hero / section 用: generous radius + scene duration */
+export const KAZE_GEN_SURFACE: CSSProperties = {
+  borderRadius: 'var(--kaze-r-gen)',
+  transitionProperty: 'transform, opacity',
+  transitionDuration: 'var(--kaze-dur-scene)',
+  transitionTimingFunction: 'var(--kaze-ease)',
+}
+
+// ============================================================
+// typography セット — role 別
+// ============================================================
+
+/** CTA ラベル・eyebrow ラベル等: Plex Mono + uppercase + wide tracking */
+export const KAZE_MONO_LABEL: CSSProperties = {
+  fontFamily: 'var(--kaze-font-mono)',
+  letterSpacing: '0.08em',
+  textTransform: 'uppercase',
+}
+
+/** eyebrow 専用: Mono + さらに広い tracking + 小さいサイズ想定 */
+export const KAZE_EYEBROW: CSSProperties = {
+  fontFamily: 'var(--kaze-font-mono)',
+  fontSize: '0.75rem',
+  fontWeight: 500,
+  letterSpacing: '0.24em',
+  textTransform: 'uppercase',
+}
+
+/** display 見出し: Fraunces Variable + 基調 axis */
+export const KAZE_DISPLAY: CSSProperties = {
+  fontFamily: 'var(--kaze-font-display)',
+  fontWeight: 380,
+  letterSpacing: '-0.02em',
+  fontVariationSettings: "'opsz' 144, 'wght' 380, 'SOFT' 30, 'WONK' 0",
+}
+
+/** display 強調 (italic + WONK): "Infinite" のような accent word 用 */
+export const KAZE_DISPLAY_EMPHASIS: CSSProperties = {
+  fontFamily: 'var(--kaze-font-display)',
+  fontStyle: 'italic',
+  fontWeight: 420,
+  letterSpacing: '-0.02em',
+  fontVariationSettings: "'opsz' 144, 'wght' 420, 'SOFT' 70, 'WONK' 1",
+}
+
+/** body text: Plex Sans + 日本語の呼吸 */
+export const KAZE_BODY: CSSProperties = {
+  fontFamily: 'var(--kaze-font-body)',
+  letterSpacing: '0.02em',
+  lineHeight: 1.7,
+}

--- a/src/themes/kazeTokens.ts
+++ b/src/themes/kazeTokens.ts
@@ -1,0 +1,92 @@
+/**
+ * Kaze 骨格トークン (v0)
+ *
+ * 「墨で書かれ、風で運ばれる」世界観を 4 軸で固定する single source of truth。
+ * 既存 MUI テーマ（primary/secondary/...）には触れず、additive に共存する。
+ * 新規コンポーネント・refresh 済み画面はこれを参照する。
+ *
+ * 参照: src/stories/01-DesignPhilosophy/KazeSkeleton.stories.tsx
+ */
+
+export const kazeTokens = {
+  color: {
+    kazeTeal: '#0EADB8',
+    sumi: '#0A0A0A',
+    washi: '#F7F4EE',
+    asagi: '#5B8FB9',
+    beni: '#E34E3A',
+  },
+  ink: {
+    primary: 'rgba(10, 10, 10, 0.88)',
+    muted: 'rgba(10, 10, 10, 0.54)',
+    hair: 'rgba(10, 10, 10, 0.12)',
+    mist: 'rgba(10, 10, 10, 0.04)',
+  },
+  radius: {
+    sharp: 2,
+    soft: 8,
+    gen: 24,
+    full: 9999,
+  },
+  motion: {
+    ease: {
+      kaze: 'cubic-bezier(0.33, 0, 0, 1)',
+    },
+    duration: {
+      micro: 120,
+      macro: 240,
+      scene: 480,
+    },
+  },
+  font: {
+    display:
+      "'Fraunces', 'Shippori Mincho B1', 'Noto Serif JP', Georgia, serif",
+    body: "'IBM Plex Sans', 'IBM Plex Sans JP', 'Hiragino Kaku Gothic ProN', sans-serif",
+    mono: "'IBM Plex Mono', 'SFMono-Regular', Menlo, monospace",
+  },
+  fontAxis: {
+    displayDefault: "'opsz' 144, 'wght' 380, 'SOFT' 30, 'WONK' 0",
+    displayEmphasis: "'opsz' 144, 'wght' 420, 'SOFT' 70, 'WONK' 1",
+  },
+} as const
+
+export type KazeTokens = typeof kazeTokens
+
+/**
+ * Google Fonts URL。Storybook preview-head / LP <head> / アプリ _document で
+ * 同一ソースを使う。
+ */
+export const KAZE_GOOGLE_FONTS_HREF =
+  'https://fonts.googleapis.com/css2' +
+  '?family=Fraunces:opsz,wght,SOFT,WONK@9..144,300..900,0..100,0..1' +
+  '&family=IBM+Plex+Sans:wght@300;400;500;600;700' +
+  '&family=IBM+Plex+Sans+JP:wght@300;400;500;600;700' +
+  '&family=IBM+Plex+Mono:wght@400;500;600' +
+  '&display=swap'
+
+/**
+ * CSS カスタムプロパティとして注入するための key-value マップ。
+ * :root や scope element に展開して使う。
+ */
+export const kazeCssVars: Record<string, string> = {
+  '--kaze-teal': kazeTokens.color.kazeTeal,
+  '--kaze-sumi': kazeTokens.color.sumi,
+  '--kaze-washi': kazeTokens.color.washi,
+  '--kaze-asagi': kazeTokens.color.asagi,
+  '--kaze-beni': kazeTokens.color.beni,
+  '--kaze-ink': kazeTokens.ink.primary,
+  '--kaze-ink-muted': kazeTokens.ink.muted,
+  '--kaze-ink-hair': kazeTokens.ink.hair,
+  '--kaze-ink-mist': kazeTokens.ink.mist,
+  '--kaze-r-sharp': `${kazeTokens.radius.sharp}px`,
+  '--kaze-r-soft': `${kazeTokens.radius.soft}px`,
+  '--kaze-r-gen': `${kazeTokens.radius.gen}px`,
+  '--kaze-r-full': `${kazeTokens.radius.full}px`,
+  '--kaze-ease': kazeTokens.motion.ease.kaze,
+  '--kaze-dur-micro': `${kazeTokens.motion.duration.micro}ms`,
+  '--kaze-dur-macro': `${kazeTokens.motion.duration.macro}ms`,
+  '--kaze-dur-scene': `${kazeTokens.motion.duration.scene}ms`,
+  '--kaze-font-display': kazeTokens.font.display,
+  '--kaze-font-body': kazeTokens.font.body,
+  '--kaze-font-mono': kazeTokens.font.mono,
+}


### PR DESCRIPTION
## 概要

\`StatusTag\` に \`kaze\` boolean prop を追加。pill (16px) から骨格 sharp (2px) + Plex Mono uppercase に切替可能。

## 依存

[PR #46 (chip + kazeMixins)](https://github.com/BoxPistols/kaze-ux/pull/46) から派生（\`KAZE_SHARP_UI\` / \`KAZE_MONO_LABEL\` mixin を参照）。

## 変更

\`\`\`ts
import { KAZE_MONO_LABEL, KAZE_SHARP_UI } from '@/themes/kazeMixins'

// Props
kaze?: boolean  // default false

// render
sx={kaze
  ? [baseSx, KAZE_SHARP_UI, KAZE_MONO_LABEL, sx ?? false]
  : { ...baseSx, ...sx }
}
\`\`\`

kaze=true で:
- \`borderRadius\`: 16px → \`var(--kaze-r-sharp)\` (2px)
- \`fontFamily\` → \`var(--kaze-font-mono)\`
- \`letterSpacing\` → 0.08em
- \`textTransform\` → uppercase
- \`transition\` → 120ms cubic-bezier(0.33, 0, 0, 1)

## 温存

既存 7 status (draft/submitted/approved/rejected/pending/active/inactive) のカラー、\`fontSize: 10px\`、\`fontWeight: bold\`、\`'& .MuiChip-label'\` padding、既存 sx 合成はすべて維持。

## Test plan

- [x] \`pnpm build-storybook\`: 成功
- [ ] \`<StatusTag text='Approved' status='approved' kaze />\` で角 + mono 適用確認
- [ ] 7 status すべて kaze と直交して動作
- [ ] dark mode で読みやすさ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)