### PR TITLE
fix(sky-kaze): テーマを実アプリに接続し、色の定義を生成に一本化 (#69, #70)

### DIFF
--- a/apps/sky-kaze/src/App.tsx
+++ b/apps/sky-kaze/src/App.tsx
@@ -14,6 +14,8 @@ import { toast } from 'sonner'
 import { ThemeProvider } from '@/components/ThemeProvider'
 import { CustomToaster } from '@/components/ui/toast'
 
+import { skyTheme } from './theme/skyTheme'
+
 import { CompleteView } from '~/components/CompleteView'
 import { DriverPanel } from '~/components/DriverPanel'
 import { EventLog } from '~/components/EventLog'
@@ -73,7 +75,7 @@ const App = () => {
   const viewMode = useSimulation((s) => s.viewMode)
 
   return (
-    <ThemeProvider>
+    <ThemeProvider theme={skyTheme}>
       <CssBaseline />
       <CustomToaster position='top-right' duration={3000} />
       <Box

--- a/apps/sky-kaze/src/index.css
+++ b/apps/sky-kaze/src/index.css
@@ -1,3 +1,9 @@
+/* 色の CSS 変数は src/themes/colorToken.ts の createCssVars() が
+   テーマ適用時に :root へ注入する（実体は src/theme/skyTheme.ts）。
+   ここに手打ちすると MUI 側のトークンを直しても Tailwind 側が古い値の
+   まま残り、同じ画面で primary が食い違うため、定義を置かないこと。
+   アプリ固有の --color-accent* も skyTheme.ts 側で生成している。 */
+
 @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700;800&family=Noto+Sans+JP:wght@400;500;700&family=JetBrains+Mono:wght@400;500;600&display=swap');
 
 @import 'tailwindcss/base';
@@ -5,45 +11,6 @@
 @import 'tailwindcss/utilities';
 
 :root {
-  --color-primary: #1e293b;
-  --color-primary-foreground: #ffffff;
-  --color-primary-light: #334155;
-  --color-primary-dark: #0f172a;
-
-  --color-accent: #ea580c;
-  --color-accent-light: rgba(234, 88, 12, 0.08);
-  /* accent の上に置く文字。白は 3.56:1 で小さな文字に届かないため墨 (5.56:1) */
-  --color-accent-foreground: #0a0a0a;
-
-  --color-secondary: #64748b;
-  --color-secondary-foreground: #ffffff;
-
-  --color-success: #059669;
-  --color-success-foreground: #ffffff;
-  --color-success-light: #ecfdf5;
-  --color-success-border: #6ee7b7;
-
-  --color-error: #dc2626;
-  --color-error-foreground: #ffffff;
-  --color-error-light: #fef2f2;
-  --color-error-border: #fca5a5;
-
-  --color-warning: #d97706;
-  --color-warning-foreground: #ffffff;
-  --color-warning-light: #fffbeb;
-  --color-warning-border: #fde68a;
-
-  --color-info: #0284c7;
-  --color-info-foreground: #ffffff;
-  --color-info-light: #e0f2fe;
-  --color-info-border: #7dd3fc;
-
-  --color-background: #fafafa;
-  --color-background-paper: #ffffff;
-  --color-foreground: #0f172a;
-  --color-muted: #64748b;
-  --color-border: #e5e7eb;
-
   font-family: 'DM Sans', 'Noto Sans JP', system-ui, sans-serif;
   line-height: 1.5;
   font-weight: 400;
@@ -52,47 +19,6 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: 'cv02', 'cv03', 'cv04';
-}
-
-.dark {
-  --color-primary: #e2e8f0;
-  --color-primary-foreground: #0f172a;
-  --color-primary-light: #94a3b8;
-  --color-primary-dark: #f1f5f9;
-
-  --color-accent: #f97316;
-  --color-accent-light: rgba(249, 115, 22, 0.1);
-  /* ダークの accent はさらに明るく、白は 2.80:1。墨なら 7.06:1 */
-  --color-accent-foreground: #0a0a0a;
-
-  --color-secondary: #94a3b8;
-  --color-secondary-foreground: #ffffff;
-
-  --color-success: #34d399;
-  --color-success-foreground: #064e3b;
-  --color-success-light: #064e3b;
-  --color-success-border: #6ee7b7;
-
-  --color-error: #f87171;
-  --color-error-foreground: #ffffff;
-  --color-error-light: #450a0a;
-  --color-error-border: #fca5a5;
-
-  --color-warning: #fbbf24;
-  --color-warning-foreground: #451a03;
-  --color-warning-light: #451a03;
-  --color-warning-border: #fde68a;
-
-  --color-info: #38bdf8;
-  --color-info-foreground: #ffffff;
-  --color-info-light: #0c4a6e;
-  --color-info-border: #7dd3fc;
-
-  --color-background: #0f172a;
-  --color-background-paper: #1e293b;
-  --color-foreground: #f1f5f9;
-  --color-muted: #94a3b8;
-  --color-border: #334155;
 }
 
 body {
@@ -129,30 +55,6 @@ html[data-theme-transitioning] body {
   50% {
     opacity: 0.3;
   }
-}
-
-/* MUI Stepper カスタマイズ */
-.MuiStepLabel-label {
-  font-family: 'DM Sans', 'Noto Sans JP', sans-serif !important;
-  font-weight: 600 !important;
-  font-size: 15px !important;
-}
-
-/* 円の色を変えるなら、中の番号も一緒に決める。
-   値を直に書くとダークで accent が #f97316 に変わっても追随しないため、
-   変数を参照する。
-   完了状態に .MuiStepIcon-text の指定は要らない。MUI は completed のとき
-   CheckCircle を返して早期 return するので、text ノード自体が生まれない */
-.MuiStepIcon-root.Mui-completed {
-  color: var(--color-success) !important;
-}
-
-.MuiStepIcon-root.Mui-active {
-  color: var(--color-accent) !important;
-}
-
-.MuiStepIcon-root.Mui-active .MuiStepIcon-text {
-  fill: var(--color-accent-foreground) !important;
 }
 
 /* テーブルのスムーズなホバー */

--- a/apps/sky-kaze/src/theme/skyTheme.ts
+++ b/apps/sky-kaze/src/theme/skyTheme.ts
@@ -1,15 +1,24 @@
-import { createTheme } from '@mui/material/styles'
-
-import { ON_SURFACE_INKS } from '@/themes/colorToken'
-import { bestContrast, ensureContrast } from '@/themes/contrast'
-import { darkTheme, lightTheme } from '@/themes/theme'
+import {
+  ON_SURFACE_INKS,
+  createColorSet,
+  createDarkThemeColors,
+  createLightThemeColors,
+  withTextContrast,
+} from '@/themes/colorToken'
+import type { ColorSet, ThemeColors } from '@/themes/colorToken'
+import { bestContrast } from '@/themes/contrast'
+import { createBrandTheme } from '@/themes/theme'
 
 import {
+  LOGI_NAVY,
+  LOGI_NAVY_LIGHT,
   LOGI_ORANGE,
   LOGI_ORANGE_DARK,
   LOGI_ORANGE_LIGHT,
   LOGI_TEAL,
 } from './colors'
+
+import type { Theme } from '@mui/material/styles'
 
 // MUI パレット型を拡張
 declare module '@mui/material/styles' {
@@ -26,7 +35,82 @@ declare module '@mui/material/styles' {
 /** 塗り面に乗せる文字色は白固定にせず実測で選ぶ（明るいオレンジに白は乗らない） */
 const onSurface = (bg: string) => bestContrast(bg, ON_SURFACE_INKS)
 
-const logiColors = {
+/**
+ * KazeLogistics の環境色。
+ *
+ * ダークの面を navy に保つのは意匠の都合だけではない。colors.ts の
+ * logiForeground() は暗い面を LOGI_NAVY_LIGHT と決め打って前景色を実測して
+ * いるので、ここを別系統の色にすると「測った面」と「実際に置かれる面」が
+ * ずれて、通っているはずの検証が意味を失う。
+ */
+const skyEnv = {
+  light: {
+    background: { default: '#FAFAFA', paper: '#FFFFFF' },
+    text: { primary: LOGI_NAVY, secondary: '#64748B' },
+    divider: '#E5E7EB',
+  },
+  dark: {
+    background: { default: LOGI_NAVY, paper: LOGI_NAVY_LIGHT },
+    text: { primary: '#F1F5F9', secondary: '#94A3B8' },
+    divider: '#334155',
+  },
+} as const
+
+/**
+ * ブランドプライマリ。
+ *
+ * 物流の骨格は navy、アクション（追跡・CTA）はオレンジという役割分担で、
+ * primary は navy 側を指す。ダークでは同じ役割を反転した淡い slate が担う
+ * （暗い面に暗い navy を置いても面として成立しない）。
+ * どちらも contrastText は実測なので、値を動かしても文字色は追従する。
+ */
+const skyPrimary = {
+  light: createColorSet(LOGI_NAVY_LIGHT, LOGI_NAVY, '#334155', '#E2E8F0'),
+  dark: createColorSet('#E2E8F0', '#F1F5F9', '#94A3B8', '#334155'),
+} as const
+
+/** KazeLogistics の色定義。Kaze のセマンティック色を継ぎ、ブランド軸だけ差し替える */
+const createSkyColors = (mode: 'light' | 'dark'): ThemeColors => {
+  const base =
+    mode === 'light'
+      ? createLightThemeColors('kaze')
+      : createDarkThemeColors('kaze')
+  const env = skyEnv[mode]
+  // 背景を差し替えたので、前景として使う色は新しい面で測り直す
+  const fg = (cs: ColorSet) => withTextContrast(cs, mode, env.background)
+
+  return {
+    ...base,
+    primary: fg(skyPrimary[mode]),
+    secondary: fg(base.secondary),
+    success: fg(base.success),
+    info: fg(base.info),
+    warning: fg(base.warning),
+    error: fg(base.error),
+    text: { ...base.text, ...env.text },
+    background: env.background,
+    divider: env.divider,
+  }
+}
+
+export const skyLightColors = createSkyColors('light')
+export const skyDarkColors = createSkyColors('dark')
+
+/**
+ * アクセント（追跡・CTA・進行中ステップ）。
+ *
+ * createCssVars() は DS 共通の変数しか持たないため、アプリ固有の accent は
+ * ここで生成して同じ経路に載せる。index.css に手打ちすると、モードを
+ * 切り替えたときに追従しなくなる。
+ */
+const accentCssVars = (main: string, light: string) => ({
+  '--color-accent': main,
+  '--color-accent-light': light,
+  // 明るいオレンジに白は乗らない（#EA580C に白は 3.56:1、墨なら 5.56:1）
+  '--color-accent-foreground': onSurface(main),
+})
+
+const logiPalette = {
   logiOrange: {
     main: LOGI_ORANGE,
     dark: LOGI_ORANGE_DARK,
@@ -36,37 +120,51 @@ const logiColors = {
   logiTeal: { main: LOGI_TEAL },
 }
 
-// ダークでは main が Stepper のアイコンやロゴなど前景としても使われるため、
-// 面の上で本文 AA を満たす明度まで補正する（ブランドの色相は保つ）
-const darkPrimaryMain = ensureContrast(
-  LOGI_ORANGE,
-  darkTheme.palette.background.paper
-)
-
-export const logiLightTheme = createTheme({
-  ...lightTheme,
-  palette: {
-    ...lightTheme.palette,
-    ...logiColors,
-    primary: {
-      main: LOGI_ORANGE_DARK,
-      dark: '#C2410C',
-      light: LOGI_ORANGE,
-      contrastText: onSurface(LOGI_ORANGE_DARK),
-    },
+/**
+ * KazeLogistics のテーマ。App.tsx が ThemeProvider に渡す実体。
+ *
+ * MUI の palette と Tailwind の `--color-*` が同じ ThemeColors から出るため、
+ * 片方だけ直して食い違う状態にならない。
+ */
+export const skyTheme: Theme = createBrandTheme({
+  light: skyLightColors,
+  dark: skyDarkColors,
+  paletteExtras: { light: logiPalette, dark: logiPalette },
+  cssVars: {
+    light: accentCssVars(LOGI_ORANGE_DARK, 'rgba(234, 88, 12, 0.08)'),
+    dark: accentCssVars(LOGI_ORANGE, 'rgba(249, 115, 22, 0.10)'),
   },
-})
-
-export const logiDarkTheme = createTheme({
-  ...darkTheme,
-  palette: {
-    ...darkTheme.palette,
-    ...logiColors,
-    primary: {
-      main: darkPrimaryMain,
-      dark: LOGI_ORANGE_DARK,
-      light: '#FB923C',
-      contrastText: onSurface(darkPrimaryMain),
+  components: {
+    // 円の色を変えるなら中の番号も一緒に決める。かつては index.css から
+    // !important で差し替えていたが、テーマの外から色を入れる形だと
+    // モード切替に追従せず、番号のコントラストも別管理になっていた。
+    // 完了状態に text の指定は要らない（MUI は completed のとき CheckCircle を
+    // 返して早期 return するので、text ノード自体が生まれない）
+    MuiStepIcon: {
+      styleOverrides: {
+        root: ({ theme }: { theme: Theme }) => ({
+          '&.Mui-completed': { color: theme.palette.success.main },
+          '&.Mui-active': {
+            color: 'var(--color-accent)',
+            '& .MuiStepIcon-text': { fill: 'var(--color-accent-foreground)' },
+          },
+        }),
+      },
+    },
+    MuiStepLabel: {
+      styleOverrides: {
+        label: {
+          fontFamily: "'DM Sans', 'Noto Sans JP', sans-serif",
+          fontWeight: 600,
+          fontSize: 15,
+          // MUI 自身が `.MuiStepLabel-label.Mui-active` で fontWeight: 500 を
+          // 当てており、素の `.MuiStepLabel-label` では詳細度で負ける。
+          // index.css 側が !important を必要としていたのはこれが理由なので、
+          // 状態セレクタを明示して打ち返す（実測で 600 になることを確認済み）
+          '&.Mui-active': { fontWeight: 600 },
+          '&.Mui-completed': { fontWeight: 600 },
+        },
+      },
     },
   },
 })

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -7,9 +7,10 @@ import {
 import { useEffect } from 'react'
 import type { ReactNode } from 'react'
 
-import { theme } from '../themes/theme'
+import { theme as defaultTheme } from '../themes/theme'
 
 import type { ThemeMode } from '../types/theme'
+import type { Theme } from '@mui/material/styles'
 
 /**
  * CssVarsProvider 内部でモード変更をHTML属性に同期するコンポーネント
@@ -37,6 +38,13 @@ const ThemeSync = ({ children }: { children: ReactNode }) => {
 export interface ThemeProviderProps {
   children: ReactNode
   defaultMode?: ThemeMode
+  /**
+   * アプリ固有のブランドテーマ。省略時は Kaze の既定テーマ。
+   *
+   * createBrandTheme() で生成したものを渡すと、MUI の palette と
+   * Tailwind が参照する `--color-*` が同じ定義から出る。
+   */
+  theme?: Theme
 }
 
 /**
@@ -46,6 +54,7 @@ export interface ThemeProviderProps {
 export const ThemeProvider = ({
   children,
   defaultMode = 'light',
+  theme = defaultTheme,
 }: ThemeProviderProps) => {
   return (
     <StyledEngineProvider injectFirst>

--- a/src/themes/__tests__/app-themes.test.ts
+++ b/src/themes/__tests__/app-themes.test.ts
@@ -1,8 +1,12 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
 import { describe, expect, it } from 'vitest'
 
 import {
-  logiDarkTheme,
-  logiLightTheme,
+  skyDarkColors,
+  skyLightColors,
+  skyTheme,
 } from '../../../apps/sky-kaze/src/theme/skyTheme'
 import {
   LOGI_AMBER,
@@ -34,11 +38,23 @@ import type { Theme } from '@mui/material/styles'
  * という最悪の状態になり、しかも見た目では気づきにくい。
  */
 const brandThemes: Array<[string, Theme, 'light' | 'dark']> = [
-  ['sky-kaze (light)', logiLightTheme, 'light'],
-  ['sky-kaze (dark)', logiDarkTheme, 'dark'],
   ['ubereats-clone (light)', ueLightTheme, 'light'],
   ['ubereats-clone (dark)', ueDarkTheme, 'dark'],
 ]
+
+/** colorSchemes 版テーマ（1 つのテーマが light/dark 両方を持つ） */
+const cssVarsThemes: Array<[string, Theme]> = [
+  ['kaze (共有)', theme],
+  ['sky-kaze', skyTheme],
+]
+
+const cssBaselineOverrides = (t: Theme): Record<string, unknown> =>
+  (t.components?.MuiCssBaseline?.styleOverrides ?? {}) as Record<
+    string,
+    unknown
+  >
+
+const DARK_SELECTOR = '[data-mui-color-scheme="dark"], .dark'
 
 describe('プロダクトテーマが光学タイポグラフィを継承している', () => {
   for (const [name, t] of brandThemes) {
@@ -100,13 +116,11 @@ describe('プロダクトテーマがエレベーション体系を継承して�
 })
 
 describe('ブランド差し替えが目的どおり効いている', () => {
-  it('sky-kaze は primary をロジ・オレンジに差し替える', () => {
+  it('sky-kaze は primary をロジのブランド軸に差し替える', () => {
     // ブランド色をハードコードすると、Kaze 側の primary を変えたときに
     // 差し替えの検証にならないまま通過する
-    expect(logiLightTheme.palette.primary.main).not.toBe(
-      theme.palette.primary.main
-    )
-    expect(logiLightTheme.palette.logiOrange.main).toBeTruthy()
+    expect(skyLightColors.primary.main).not.toBe(theme.palette.primary.main)
+    expect(skyTheme.palette.logiOrange.main).toBeTruthy()
   })
 
   it('ubereats-clone は ueGreen を追加しつつ Kaze の primary を保つ', () => {
@@ -114,53 +128,123 @@ describe('ブランド差し替えが目的どおり効いている', () => {
   })
 })
 
-describe('CssVarsProvider 版テーマ (saas-dashboard が使用)', () => {
-  it('ライトの影スケールを持つ', () => {
-    const light = createShadows('light')
-    expect(theme.shadows[elevation.raised]).toBe(light[elevation.raised])
+describe('colorSchemes 版テーマ (saas-dashboard / sky-kaze が使用)', () => {
+  for (const [name, t] of cssVarsThemes) {
+    it(`${name}: ライトの影スケールを持つ`, () => {
+      const light = createShadows('light')
+      expect(t.shadows[elevation.raised]).toBe(light[elevation.raised])
+    })
+
+    it(`${name}: モーション体系を持つ`, () => {
+      expect(t.transitions.easing.easeOut).toBe(kazeEasing.enter)
+    })
+
+    it(`${name}: 光学タイポグラフィを継承している`, () => {
+      expect(t.typography.h1.letterSpacing).toBe(letterSpacingVariant.xxl)
+      expect(t.typography.body1.lineHeight).toBe(1.6)
+      expect(t.typography.button.fontWeight).toBe(500)
+    })
+
+    it(`${name}: ダークスキームでもリムライトが効く`, () => {
+      // colorSchemes 版は shadows をスキーム別に持てないため、
+      // CssBaseline 側でダークスキーム時の影を上書きしている
+      const darkRules = cssBaselineOverrides(t)[DARK_SELECTOR] as
+        Record<string, { boxShadow: string }> | undefined
+      expect(darkRules, 'ダークスキーム用の影上書き').toBeDefined()
+
+      const dark = createShadows('dark')
+      expect(darkRules?.['& .MuiCard-root'].boxShadow).toBe(
+        dark[elevation.raised]
+      )
+      expect(darkRules?.['& .MuiCard-root'].boxShadow).toContain('inset')
+      expect(darkRules?.['& .MuiDialog-paper'].boxShadow).toBe(
+        dark[elevation.modal]
+      )
+    })
+
+    it(`${name}: ダーク上書きが主要な浮遊面を網羅している`, () => {
+      const darkRules = cssBaselineOverrides(t)[DARK_SELECTOR] as
+        Record<string, unknown> | undefined
+
+      for (const selector of [
+        '& .MuiCard-root',
+        '& .MuiCard-root:hover',
+        '& .MuiMenu-paper',
+        '& .MuiPopover-paper',
+        '& .MuiTooltip-tooltip',
+        '& .MuiDialog-paper',
+        '& .MuiDrawer-paper',
+      ]) {
+        expect(darkRules?.[selector], selector).toBeDefined()
+      }
+    })
+  }
+})
+
+/**
+ * #69: apps/sky-kaze だけ `--color-*` が index.css に手打ちで残り、
+ * 同じ画面で MUI の primary (青) と Tailwind の primary (navy) が
+ * 別の色を指していた。どちらが効くかは CSS の注入順次第だった。
+ *
+ * 「MUI と Tailwind が同じ定義から出ていること」を構造として検証する。
+ */
+describe('MUI と Tailwind が同じ色定義を指している (sky-kaze)', () => {
+  const overrides = cssBaselineOverrides(skyTheme)
+  const lightVars = overrides[':root'] as Record<string, string>
+  const darkVars = overrides[DARK_SELECTOR] as Record<string, string>
+
+  it('ライト: --color-primary が palette.primary.main と一致する', () => {
+    expect(lightVars['--color-primary']).toBe(skyLightColors.primary.main)
+    expect(lightVars['--color-primary']).toBe(skyTheme.palette.primary.main)
   })
 
-  it('モーション体系を持つ', () => {
-    expect(theme.transitions.easing.easeOut).toBe(kazeEasing.enter)
+  it('ダーク: --color-primary が ダークスキームの primary.main と一致する', () => {
+    expect(darkVars['--color-primary']).toBe(skyDarkColors.primary.main)
   })
 
-  it('ダークスキームでもリムライトが効く', () => {
-    // colorSchemes 版は shadows をスキーム別に持てないため、
-    // CssBaseline 側でダークスキーム時の影を上書きしている
-    const overrides = theme.components?.MuiCssBaseline?.styleOverrides as
-      Record<string, unknown> | undefined
-    expect(overrides).toBeDefined()
-
-    const darkRules = overrides?.['[data-mui-color-scheme="dark"], .dark'] as
-      Record<string, { boxShadow: string }> | undefined
-    expect(darkRules, 'ダークスキーム用の影上書き').toBeDefined()
-
-    const dark = createShadows('dark')
-    expect(darkRules?.['& .MuiCard-root'].boxShadow).toBe(
-      dark[elevation.raised]
+  it('背景・文字もモードごとに生成されている', () => {
+    expect(lightVars['--color-background-paper']).toBe(
+      skyLightColors.background.paper
     )
-    expect(darkRules?.['& .MuiCard-root'].boxShadow).toContain('inset')
-    expect(darkRules?.['& .MuiDialog-paper'].boxShadow).toBe(
-      dark[elevation.modal]
+    expect(darkVars['--color-background-paper']).toBe(
+      skyDarkColors.background.paper
     )
+    expect(lightVars['--color-foreground']).toBe(skyLightColors.text.primary)
+    expect(darkVars['--color-foreground']).toBe(skyDarkColors.text.primary)
   })
 
-  it('ダーク上書きが主要な浮遊面を網羅している', () => {
-    const overrides = theme.components?.MuiCssBaseline?.styleOverrides as
-      Record<string, unknown> | undefined
-    const darkRules = overrides?.['[data-mui-color-scheme="dark"], .dark'] as
-      Record<string, unknown> | undefined
+  it('アプリ固有の accent も生成側に載っている', () => {
+    for (const [label, vars] of [
+      ['light', lightVars],
+      ['dark', darkVars],
+    ] as const) {
+      expect(vars['--color-accent'], label).toBeTruthy()
+      expect(vars['--color-accent-light'], label).toBeTruthy()
+      // 塗り面に置く文字は実測で決める（明るいオレンジに白は乗らない）
+      const accent = vars['--color-accent']
+      const ink = vars['--color-accent-foreground']
+      expect(
+        contrastRatioOf(ink, accent),
+        `${label}: accent ${accent} に ${ink}`
+      ).toBeGreaterThanOrEqual(CONTRAST_THRESHOLD.text)
+    }
+  })
 
-    for (const selector of [
-      '& .MuiCard-root',
-      '& .MuiCard-root:hover',
-      '& .MuiMenu-paper',
-      '& .MuiPopover-paper',
-      '& .MuiTooltip-tooltip',
-      '& .MuiDialog-paper',
-      '& .MuiDrawer-paper',
-    ]) {
-      expect(darkRules?.[selector], selector).toBeDefined()
+  it('アプリの index.css に --color-* の手打ち定義が無い', () => {
+    // 生成に一本化した意味は「もう一つのソースが無いこと」にある。
+    // 1 行に複数宣言が来ても拾えるよう、行頭を前提にしない
+    // apps/ubereats-clone にも手打ちが残っているが、そちらはブランド色の
+    // 変更と一緒に移す（#72）。移したらこの配列に足す
+    const cssFiles = [
+      'apps/sky-kaze/src/index.css',
+      'apps/saas-dashboard/src/index.css',
+    ]
+    for (const rel of cssFiles) {
+      const css = readFileSync(join(process.cwd(), rel), 'utf8')
+      // コメント内の記述は対象外（注意書きで --color-* に言及している）
+      const withoutComments = css.replace(/\/\*[\s\S]*?\*\//g, '')
+      const declarations = withoutComments.match(/--color-[\w-]+\s*:/g) ?? []
+      expect(declarations, `${rel} の手打ち定義`).toEqual([])
     }
   })
 })

--- a/src/themes/colorToken.ts
+++ b/src/themes/colorToken.ts
@@ -143,7 +143,13 @@ export const foregroundVariant = (
  */
 const TEXT_CONTRAST_HEADROOM = 1.2
 
-const withTextContrast = (
+/**
+ * アプリ側のブランドテーマも同じ計算に載せる必要があるため公開する。
+ *
+ * 背景を差し替えたのに textContrast を計算し直さないと、前景色が
+ * 「別の面を基準に測った値」のまま残って無言で AA を割る。
+ */
+export const withTextContrast = (
   cs: ColorSet,
   mode: 'light' | 'dark',
   background: { default: string; paper: string }
@@ -167,7 +173,13 @@ const withTextContrast = (
   ),
 })
 
-const createColorSet = (
+/**
+ * ブランド色の ColorSet を組み立てる。
+ *
+ * アプリ側（KazeLogistics / KazeEats）も自前の ColorSet を作るため公開する。
+ * 各所で手組みすると contrastText の決め方（実測 or 白固定）が食い違う。
+ */
+export const createColorSet = (
   main: string,
   dark: string,
   light: string,

--- a/src/themes/theme.ts
+++ b/src/themes/theme.ts
@@ -915,6 +915,79 @@ const theme = createTheme({
   >,
 })
 
+export interface BrandThemeOptions {
+  /** ライトスキームの色定義 */
+  light: ThemeColors
+  /** ダークスキームの色定義 */
+  dark: ThemeColors
+  /**
+   * palette に足すブランド固有スロット（例: logiOrange）。
+   * MUI の型拡張は各アプリ側の module augmentation で行う。
+   */
+  paletteExtras?: { light?: object; dark?: object }
+  /**
+   * createCssVars() が持たないアプリ固有の CSS 変数（例: --color-accent）。
+   * 生成済みの変数と同じ経路に載せることで、手打ちに戻らないようにする。
+   */
+  cssVars?: { light?: Record<string, string>; dark?: Record<string, string> }
+  /** アプリ固有のコンポーネント上書き。createTheme の deep merge で合流する */
+  components?: Components<Theme>
+}
+
+/**
+ * アプリのブランド色から colorSchemes 版テーマを生成する。
+ *
+ * 各アプリが lightTheme / darkTheme を spread して palette だけ差し替える形だと、
+ * Tailwind が参照する `--color-*` は付いてこないため index.css に手打ちされ、
+ * 同じ画面で MUI と Tailwind が別の色を指す状態になっていた
+ * (apps/sky-kaze の primary が MUI=青 / Tailwind=navy だった)。
+ *
+ * ここを通すと両方が同じ ThemeColors から生成されるため、構造的に食い違わない。
+ */
+export const createBrandTheme = ({
+  light,
+  dark,
+  paletteExtras,
+  cssVars,
+  components,
+}: BrandThemeOptions): Theme => {
+  const base = createTheme({
+    ...commonThemeOptions,
+    // colorSchemes 版は shadows をスキーム別に持てないためライト基準。
+    // ダークは下の CssBaseline 上書きで補う
+    shadows: createShadows('light'),
+    defaultColorScheme: 'light',
+    colorSchemes: {
+      light: { palette: { mode: 'light', ...light, ...paletteExtras?.light } },
+      dark: { palette: { mode: 'dark', ...dark, ...paletteExtras?.dark } },
+    },
+    components: {
+      ...componentStyles,
+      MuiCssBaseline: {
+        styleOverrides: {
+          ...componentStyles.MuiCssBaseline.styleOverrides,
+          // :root を先に、ダークスキームを後に出す。両者は同じ詳細度 (0,1,0)
+          // のため、順序が逆だとライトの変数が勝ってダークで白面が残る
+          ':root': {
+            ...createCssVars(light),
+            ...createMotionCssVars(),
+            ...cssVars?.light,
+          },
+          '[data-mui-color-scheme="dark"], .dark': {
+            ...createDarkSchemeElevationOverrides()[
+              '[data-mui-color-scheme="dark"], .dark'
+            ],
+            ...createCssVars(dark),
+            ...cssVars?.dark,
+          },
+        },
+      },
+    } as Components<Omit<Theme, 'components' | 'palette'> & CssVarsTheme>,
+  })
+
+  return components ? createTheme(base, { components }) : base
+}
+
 // 後方互換性のために従来のテーマも提供
 const lightThemeColors = createLightThemeColors('kaze')
 const lightTheme = createTheme({


### PR DESCRIPTION
Closes https://github.com/BoxPistols/kaze-ux/issues/69
Closes https://github.com/BoxPistols/kaze-ux/issues/70

2 件は同じ 1 つの原因（sky-kaze のテーマが実アプリに繋がっていない）から出ているため、まとめて直した。

## 何が起きていたか

`apps/sky-kaze` は共有 `ThemeProvider` をそのまま使っており、`skyTheme.ts` はテストからしか参照されていなかった（#70）。一方 Tailwind が読む `--color-*` は `index.css` に手打ちされていた（#69）。結果として同じ画面で MUI と Tailwind が別の色を指していた。

実ブラウザで測ると、食い違いは issue が挙げていたライトの primary だけではなかった。

| | Tailwind (`--color-*`) | MUI が実際に描画 |
|---|---|---|
| ライト primary | `#1e293b` (navy) | `rgb(0,87,184)` = `#0057B8` |
| ライト 地 | `#fafafa` | `rgb(248,250,252)` |
| ダーク primary | `#e2e8f0` | `rgb(127,168,248)` = Dracula の青 |
| **ダーク 地** | `#0f172a` (navy) | `rgb(40,42,54)` = **Dracula の紫灰** |

ダークでは MUI が Dracula テーマを丸ごと描いていた。どちらが効くかは CSS の注入順次第で、意図して選ばれた状態ではなかった。

## やったこと

- **`createBrandTheme()` を `src/themes/theme.ts` に追加** — `ThemeColors` から colorSchemes 版テーマを作り、light/dark 両方の `--color-*` を生成して `MuiCssBaseline` に載せる。MUI の palette と Tailwind の変数が同じ定義から出るので、構造的に食い違わない
- **`skyTheme.ts` を書き直し、`App.tsx` が `ThemeProvider` に渡す実体にした** — primary はロジの navy（ダークは反転した slate）、オレンジは accent。`logiOrange` / `logiTeal` は従来どおり
- **`ThemeProvider` に `theme` prop を追加** — 既定は従来の共有テーマなので saas-dashboard 等は無影響
- **`index.css` の手打ち `--color-*` と StepIcon の `!important` を削除** — StepIcon / StepLabel の意匠はテーマの `styleOverrides` へ
- **`createColorSet` / `withTextContrast` を公開** — 背景を差し替えたら前景色を測り直す必要があるため、アプリ側も同じ計算に載せる

## 見た目の変更（意図的）

`#69` が「ロジ系のブランドとしては navy が意図した色なので現状の見た目は正しい」としているため、**Tailwind 側が既に描いていた見た目に MUI を合わせる**方向で揃えた。

- MUI の primary: 青 `#0057B8` → navy `#1E293B`（ダークは `#E2E8F0`）
- ダークの地: Dracula の紫灰 → navy
- セマンティック色は DS の値に統一（success `#059669` → `#46ab4a` 等）

`color='primary'` の使用箇所はアプリ全体で 2 箇所（Chip）なので、MUI 側の波及は小さい。

## 途中で見つけた罠

`StepLabel` の `fontWeight` をテーマに移したら 600 → 500 に戻っていた。MUI 自身が `.MuiStepLabel-label.Mui-active { font-weight: 500 }` を持っており、素の `.MuiStepLabel-label` では詳細度で負ける（`index.css` が `!important` を必要としていたのはこれが理由）。状態セレクタを明示して打ち返し、実ブラウザの computed style で 600 を確認した。

## 検証

- **実ブラウザで変更前後の computed style を比較**（ライト・ダーク両方）。変更後は `--color-primary` と MUI の描画色が一致することを確認
- **Stepper を実際に進めて**完了状態が success の緑 `rgb(70,171,74)`、進行中がオレンジ `rgb(234,88,12)` + 墨の番号になることを確認
- `app-themes.test.ts` に「アプリの `index.css` に `--color-*` の手打ちが無い」検査を追加。**わざと 1 行戻して赤になることを確認済み**
- `pnpm test:run` 504 passed（+5）
- sky-kaze / saas-dashboard / ubereats-clone の 3 アプリとも `tsc --noEmit` + `vite build` 通過

## 補足

`apps/ubereats-clone/src/index.css` にも同じ手打ちが残っている（issue は「sky-kaze だけ残った」としているが、実際は 2 つ残っていた）。そちらはブランド色の変更と一緒に移すため #72 で扱う。上記のテストにも「移したら配列に足す」旨をコメントで残した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PtyboWRPPoLSn4ptQFdpj