### PR TITLE
refactor(ds): Button / Card を kazeMixins 参照に (DRY 化)

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -6,6 +6,7 @@
 import { type VariantProps, cva } from 'class-variance-authority'
 import * as React from 'react'
 
+import { KAZE_META, KAZE_STAMP } from '@/themes/kazeMixins'
 import { cn } from '@/utils/className'
 
 const buttonVariants = cva(
@@ -52,16 +53,9 @@ export interface ButtonProps
   kaze?: boolean
 }
 
-// Kaze opt-in 時のスタイル上書き。CSS vars は :root / .dark で定義済み (#39)
-const kazeStyle: React.CSSProperties = {
-  borderRadius: 'var(--kaze-r-sharp)',
-  fontFamily: 'var(--kaze-font-mono)',
-  transitionProperty: 'background-color, color, border-color, transform',
-  transitionDuration: 'var(--kaze-dur-micro)',
-  transitionTimingFunction: 'var(--kaze-ease)',
-  letterSpacing: '0.08em',
-  textTransform: 'uppercase',
-}
+// Kaze opt-in 時のスタイル上書き。骨格 mixin を合成 (PR #53 領域語彙)。
+// STAMP = 押印の鋭さ (radius + transition)、META = mono label (font)。
+const kazeStyle: React.CSSProperties = { ...KAZE_STAMP, ...KAZE_META }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   (

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -12,6 +12,7 @@ import {
 } from '@mui/material'
 import * as React from 'react'
 
+import { KAZE_LEAF, KAZE_PRINT, KAZE_RUN } from '@/themes/kazeMixins'
 import { cn } from '@/utils/className'
 
 // Card 配下の subcomponent (Title/Description/etc) が kaze mode を
@@ -29,12 +30,8 @@ export interface CardProps extends PaperProps {
   kaze?: boolean
 }
 
-const kazeCardStyle: React.CSSProperties = {
-  borderRadius: 'var(--kaze-r-soft)',
-  transitionProperty: 'border-color, box-shadow, transform',
-  transitionDuration: 'var(--kaze-dur-macro)',
-  transitionTimingFunction: 'var(--kaze-ease)',
-}
+// LEAF = 一葉 (soft radius + macro duration)、card/panel 想定
+const kazeCardStyle: React.CSSProperties = KAZE_LEAF
 
 const Card = React.forwardRef<HTMLDivElement, CardProps>(
   ({ className, kaze = false, style, ...props }, ref) => (
@@ -66,12 +63,8 @@ const CardHeader = React.forwardRef<
 ))
 CardHeader.displayName = 'CardHeader'
 
-const kazeTitleStyle: React.CSSProperties = {
-  fontFamily: 'var(--kaze-font-display)',
-  fontWeight: 380,
-  letterSpacing: '-0.02em',
-  fontVariationSettings: "'opsz' 144, 'wght' 380, 'SOFT' 30, 'WONK' 0",
-}
+// PRINT = 活字 (Fraunces Variable 基調)、display 見出し
+const kazeTitleStyle: React.CSSProperties = KAZE_PRINT
 
 const CardTitle = React.forwardRef<HTMLParagraphElement, TypographyProps>(
   ({ className, variant = 'h3', style, ...props }, ref) => {
@@ -92,11 +85,8 @@ const CardTitle = React.forwardRef<HTMLParagraphElement, TypographyProps>(
 )
 CardTitle.displayName = 'CardTitle'
 
-const kazeDescStyle: React.CSSProperties = {
-  fontFamily: 'var(--kaze-font-body)',
-  letterSpacing: '0.01em',
-  lineHeight: 1.65,
-}
+// RUN = 本文 (Plex Sans + 呼吸)。CardDescription 用、行高を 1.65 に締める
+const kazeDescStyle: React.CSSProperties = { ...KAZE_RUN, lineHeight: 1.65 }
 
 const CardDescription = React.forwardRef<HTMLParagraphElement, TypographyProps>(
   ({ className, variant = 'body2', style, ...props }, ref) => {


### PR DESCRIPTION
## 概要

PR #43 (Button) / #44 (Card) で各ファイル内に直書きしていた kaze 用 style object を、PR #46 で導入し PR #53 で領域語彙化された \`kazeMixins\` の参照に置き換える。mixin を単一の source に揃えて DRY 化。

## 置換内容

### Button (\`src/components/ui/Button.tsx\`)
\`\`\`diff
+ import { KAZE_META, KAZE_STAMP } from '@/themes/kazeMixins'

- const kazeStyle: React.CSSProperties = {
-   borderRadius: 'var(--kaze-r-sharp)',
-   fontFamily: 'var(--kaze-font-mono)',
-   transitionProperty: 'background-color, color, border-color, transform',
-   transitionDuration: 'var(--kaze-dur-micro)',
-   transitionTimingFunction: 'var(--kaze-ease)',
-   letterSpacing: '0.08em',
-   textTransform: 'uppercase',
- }
+ const kazeStyle: React.CSSProperties = { ...KAZE_STAMP, ...KAZE_META }
\`\`\`

### Card (\`src/components/ui/Card.tsx\`)
3 つの style object を 3 つの mixin に置換:
\`\`\`diff
+ import { KAZE_LEAF, KAZE_PRINT, KAZE_RUN } from '@/themes/kazeMixins'

- const kazeCardStyle = { borderRadius: 'var(--kaze-r-soft)', ... 5 lines }
+ const kazeCardStyle: React.CSSProperties = KAZE_LEAF

- const kazeTitleStyle = { fontFamily: 'var(--kaze-font-display)', ... 5 lines }
+ const kazeTitleStyle: React.CSSProperties = KAZE_PRINT

- const kazeDescStyle = { fontFamily: 'var(--kaze-font-body)', ... 4 lines }
+ const kazeDescStyle: React.CSSProperties = { ...KAZE_RUN, lineHeight: 1.65 }
\`\`\`

(CardDescription は \`RUN\` の \`lineHeight: 1.7\` より少し締めた 1.65 を採用していた経緯を尊重、override で表現)

## 成果

| | 修正前 | 修正後 |
|---|---|---|
| コード行数 | 27 行の直書き style | 4 行の mixin 参照 |
| 骨格変更時の追従 | 4 ファイル手修正 | mixin 1 箇所で波及 |
| 領域語彙 | 無名 (kazeStyle / kazeCardStyle 等) | KAZE_STAMP / LEAF / PRINT / META / RUN |

## 挙動確認

mixin は元の直書き内容と完全同値なので、runtime は 1 byte も変わらない。

- [x] \`pnpm exec tsc --noEmit\`: エラーなし
- [x] \`pnpm test:run\`: 324/324 pass
- [x] \`pnpm build-storybook\`: 成功

## 次の候補

- IconButton / Tag / Chip / ToggleButton の kazeStyle 相当は PR #53 時点で既に mixin 参照化済み
- 残り primitive (Dialog / Menu / Accordion / LoadingButton etc.) への kaze 対応 (機械的)
- Apps 側 (KazeEats / sky-kaze) への骨格展開

🤖 Generated with [Claude Code](https://claude.com/claude-code)