### PR TITLE
feat(saas-dashboard): KPI カードに kaze 骨格タイポを適用

### DIFF
--- a/apps/saas-dashboard/src/pages/DashboardPage.tsx
+++ b/apps/saas-dashboard/src/pages/DashboardPage.tsx
@@ -18,6 +18,7 @@ import { Fab } from '@/components/ui/fab'
 import { StatusTag } from '@/components/ui/tag'
 import type { StatusType } from '@/components/ui/tag'
 import { PageHeader } from '@/components/ui/text'
+import { KAZE_DISPLAY, KAZE_EYEBROW } from '@/themes/kazeMixins'
 
 import { activities } from '~/data/activity'
 import { kpiCards } from '~/data/kpi'
@@ -120,12 +121,21 @@ export const DashboardPage = () => {
                       <Typography
                         variant='body2'
                         color='text.secondary'
-                        sx={{ mb: 0.5, fontWeight: 500 }}>
+                        sx={{
+                          ...KAZE_EYEBROW,
+                          mb: 0.75,
+                          fontSize: '0.68rem',
+                          color: 'text.secondary',
+                        }}>
                         {kpi.title}
                       </Typography>
                       <Typography
                         variant='h4'
-                        sx={{ fontWeight: 800, letterSpacing: '-0.02em' }}>
+                        sx={{
+                          ...KAZE_DISPLAY,
+                          fontSize: { xs: '1.9rem', sm: '2.2rem' },
+                          letterSpacing: '-0.025em',
+                        }}>
                         {kpi.value}
                       </Typography>
                       <Box


### PR DESCRIPTION
## 概要

SaaS Dashboard (\`apps/saas-dashboard\`) 側で初の kaze 適用。\`DashboardPage\` 最上部の KPI カード 4 枚のタイポグラフィを骨格に寄せる。最小スコープで apps 層の骨格 adoption を始める第 1 歩。

## 変更

\`\`\`diff
  import { PageHeader } from '@/components/ui/text'
+ import { KAZE_DISPLAY, KAZE_EYEBROW } from '@/themes/kazeMixins'

  <Typography variant='body2' color='text.secondary'
-   sx={{ mb: 0.5, fontWeight: 500 }}>
+   sx={{
+     ...KAZE_EYEBROW,
+     mb: 0.75,
+     fontSize: '0.68rem',
+     color: 'text.secondary',
+   }}>
    {kpi.title}
  </Typography>

  <Typography variant='h4'
-   sx={{ fontWeight: 800, letterSpacing: '-0.02em' }}>
+   sx={{
+     ...KAZE_DISPLAY,
+     fontSize: { xs: '1.9rem', sm: '2.2rem' },
+     letterSpacing: '-0.025em',
+   }}>
    {kpi.value}
  </Typography>
\`\`\`

## 変化

- **KPI タイトル**: Inter 500 → **Plex Mono + 0.24em tracking** + 小さく (0.68rem) 落として "版の上付き" の質感に
- **KPI 値**: Inter 800 → **Fraunces Variable** (opsz 144 / wght 380 / SOFT 30 / WONK 0) で 2.2rem に拡大

4 つの大きな数字が一気に editorial なプレゼンスを獲得、上のラベルはタイポグラフィックな "meta" として沈む。dashboard の第一印象が stock admin → editorial publishing に転ずる。

## 温存

- レイアウト / grid / アイコン config (kpiIconConfig) 無変更
- trend chip (+12% / -3%) 部分の色・動きすべて温存
- hover シャドウアニメーション温存
- dark mode 自動追従 (CSS var 経由)
- 既存 Card / CustomChip / StatusTag 呼び出し箇所は kaze prop を付けていないのでデフォルト挙動のまま

## Test plan

- [x] \`pnpm --filter saas-dashboard exec vite build\`: 7.01s 成功
- [ ] \`pnpm dev:dashboard\` → /dashboard で KPI 値が Fraunces、タイトルが Plex Mono になっているか目視確認
- [ ] dark mode でのコントラスト確認
- [ ] レスポンシブ (xs = 1.9rem / sm = 2.2rem) が両方動く

## 次の候補

- **Dashboard の他セクション** (Recent Activity / Projects / Team Online 等) の見出しに KAZE_EYEBROW 適用
- **PageHeader** をカスタム prop で骨格寄せ (shared component の拡張)
- 他ページ (ProjectsPage / InvoicesPage / ReportsPage) への展開

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Style（スタイル改善）**
  * ダッシュボードページのKPIカードのタイポグラフィスタイルを更新し、より一貫性のある視覚表現を実現しました。カードのタイトルと数値の表示が改善されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->