### PR TITLE
refactor(mixins): kazeMixins をドメイン語彙に昇格 (STAMP / LEAF / SPREAD / PRINT / META / ACCENT / RUN)

### DIFF
--- a/apps/saas-dashboard/src/pages/DashboardPage.tsx
+++ b/apps/saas-dashboard/src/pages/DashboardPage.tsx
@@ -18,7 +18,7 @@ import { Fab } from '@/components/ui/fab'
 import { StatusTag } from '@/components/ui/tag'
 import type { StatusType } from '@/components/ui/tag'
 import { PageHeader } from '@/components/ui/text'
-import { KAZE_DISPLAY, KAZE_EYEBROW } from '@/themes/kazeMixins'
+import { KAZE_EYEBROW, KAZE_PRINT } from '@/themes/kazeMixins'
 
 import { activities } from '~/data/activity'
 import { kpiCards } from '~/data/kpi'
@@ -132,7 +132,7 @@ export const DashboardPage = () => {
                       <Typography
                         variant='h4'
                         sx={{
-                          ...KAZE_DISPLAY,
+                          ...KAZE_PRINT,
                           fontSize: { xs: '1.9rem', sm: '2.2rem' },
                           letterSpacing: '-0.025em',
                         }}>

--- a/src/components/ui/chip/customChip.tsx
+++ b/src/components/ui/chip/customChip.tsx
@@ -1,6 +1,6 @@
 import { Chip, type ChipProps } from '@mui/material'
 
-import { KAZE_MONO_LABEL, KAZE_SHARP_UI } from '@/themes/kazeMixins'
+import { KAZE_META, KAZE_STAMP } from '@/themes/kazeMixins'
 
 export interface CustomChipProps extends ChipProps {
   /**
@@ -27,7 +27,7 @@ export const CustomChip = ({
       sx={
         kaze
           ? [
-              { ...KAZE_SHARP_UI, ...KAZE_MONO_LABEL },
+              { ...KAZE_STAMP, ...KAZE_META },
               ...(Array.isArray(sx) ? sx : sx ? [sx] : []),
             ]
           : sx

--- a/src/components/ui/icon-button/iconButton.tsx
+++ b/src/components/ui/icon-button/iconButton.tsx
@@ -10,7 +10,7 @@ import {
 } from '@mui/material'
 import { forwardRef } from 'react'
 
-import { KAZE_SHARP_UI } from '@/themes/kazeMixins'
+import { KAZE_STAMP } from '@/themes/kazeMixins'
 
 import {
   BUTTON_BORDER_RADIUS,
@@ -178,7 +178,7 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
         aria-label={accessibleLabel}
         sx={[
           kaze
-            ? KAZE_SHARP_UI
+            ? KAZE_STAMP
             : {
                 borderRadius: BUTTON_BORDER_RADIUS,
                 transition: BUTTON_TRANSITION,

--- a/src/components/ui/tag/statusTag.tsx
+++ b/src/components/ui/tag/statusTag.tsx
@@ -2,7 +2,7 @@
 // StatusTagコンポーネント
 import { Chip, type SxProps, type Theme } from '@mui/material'
 
-import { KAZE_MONO_LABEL, KAZE_SHARP_UI } from '@/themes/kazeMixins'
+import { KAZE_META, KAZE_STAMP } from '@/themes/kazeMixins'
 
 /** ステータスの種類 */
 export type StatusType =
@@ -95,8 +95,8 @@ export const StatusTag = ({ text, status, sx, kaze = false }: StatusTagProps) =>
         kaze
           ? [
               baseSx,
-              KAZE_SHARP_UI,
-              KAZE_MONO_LABEL,
+              KAZE_STAMP,
+              KAZE_META,
               ...(Array.isArray(sx) ? sx : sx ? [sx] : []),
             ]
           : { ...baseSx, ...sx }

--- a/src/components/ui/toggle-button/toggleButton.tsx
+++ b/src/components/ui/toggle-button/toggleButton.tsx
@@ -11,7 +11,7 @@ import {
 } from '@mui/material'
 import { forwardRef, type ReactNode } from 'react'
 
-import { KAZE_SHARP_UI } from '@/themes/kazeMixins'
+import { KAZE_STAMP } from '@/themes/kazeMixins'
 
 // ToggleButton Props
 export interface ToggleButtonProps extends Omit<MuiToggleButtonProps, 'color'> {
@@ -71,7 +71,7 @@ export const ToggleButton = forwardRef<HTMLButtonElement, ToggleButtonProps>(
     ref
   ) => {
     const baseSx = kaze
-      ? { ...KAZE_SHARP_UI, '&.Mui-selected': { fontWeight: 600 } }
+      ? { ...KAZE_STAMP, '&.Mui-selected': { fontWeight: 600 } }
       : {
           textTransform: 'none' as const,
           borderRadius: 1.5,

--- a/src/themes/kazeMixins.ts
+++ b/src/themes/kazeMixins.ts
@@ -1,37 +1,48 @@
 /**
  * Kaze 骨格スタイル mixin 集
  *
- * 各コンポーネントの kaze opt-in 実装で import してスプレッドで使う。
- * 同じ style object を 3 回以上書く前にここに集約する。
+ * ドメイン語彙で命名する。UI 階層の「何に使うか」を機械分類
+ * (SHARP_UI / SOFT_CARD) で呼ぶのではなく、編集デザインの
+ * メタファーで呼ぶ。Matlens aeros-design-system 並走の助言 2026-04-20。
  *
- * CSS 変数は src/index.css の :root / .dark で定義済み (PR #39)。
+ * 対応表:
+ *   STAMP  (印・判)     → button / chip / input / tab / icon-button
+ *   LEAF   (一葉)       → card / panel / popover
+ *   SPREAD (見開き)      → modal / hero / section
+ *   PRINT  (活字)       → display 見出し
+ *   ACCENT (強調)       → 強調語 (italic + WONK)
+ *   META   (メタ表示)    → CTA ラベル・小さな mono 表記
+ *   EYEBROW(袖見出し)    → section 上の小ラベル (editorial 標準語)
+ *   RUN    (本文)       → 通常本文
+ *
+ * CSS 変数は src/index.css の :root / .dark で定義 (PR #39)。
  * 値の TS ミラーは src/themes/kazeTokens.ts (PR #38)。
  */
 
 import type { CSSProperties } from 'react'
 
 // ============================================================
-// radius + transition セット — UI 階層別
+// 接地 (radius + transition) — 何に「押される」か
 // ============================================================
 
-/** button / input / chip / tab 用: sharp radius + micro duration */
-export const KAZE_SHARP_UI: CSSProperties = {
+/** 印 (STAMP): 押印のように鋭い面 — button / chip / input / tab */
+export const KAZE_STAMP: CSSProperties = {
   borderRadius: 'var(--kaze-r-sharp)',
   transitionProperty: 'background-color, color, border-color, transform',
   transitionDuration: 'var(--kaze-dur-micro)',
   transitionTimingFunction: 'var(--kaze-ease)',
 }
 
-/** card / panel / popover 用: soft radius + macro duration */
-export const KAZE_SOFT_CARD: CSSProperties = {
+/** 一葉 (LEAF): 一枚の和紙のような柔らかい面 — card / panel / popover */
+export const KAZE_LEAF: CSSProperties = {
   borderRadius: 'var(--kaze-r-soft)',
   transitionProperty: 'border-color, box-shadow, transform',
   transitionDuration: 'var(--kaze-dur-macro)',
   transitionTimingFunction: 'var(--kaze-ease)',
 }
 
-/** modal / hero / section 用: generous radius + scene duration */
-export const KAZE_GEN_SURFACE: CSSProperties = {
+/** 見開き (SPREAD): 誌面の見開きのような大きな面 — modal / hero / section */
+export const KAZE_SPREAD: CSSProperties = {
   borderRadius: 'var(--kaze-r-gen)',
   transitionProperty: 'transform, opacity',
   transitionDuration: 'var(--kaze-dur-scene)',
@@ -39,17 +50,17 @@ export const KAZE_GEN_SURFACE: CSSProperties = {
 }
 
 // ============================================================
-// typography セット — role 別
+// 文字 (typography) — 何として「読まれる」か
 // ============================================================
 
-/** CTA ラベル・eyebrow ラベル等: Plex Mono + uppercase + wide tracking */
-export const KAZE_MONO_LABEL: CSSProperties = {
+/** メタ (META): 版の奥付のような mono 小文字 — CTA ラベル / caption */
+export const KAZE_META: CSSProperties = {
   fontFamily: 'var(--kaze-font-mono)',
   letterSpacing: '0.08em',
   textTransform: 'uppercase',
 }
 
-/** eyebrow 専用: Mono + さらに広い tracking + 小さいサイズ想定 */
+/** 袖見出し (EYEBROW): editorial 標準語、section 頭の小ラベル */
 export const KAZE_EYEBROW: CSSProperties = {
   fontFamily: 'var(--kaze-font-mono)',
   fontSize: '0.75rem',
@@ -58,16 +69,16 @@ export const KAZE_EYEBROW: CSSProperties = {
   textTransform: 'uppercase',
 }
 
-/** display 見出し: Fraunces Variable + 基調 axis */
-export const KAZE_DISPLAY: CSSProperties = {
+/** 活字 (PRINT): Fraunces Variable の基調。display 見出し */
+export const KAZE_PRINT: CSSProperties = {
   fontFamily: 'var(--kaze-font-display)',
   fontWeight: 380,
   letterSpacing: '-0.02em',
   fontVariationSettings: "'opsz' 144, 'wght' 380, 'SOFT' 30, 'WONK' 0",
 }
 
-/** display 強調 (italic + WONK): "Infinite" のような accent word 用 */
-export const KAZE_DISPLAY_EMPHASIS: CSSProperties = {
+/** 強調 (ACCENT): italic + WONK で「書き込み」の質感。"Infinite" 型 */
+export const KAZE_ACCENT: CSSProperties = {
   fontFamily: 'var(--kaze-font-display)',
   fontStyle: 'italic',
   fontWeight: 420,
@@ -75,8 +86,8 @@ export const KAZE_DISPLAY_EMPHASIS: CSSProperties = {
   fontVariationSettings: "'opsz' 144, 'wght' 420, 'SOFT' 70, 'WONK' 1",
 }
 
-/** body text: Plex Sans + 日本語の呼吸 */
-export const KAZE_BODY: CSSProperties = {
+/** 本文 (RUN): Plex Sans + 日本語の呼吸。通常本文 */
+export const KAZE_RUN: CSSProperties = {
   fontFamily: 'var(--kaze-font-body)',
   letterSpacing: '0.02em',
   lineHeight: 1.7,


### PR DESCRIPTION
## 概要

Matlens aeros-design-system ピア並走 (2026-04-20) で得た助言を反映して、\`src/themes/kazeMixins.ts\` の export 名を **機械分類** (SHARP_UI / SOFT_CARD / GEN_SURFACE…) から **編集デザインのドメイン語彙** に昇格させる。kaze-ux が掲げる「墨で書かれ、風で運ばれる」の世界観に命名も揃える。

## 対応表

| 旧 | 新 | 意味 | 適用先 |
|---|---|---|---|
| \`KAZE_SHARP_UI\` | **\`KAZE_STAMP\`** | 印・判 (押印の鋭さ) | button / chip / input / tab / icon-button |
| \`KAZE_SOFT_CARD\` | **\`KAZE_LEAF\`** | 一葉 (和紙 1 枚) | card / panel / popover |
| \`KAZE_GEN_SURFACE\` | **\`KAZE_SPREAD\`** | 見開き (誌面) | modal / hero / section |
| \`KAZE_DISPLAY\` | **\`KAZE_PRINT\`** | 活字 | display 見出し |
| \`KAZE_DISPLAY_EMPHASIS\` | **\`KAZE_ACCENT\`** | 強調 (italic + WONK) | accent word |
| \`KAZE_MONO_LABEL\` | **\`KAZE_META\`** | メタ表示 | CTA / caption |
| \`KAZE_BODY\` | **\`KAZE_RUN\`** | running text | 本文 |
| \`KAZE_EYEBROW\` | \`KAZE_EYEBROW\` | 袖見出し (editorial 標準語) | ラベル *(維持)* |

## 移行コンポーネント (5 ファイル)

すべて kazeMixins を import していた既存ファイル。alias は残さず一括置換:

- \`src/components/ui/chip/customChip.tsx\`
- \`src/components/ui/icon-button/iconButton.tsx\`
- \`src/components/ui/tag/statusTag.tsx\`
- \`src/components/ui/toggle-button/toggleButton.tsx\`
- \`apps/saas-dashboard/src/pages/DashboardPage.tsx\`

## なぜ alias を残さないか

- 導入直後 (PR #46 から数日) で外部参照が無い
- 段階移行の複雑さより「1 発で世界観を固める」方が価値が高い
- 新規採用は確定した語彙から始まるので迷いがない

## ドキュメント改善

\`kazeMixins.ts\` の冒頭に対応表コメントを追加:

\`\`\`
 * STAMP  (印・判)     → button / chip / input / tab / icon-button
 * LEAF   (一葉)       → card / panel / popover
 * SPREAD (見開き)      → modal / hero / section
 * PRINT  (活字)       → display 見出し
 * ACCENT (強調)       → 強調語 (italic + WONK)
 * META   (メタ表示)    → CTA ラベル・小さな mono 表記
 * EYEBROW(袖見出し)    → section 上の小ラベル (editorial 標準語)
 * RUN    (本文)       → 通常本文
\`\`\`

## Test plan

- [x] \`pnpm exec tsc --noEmit\`: エラーなし
- [x] \`pnpm test:run\`: 324/324 pass
- [ ] \`pnpm build-storybook\` / \`pnpm build-sandbox\` regression なし
- [ ] 既存 \`<Button kaze />\` \`<Card kaze />\` etc. の視覚的挙動無変更

## 余談

ピア (aeros-design-system) も自分のドメイン (食・モビリティ) に翻訳すると
\`RELAY_TIGHT_UI\` / \`RELAY_SOFT_SURFACE\` / \`RELAY_NUMERIC\` になると言っていた。
機械分類より意味の腐敗に強い、という気付き。

🤖 Generated with [Claude Code](https://claude.com/claude-code)