### PR TITLE
fix(ds): sx 配列型の不一致を解消 (Chip / StatusTag / ToggleButton)

### DIFF
--- a/src/components/ui/chip/customChip.tsx
+++ b/src/components/ui/chip/customChip.tsx
@@ -24,7 +24,14 @@ export const CustomChip = ({
   return (
     <Chip
       size='medium'
-      sx={kaze ? [{ ...KAZE_SHARP_UI, ...KAZE_MONO_LABEL }, sx ?? false] : sx}
+      sx={
+        kaze
+          ? [
+              { ...KAZE_SHARP_UI, ...KAZE_MONO_LABEL },
+              ...(Array.isArray(sx) ? sx : sx ? [sx] : []),
+            ]
+          : sx
+      }
       {...props}
     />
   )

--- a/src/components/ui/tag/statusTag.tsx
+++ b/src/components/ui/tag/statusTag.tsx
@@ -91,7 +91,16 @@ export const StatusTag = ({ text, status, sx, kaze = false }: StatusTagProps) =>
       label={text}
       size='small'
       variant='outlined'
-      sx={kaze ? [baseSx, KAZE_SHARP_UI, KAZE_MONO_LABEL, sx ?? false] : { ...baseSx, ...sx }}
+      sx={
+        kaze
+          ? [
+              baseSx,
+              KAZE_SHARP_UI,
+              KAZE_MONO_LABEL,
+              ...(Array.isArray(sx) ? sx : sx ? [sx] : []),
+            ]
+          : { ...baseSx, ...sx }
+      }
     />
   )
 }

--- a/src/components/ui/toggle-button/toggleButton.tsx
+++ b/src/components/ui/toggle-button/toggleButton.tsx
@@ -85,7 +85,11 @@ export const ToggleButton = forwardRef<HTMLButtonElement, ToggleButtonProps>(
       <MuiToggleButton
         ref={ref}
         color={color}
-        sx={kaze ? [baseSx, sx ?? false] : { ...baseSx, ...sx }}
+        sx={
+          kaze
+            ? [baseSx, ...(Array.isArray(sx) ? sx : sx ? [sx] : [])]
+            : { ...baseSx, ...sx }
+        }
         {...props}>
         {children}
       </MuiToggleButton>


### PR DESCRIPTION
## 概要

PR #46 / #48 / #49 で導入した \`kaze\` opt-in の \`sx\` 配列合成で、\`sx ?? false\` と書いていた箇所が MUI v7 の \`SxProps\` 型と非互換で tsc エラーを発生させていた (build は通るが \`tsc --noEmit\` が fail)。

\`\`\`
error TS2769: No overload matches this call.
Type '(false | SystemCssProperties<Theme> | ...)' is not assignable to type 'SxProps<Theme>'
Index signature for type 'string' is missing...
\`\`\`

## 原因

\`sx\` プロパティは \`SxProps<Theme> | SxProps<Theme>[]\` を受け付けるが、**配列要素に \`false\` を含めることは許されない**。"optional な合成" のつもりで書いた \`sx ?? false\` が要素として無効だった。

## 修正

\`\`\`diff
- sx={kaze ? [kazeStyle, sx ?? false] : sx}
+ sx={
+   kaze
+     ? [kazeStyle, ...(Array.isArray(sx) ? sx : sx ? [sx] : [])]
+     : sx
+ }
\`\`\`

3 ファイル同パターンで修正:
- \`src/components/ui/chip/customChip.tsx\`
- \`src/components/ui/tag/statusTag.tsx\`
- \`src/components/ui/toggle-button/toggleButton.tsx\`

## Test plan

- [x] \`pnpm exec tsc --noEmit\`: エラー 0 (3 → 0)
- [x] \`pnpm test:run\`: 324/324 pass
- [x] \`pnpm build-sandbox\`: 成功
- [ ] kaze=true / kaze=false どちらでも sx 合成が動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 複数の UI コンポーネント（Chip、StatusTag、ToggleButton）のスタイル適用ロジックを改善しました。カスタムスタイルがより正確かつ一貫性を持って反映されるようになり、コンポーネント表示の信頼性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->