### PR TITLE
fix: /ubereats/ (末尾スラッシュ) が 404 になっていたのを直す

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,8 +8,13 @@
       "permanent": true
     },
     {
-      "source": "/ubereats/:path*",
-      "destination": "/kaze-eats/:path*",
+      "source": "/ubereats/",
+      "destination": "/kaze-eats/",
+      "permanent": true
+    },
+    {
+      "source": "/ubereats/:path+",
+      "destination": "/kaze-eats/:path+",
       "permanent": true
     }
   ],


### PR DESCRIPTION
Refs https://github.com/BoxPistols/kaze-ux/issues/73

#73 で入れた旧パスのリダイレクトを**本番で実測**したところ、末尾スラッシュ付きの形だけ効いていなかった。

| パス | 実測 |
|---|---|
| `/ubereats` | 308 → `/kaze-eats/` ✅ |
| `/ubereats/favicon.svg` | 308 → `/kaze-eats/favicon.svg` ✅ |
| **`/ubereats/`** | **404** ❌ |

共有されているリンクとして一番ありそうな形がこれなので実害が大きい。

## なぜすり抜けたか

原因は `:path*` の解釈。マージ前にローカルで正規表現に落として照合し `/ubereats/` も拾えると判断したが、**それは Vercel のマッチャそのものではなく模擬でしかなかった**。実際の Vercel は残りが空の `:path*` にマッチさせず、書き換え先も無いので 404 になっていた。

Vercel のプレビューは SSO 保護がかかっていて未認証では 302 しか返らず、プレビュー段階では確認できなかった（PR 本文にも「マージ後に本番で確認するのが確実」と書いていた）。

## 直し方

- `/ubereats/` を独立したルールとして明示
- 配下は `:path*` → `:path+` に変更。1 セグメント以上を明示し、空マッチの扱いを実装依存にしない

## 検証

マージ後、本番の実 URL に対して 4 パターン（`/ubereats`, `/ubereats/`, `/ubereats/favicon.svg`, `/kaze-eats/`）を再度当てて確認します。**ルーティング設定は本番の実 URL に当てるまで確認済みとしない**、という運用にします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PtyboWRPPoLSn4ptQFdpj