### PR TITLE
feat(ChatSupport): デフォルトAPIキーに 30 回/日 の利用制限を追加 (#15)

### DIFF
--- a/src/components/ui/ChatSupport/__tests__/dailyUsageLimit.test.ts
+++ b/src/components/ui/ChatSupport/__tests__/dailyUsageLimit.test.ts
@@ -1,0 +1,142 @@
+// デフォルトAPIキーの日次利用制限 ユニットテスト
+
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import {
+  DAILY_LIMIT,
+  USAGE_STORAGE_KEY,
+  consumeUse,
+  isLimitReached,
+  isUsingDefaultKey,
+  limitReachedMessage,
+  localDateKey,
+  readUsage,
+  remainingUses,
+  resetUsage,
+} from '../dailyUsageLimit'
+
+const TODAY = new Date(2026, 7, 12, 10, 0, 0) // 2026-08-12 10:00 ローカル
+const TOMORROW = new Date(2026, 7, 13, 0, 30, 0)
+
+describe('localDateKey', () => {
+  it('ローカル日付を YYYY-MM-DD で返す', () => {
+    expect(localDateKey(TODAY)).toBe('2026-08-12')
+  })
+
+  it('UTC ではなくローカル日付で切る', () => {
+    // JST の 8/12 8:00 は UTC では 8/11。toISOString() を使うと前日になる
+    const morning = new Date(2026, 7, 12, 8, 0, 0)
+    expect(localDateKey(morning)).toBe('2026-08-12')
+    expect(localDateKey(morning)).not.toBe(
+      morning.toISOString().slice(0, 10) === '2026-08-12'
+        ? 'never'
+        : morning.toISOString().slice(0, 10)
+    )
+  })
+})
+
+describe('日次カウント', () => {
+  beforeEach(() => {
+    resetUsage()
+  })
+
+  it('初期状態では 0 回・残りは上限いっぱい', () => {
+    expect(readUsage(TODAY).count).toBe(0)
+    expect(remainingUses(TODAY)).toBe(DAILY_LIMIT)
+    expect(isLimitReached(TODAY)).toBe(false)
+  })
+
+  it('消費すると残りが減る', () => {
+    expect(consumeUse(TODAY)).toBe(DAILY_LIMIT - 1)
+    expect(consumeUse(TODAY)).toBe(DAILY_LIMIT - 2)
+    expect(readUsage(TODAY).count).toBe(2)
+  })
+
+  it('上限ちょうどで到達判定になる（超過してからではない）', () => {
+    for (let i = 0; i < DAILY_LIMIT - 1; i++) consumeUse(TODAY)
+    expect(isLimitReached(TODAY)).toBe(false)
+    consumeUse(TODAY)
+    expect(isLimitReached(TODAY)).toBe(true)
+    expect(remainingUses(TODAY)).toBe(0)
+  })
+
+  it('上限を超えても残りは負にならない', () => {
+    for (let i = 0; i < DAILY_LIMIT + 5; i++) consumeUse(TODAY)
+    expect(remainingUses(TODAY)).toBe(0)
+  })
+
+  it('日付が変わるとリセットされる', () => {
+    for (let i = 0; i < DAILY_LIMIT; i++) consumeUse(TODAY)
+    expect(isLimitReached(TODAY)).toBe(true)
+    expect(isLimitReached(TOMORROW)).toBe(false)
+    expect(remainingUses(TOMORROW)).toBe(DAILY_LIMIT)
+  })
+
+  it('日付ごとにキーを増やさず 1 レコードで持つ', () => {
+    consumeUse(TODAY)
+    consumeUse(TOMORROW)
+    const keys = Object.keys(localStorage).filter((k) => k.includes('usage'))
+    expect(keys).toEqual([USAGE_STORAGE_KEY])
+  })
+})
+
+describe('壊れた保存値からの復帰', () => {
+  beforeEach(() => {
+    resetUsage()
+  })
+
+  it('JSON として壊れていても 0 から数え直す', () => {
+    localStorage.setItem(USAGE_STORAGE_KEY, '{壊れている')
+    expect(readUsage(TODAY).count).toBe(0)
+    expect(isLimitReached(TODAY)).toBe(false)
+  })
+
+  it('型が違えば無視する', () => {
+    localStorage.setItem(
+      USAGE_STORAGE_KEY,
+      JSON.stringify({ date: 1, count: 'x' })
+    )
+    expect(readUsage(TODAY).count).toBe(0)
+  })
+
+  it('負数や小数に書き換えられても正規化する', () => {
+    localStorage.setItem(
+      USAGE_STORAGE_KEY,
+      JSON.stringify({ date: localDateKey(TODAY), count: -5 })
+    )
+    expect(readUsage(TODAY).count).toBe(0)
+    localStorage.setItem(
+      USAGE_STORAGE_KEY,
+      JSON.stringify({ date: localDateKey(TODAY), count: 3.7 })
+    )
+    expect(readUsage(TODAY).count).toBe(3)
+  })
+})
+
+describe('制限の対象判定', () => {
+  it('デフォルトキーのまま使っていれば対象', () => {
+    expect(isUsingDefaultKey('sk-default', 'sk-default')).toBe(true)
+    expect(isUsingDefaultKey(undefined, 'sk-default')).toBe(true)
+    expect(isUsingDefaultKey('', 'sk-default')).toBe(true)
+  })
+
+  it('自前キーを登録していれば対象外', () => {
+    expect(isUsingDefaultKey('sk-mine', 'sk-default')).toBe(false)
+  })
+
+  it('デフォルトキーが未設定（FAQ モード）なら対象外', () => {
+    // AI を呼ばないので数える意味がない。ここを対象にすると
+    // FAQ しか使えない人にまで上限メッセージが出る
+    expect(isUsingDefaultKey('', '')).toBe(false)
+    expect(isUsingDefaultKey(undefined, '')).toBe(false)
+  })
+})
+
+describe('上限メッセージ', () => {
+  it('上限回数と設定への導線を含む', () => {
+    const msg = limitReachedMessage()
+    expect(msg).toContain(String(DAILY_LIMIT))
+    expect(msg).toContain('API キー')
+    expect(msg).toContain('設定')
+  })
+})

--- a/src/components/ui/ChatSupport/components/ChatSettings.tsx
+++ b/src/components/ui/ChatSupport/components/ChatSettings.tsx
@@ -38,6 +38,7 @@ import {
   SHORTCUT_METADATA,
   formatShortcutLabel,
 } from '../chatSupportConstants'
+import { DAILY_LIMIT, remainingUses } from '../dailyUsageLimit'
 
 import type { ChatSupportConfig, ShortcutActionId } from '../chatSupportTypes'
 
@@ -77,6 +78,8 @@ export const ChatSettings = ({
   onResetApiKey,
 }: ChatSettingsProps) => {
   const theme = useTheme()
+  // 設定パネルを開いた時点の値。送信のたびに更新する必要はない
+  const remaining = remainingUses()
 
   return (
     <Box sx={{ p: 3, flexGrow: 1, overflowY: 'auto' }}>
@@ -115,6 +118,20 @@ export const ChatSettings = ({
                     AI対話モード
                   </Typography>
                 </Stack>
+                {/* 残りが尽きてから初めて知る形にしない。
+                    自分のキーを登録する動機もここで示す */}
+                <Typography
+                  variant='caption'
+                  color={remaining === 0 ? 'warning.main' : 'text.secondary'}
+                  sx={{ display: 'block', mt: 0.5, lineHeight: 1.6 }}>
+                  {/* JSX の改行は半角スペースになる。日本語の文中で折ると
+                      「変わると リセット」のように空きが入るため 1 式にする */}
+                  {`本日の残り ${remaining} / ${DAILY_LIMIT} 回（日付が変わるとリセット）${
+                    remaining === 0
+                      ? '。自分のAPIキーを登録すると制限なしで使えます'
+                      : ''
+                  }`}
+                </Typography>
               </>
             ) : (
               <>

--- a/src/components/ui/ChatSupport/dailyUsageLimit.ts
+++ b/src/components/ui/ChatSupport/dailyUsageLimit.ts
@@ -1,0 +1,133 @@
+/**
+ * デフォルト API キー利用時の 1 日あたり回数制限。
+ *
+ * 自分のキーを登録する利点が無いと、共有キーだけが使われてコストが読めない。
+ * 「無制限に使えること」を自前キーの利点にする。
+ *
+ * 制限の対象はデフォルトキーを使っているときだけで、
+ * - 自前キーを登録している人は無制限（現状維持）
+ * - デフォルトキーが未設定（FAQ モード）は AI を呼ばないので対象外
+ *
+ * 記録はブラウザの localStorage なので、消せば回避できる。サーバーを
+ * 持たない構成での抑止としてはこれが上限で、厳密な保証ではない。
+ */
+
+/** 1 日あたりの上限回数 */
+export const DAILY_LIMIT = 30
+
+export const USAGE_STORAGE_KEY = 'storybook_chat_usage'
+
+export interface DailyUsage {
+  /** ローカル日付 (YYYY-MM-DD)。日付が変われば自動的にリセットされる */
+  date: string
+  count: number
+}
+
+/**
+ * ローカル日付を YYYY-MM-DD で返す。
+ *
+ * toISOString() は UTC に寄せるため、日本時間の朝 9 時より前が前日扱いに
+ * なる。利用者から見た「日付が変わったらリセット」と食い違うので使わない。
+ */
+export const localDateKey = (now: Date = new Date()): string => {
+  const y = now.getFullYear()
+  const m = `${now.getMonth() + 1}`.padStart(2, '0')
+  const d = `${now.getDate()}`.padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
+const emptyUsage = (now?: Date): DailyUsage => ({
+  date: localDateKey(now),
+  count: 0,
+})
+
+/**
+ * 保存済みの利用状況を読む。日付が変わっていれば 0 から数え直す。
+ *
+ * 日付ごとに別キーを作ると、使わなくなった日付の分が localStorage に
+ * 溜まり続ける。1 レコードだけ持って日付で判定する。
+ */
+export const readUsage = (now: Date = new Date()): DailyUsage => {
+  if (typeof localStorage === 'undefined') return emptyUsage(now)
+  try {
+    const raw = localStorage.getItem(USAGE_STORAGE_KEY)
+    if (!raw) return emptyUsage(now)
+    const parsed: unknown = JSON.parse(raw)
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      typeof (parsed as DailyUsage).date !== 'string' ||
+      typeof (parsed as DailyUsage).count !== 'number' ||
+      !Number.isFinite((parsed as DailyUsage).count)
+    ) {
+      return emptyUsage(now)
+    }
+    const usage = parsed as DailyUsage
+    if (usage.date !== localDateKey(now)) return emptyUsage(now)
+    // 手で書き換えられていても負数や小数にはしない
+    return { date: usage.date, count: Math.max(0, Math.floor(usage.count)) }
+  } catch {
+    return emptyUsage(now)
+  }
+}
+
+const writeUsage = (usage: DailyUsage): void => {
+  if (typeof localStorage === 'undefined') return
+  try {
+    localStorage.setItem(USAGE_STORAGE_KEY, JSON.stringify(usage))
+  } catch {
+    // プライベートモード等で書けなくても送信自体は止めない
+  }
+}
+
+/** 残り回数（0 未満にはしない） */
+export const remainingUses = (now: Date = new Date()): number =>
+  Math.max(0, DAILY_LIMIT - readUsage(now).count)
+
+/** 上限に達しているか */
+export const isLimitReached = (now: Date = new Date()): boolean =>
+  readUsage(now).count >= DAILY_LIMIT
+
+/**
+ * 1 回分を消費して、消費後の残り回数を返す。
+ *
+ * API を呼ぶ直前に数える。成功時だけ数えると、失敗が返り続ける状況で
+ * 上限が効かず、コストを抑えるという目的を果たせない。
+ */
+export const consumeUse = (now: Date = new Date()): number => {
+  const usage = readUsage(now)
+  const next = { date: usage.date, count: usage.count + 1 }
+  writeUsage(next)
+  return Math.max(0, DAILY_LIMIT - next.count)
+}
+
+/** テストと「リセット」操作用 */
+export const resetUsage = (): void => {
+  if (typeof localStorage === 'undefined') return
+  try {
+    localStorage.removeItem(USAGE_STORAGE_KEY)
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * デフォルトキー（＝制限対象）で動いているか。
+ *
+ * defaultApiKey が空のときは AI を呼ばない FAQ モードなので対象外。
+ */
+export const isUsingDefaultKey = (
+  apiKey: string | undefined,
+  defaultApiKey: string
+): boolean => Boolean(defaultApiKey) && (!apiKey || apiKey === defaultApiKey)
+
+/** 上限到達時に出す案内文 */
+export const limitReachedMessage = (): string =>
+  [
+    `**本日の無料利用（${DAILY_LIMIT} 回/日）を使い切りました。**`,
+    '',
+    '設定から自分の API キーを登録すると、回数制限なしで利用できます。',
+    'キーはブラウザの localStorage にのみ保存され、送信先は選んだプロバイダーだけです。',
+    '',
+    `カウントは日付が変わるとリセットされます（現在: ${localDateKey()}）。`,
+  ].join('\n')

--- a/src/components/ui/ChatSupport/hooks/useChatMessage.ts
+++ b/src/components/ui/ChatSupport/hooks/useChatMessage.ts
@@ -10,6 +10,12 @@ import { useState, useMemo, useEffect, useCallback } from 'react'
 import { callAI, extractContent } from '../chatAiService'
 import { DEFAULT_API_KEY, SYSTEM_PROMPT } from '../chatSupportConstants'
 import {
+  consumeUse,
+  isLimitReached,
+  isUsingDefaultKey,
+  limitReachedMessage,
+} from '../dailyUsageLimit'
+import {
   buildSemanticContext,
   findSemanticFaqAnswer,
   getEmbeddingIndex,
@@ -177,6 +183,28 @@ export const useChatMessage = ({
     [addBotMessage, buildPageContextAnswer]
   )
 
+  /**
+   * デフォルトキーの日次上限に達しているか。
+   *
+   * 到達していたら AI を呼ばず、案内文と FAQ 回答を 1 通で返す。
+   * 「送っても何も起きない」状態にはしない。
+   */
+  const blockedByDailyLimit = useCallback(
+    (query: string): boolean => {
+      if (!isUsingDefaultKey(config.apiKey, DEFAULT_API_KEY)) return false
+      if (!isLimitReached()) return false
+
+      const faqAnswer = findFaqAnswer(query)
+      addBotMessage(
+        faqAnswer
+          ? `${limitReachedMessage()}\n\n---\n\nFAQ から回答します:\n\n${trimFaqAnswer(faqAnswer)}`
+          : limitReachedMessage()
+      )
+      return true
+    },
+    [config.apiKey, addBotMessage]
+  )
+
   const handleDownload = useCallback(() => {
     const lines = [
       '# Concierge - チャット履歴',
@@ -221,6 +249,11 @@ export const useChatMessage = ({
         respondWithFaq(userText)
         return
       }
+      if (blockedByDailyLimit(userText)) return
+
+      // API を呼ぶ直前に数える。成功時だけ数えると、失敗が返り続ける
+      // 状況で上限が効かず、コストを抑えるという目的を果たせない
+      if (isUsingDefaultKey(config.apiKey, DEFAULT_API_KEY)) consumeUse()
 
       setIsTyping(true)
       try {
@@ -271,6 +304,7 @@ export const useChatMessage = ({
       contextualPrompt,
       addBotMessage,
       respondWithFaq,
+      blockedByDailyLimit,
     ]
   )
 
@@ -289,6 +323,8 @@ export const useChatMessage = ({
         respondWithFaq(query)
         return
       }
+      if (blockedByDailyLimit(query)) return
+      if (isUsingDefaultKey(config.apiKey, DEFAULT_API_KEY)) consumeUse()
 
       setIsTyping(true)
       semanticSearch(config.apiKey, query)
@@ -337,6 +373,7 @@ export const useChatMessage = ({
       contextualPrompt,
       addBotMessage,
       respondWithFaq,
+      blockedByDailyLimit,
     ]
   )
 


### PR DESCRIPTION
Closes https://github.com/BoxPistols/kaze-ux/issues/15

共有キーで無制限に使えると、自分のキーを登録する利点が無くコストも読めない。**「無制限に使えること」を自前キーの利点**にする。

## 仕様

| 状態 | 挙動 |
|---|---|
| デフォルトキー使用時 | **30 回/日**。上限到達で AI を呼ばず案内 |
| 自前キー登録時 | 無制限（現状維持） |
| デフォルトキー未設定（FAQ モード） | AI を呼ばないので対象外 |

上限に達したら**案内文と FAQ 回答を 1 通で**返す。「送っても何も起きない」状態にはしない。設定パネルには残り回数を常時表示し、尽きてから初めて知る形を避けた。

上限は 30 回/日（issue の想定レンジ 20〜50 の中央）。

## 実装で判断したこと

- **日付は `toISOString()` ではなくローカル日付で切る。** UTC 基準だと日本時間の朝 9 時より前が前日扱いになり、「日付が変わったらリセット」と食い違う。実ブラウザ検証中、検証コード側で UTC を使って**実際に取り違えた**（上限 30 を仕込んだのに制限が効かず、原因は日付キーのズレだった）
- **日付ごとに別キーを作らず 1 レコードで持つ。** issue の実装イメージは `chat_usage_<date>` 形式だったが、それだと過去の日付が localStorage に溜まり続ける
- **API を呼ぶ直前に数える。** 成功時だけ数えると、失敗が返り続ける状況で上限が効かず、コストを抑えるという目的を果たせない
- 保存値が壊れていても 0 から数え直す。負数・小数は正規化する

> localStorage なので消せば回避できます。サーバーを持たない構成での抑止としてはこれが上限で、厳密な保証ではありません（コード内にも明記）。

## 検証

**ユニット 15 件** — 日付境界（ローカル vs UTC / 日付跨ぎ）、上限ちょうどでの到達判定、壊れた保存値からの復帰、対象判定。

**実ブラウザ**（Storybook + ダミーキー、`window.fetch` を差し替えて送信有無を観測）:

| 条件 | 結果 |
|---|---|
| 通常送信 | カウントが 1 増える |
| 上限到達（デフォルトキー） | **fetch 0 件**（送信そのものが起きない）+ 案内文 + キー登録の導線 + FAQ フォールバック |
| 上限到達（自前キー） | 送信され、カウントも消費されない |
| 設定パネル | `本日の残り 30 / 30 回（日付が変わるとリセット）` |

`pnpm test:run` 522 passed（+15）。

## 途中で直したもの

設定パネルの残数表示で、JSX の改行が全角文中に半角スペースを生み「変わると リセット」と表示されていた。実描画で気づいたので 1 式にまとめた。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PtyboWRPPoLSn4ptQFdpj