### PR TITLE
chore: カバレッジ計測から生成物を除外し、DS 準拠率の計測を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     "build:gh-pages:sky-kaze": "pnpm --filter sky-kaze build:gh-pages",
     "preview:sky-kaze": "pnpm --filter sky-kaze preview",
     "audit:contrast": "node scripts/audit-contrast.mjs",
-    "check:brand": "node scripts/check-brand-terms.mjs"
+    "check:brand": "node scripts/check-brand-terms.mjs",
+    "ds:adoption": "node scripts/ds-adoption.mjs"
   },
   "peerDependencies": {
     "@emotion/react": "^11.13.5",

--- a/scripts/ds-adoption.mjs
+++ b/scripts/ds-adoption.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+/**
+ * デザインシステムの準拠率を測る。
+ *
+ * 「DS に同等品があるのに MUI を直接使っている箇所」を数える。
+ * grep の件数ではなく、import 元を解決したうえで JSX の実利用回数を数える。
+ *
+ * Box / Grid / Stack / Typography のようなレイアウト原始要素は DS に
+ * 同等品が無いので、直接使うのが正しい。これを分母に入れると
+ * 「準拠率 20%」のような、実態と無関係な数字になる。
+ *
+ *   pnpm ds:adoption          一覧を表示
+ *   pnpm ds:adoption --strict 未準拠が 1 件でもあれば exit 1
+ */
+
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+/**
+ * MUI の部品 → DS の同等品。
+ *
+ * ここに載っているものを MUI から直接 import していたら未準拠。
+ * DS 側に部品を足したら、ここにも足す。
+ */
+export const DS_EQUIVALENT = {
+  TextField: 'CustomTextField',
+  Select: 'CustomSelect',
+  Autocomplete: 'MultiSelectAutocomplete',
+  Chip: 'CustomChip',
+  Button: 'Button (CVA) / LoadingButton / SaveButton',
+  IconButton: 'IconButton (DS)',
+  Card: 'Card (CVA) / ServiceCard',
+  CardContent: 'CardContent (CVA)',
+  CardHeader: 'CardHeader (CVA)',
+  CardActions: 'Card (CVA)',
+  Table: 'CustomTable / ResourceTable',
+  TableContainer: 'CustomTable / ResourceTable',
+  Tooltip: 'CustomTooltip',
+  Avatar: 'UserAvatar',
+  Accordion: 'CustomAccordion',
+  Dialog: 'ConfirmDialog / FormDialog',
+  Pagination: 'Pagination (DS)',
+  Fab: 'Fab (DS)',
+  Menu: 'ActionMenu',
+  ToggleButton: 'ToggleButton (DS)',
+  ToggleButtonGroup: 'ToggleButtonGroup (DS)',
+  ButtonGroup: 'ButtonGroup (DS)',
+  Snackbar: 'CustomToaster',
+  Alert: 'CustomToaster',
+}
+
+const TARGETS = [
+  ['saas-dashboard', 'apps/saas-dashboard/src'],
+  ['kaze-eats', 'apps/kaze-eats/src'],
+  ['sky-kaze', 'apps/sky-kaze/src'],
+  ['LP (src/pages)', 'src/pages'],
+]
+
+const walk = (dir, out = []) => {
+  if (!existsSync(dir)) return out
+  for (const e of readdirSync(dir)) {
+    const p = join(dir, e)
+    if (statSync(p).isDirectory()) {
+      if (['node_modules', 'dist', '__tests__'].includes(e)) continue
+      walk(p, out)
+    } else if (/\.tsx$/.test(e) && !/\.stories\.tsx$/.test(e)) {
+      out.push(p)
+    }
+  }
+  return out
+}
+
+/** import 文から「値として入ってきた名前 → モジュール」を作る。型のみの import は除く */
+const parseImports = (src) => {
+  const map = new Map()
+  const typeOnly = new Set()
+  for (const m of src.matchAll(
+    /import\s+(type\s+)?([^'"]+?)\s+from\s+['"]([^'"]+)['"]/g
+  )) {
+    const isType = Boolean(m[1])
+    const braced = m[2].match(/\{([^}]*)\}/)
+    if (braced) {
+      for (const part of braced[1].split(',')) {
+        const t = part.trim()
+        if (!t) continue
+        const inlineType = /^type\s+/.test(t)
+        const clean = t.replace(/^type\s+/, '')
+        const name = (clean.split(/\s+as\s+/)[1] ?? clean).trim()
+        if (!name) continue
+        if (isType || inlineType) typeOnly.add(name)
+        else map.set(name, m[3])
+      }
+    }
+    const head = m[2]
+      .replace(/\{[^}]*\}/, '')
+      .replace(/,/g, ' ')
+      .trim()
+    for (const tok of head.split(/\s+/)) {
+      if (!tok || tok === '*' || tok === 'as') continue
+      if (isType) typeOnly.add(tok)
+      else map.set(tok, m[3])
+    }
+  }
+  return { map, typeOnly }
+}
+
+/**
+ * JSX の開始タグを拾う。
+ *
+ * 直前が識別子の文字なら型引数 (`useState<Theme>` / `Array<Foo>`) なので数えない。
+ */
+const JSX_OPEN = /(?<![A-Za-z0-9_$])<([A-Z][A-Za-z0-9_]*)/g
+
+const isDs = (mod) =>
+  mod.startsWith('@/components') || mod.startsWith('@/layouts')
+const isMui = (mod) =>
+  mod === '@mui/material' || mod.startsWith('@mui/material/')
+
+const analyze = (dir) => {
+  const bypass = new Map()
+  const bySite = []
+  let dsUse = 0
+  for (const file of walk(join(ROOT, dir))) {
+    const src = readFileSync(file, 'utf8')
+    const { map, typeOnly } = parseImports(src)
+    const lines = src.split('\n')
+    for (const m of src.matchAll(JSX_OPEN)) {
+      const name = m[1]
+      if (typeOnly.has(name)) continue
+      const mod = map.get(name)
+      if (!mod) continue
+      if (isDs(mod)) {
+        dsUse++
+      } else if (isMui(mod) && DS_EQUIVALENT[name]) {
+        bypass.set(name, (bypass.get(name) ?? 0) + 1)
+        const line = src.slice(0, m.index).split('\n').length
+        bySite.push({
+          file: file.replace(ROOT + '/', ''),
+          line,
+          name,
+          text: (lines[line - 1] ?? '').trim().slice(0, 70),
+        })
+      }
+    }
+  }
+  return { dsUse, bypass, bySite }
+}
+
+const strict = process.argv.includes('--strict')
+const pad = (s, n) => String(s).padEnd(n)
+const rows = TARGETS.map(([app, dir]) => ({ app, ...analyze(dir) }))
+
+console.log('\n== DS 準拠率（DS に同等品がある部品の利用箇所） ==\n')
+console.log(pad('app', 18), pad('DS 使用', 9), pad('MUI 直', 8), 'DS 準拠率')
+let totalDs = 0
+let totalBypass = 0
+for (const r of rows) {
+  const b = [...r.bypass.values()].reduce((a, c) => a + c, 0)
+  const denom = r.dsUse + b
+  totalDs += r.dsUse
+  totalBypass += b
+  console.log(
+    pad(r.app, 18),
+    pad(r.dsUse, 9),
+    pad(b, 8),
+    denom ? ((r.dsUse / denom) * 100).toFixed(1) + '%' : '—'
+  )
+}
+const total = totalDs + totalBypass
+console.log(
+  '\n  合計:',
+  `DS ${totalDs} / MUI 直 ${totalBypass} → ${total ? ((totalDs / total) * 100).toFixed(1) : '—'}%`
+)
+
+const sites = rows.flatMap((r) => r.bySite)
+if (sites.length) {
+  console.log('\n== 未準拠の箇所 ==')
+  for (const s of sites) {
+    console.log(`  ${s.file}:${s.line}`)
+    console.log(`    <${s.name}> → ${DS_EQUIVALENT[s.name]}`)
+  }
+  console.log(
+    '\n  レイアウト原始要素 (Box / Grid / Stack / Typography 等) は',
+    'DS に同等品が無いため対象外です。'
+  )
+}
+
+if (strict && sites.length) {
+  console.error(`\n❌ 未準拠 ${sites.length} 箇所`)
+  process.exit(1)
+}
+console.log('')

--- a/scripts/ds-adoption.mjs
+++ b/scripts/ds-adoption.mjs
@@ -20,37 +20,60 @@ import { fileURLToPath } from 'node:url'
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
 
 /**
- * MUI の部品 → DS の同等品。
+ * MUI の部品と DS の同等品の対応。**両方向を機械可読にする。**
  *
- * ここに載っているものを MUI から直接 import していたら未準拠。
+ * - `mui` を MUI から直接 import していたら未準拠（分母の一方）
+ * - `ds` を DS から import していたら準拠（分子）
+ *
+ * **分子は「対応表に載っている DS 部品」だけを数える。** `@/components`
+ * から来たもの全部を数えると、MUI に同等品が無い部品（PageHeader /
+ * SectionTitle / KazeLogo 等）まで分子に入り、準拠率を過大に見せる。
+ *
  * DS 側に部品を足したら、ここにも足す。
  */
-export const DS_EQUIVALENT = {
-  TextField: 'CustomTextField',
-  Select: 'CustomSelect',
-  Autocomplete: 'MultiSelectAutocomplete',
-  Chip: 'CustomChip',
-  Button: 'Button (CVA) / LoadingButton / SaveButton',
-  IconButton: 'IconButton (DS)',
-  Card: 'Card (CVA) / ServiceCard',
-  CardContent: 'CardContent (CVA)',
-  CardHeader: 'CardHeader (CVA)',
-  CardActions: 'Card (CVA)',
-  Table: 'CustomTable / ResourceTable',
-  TableContainer: 'CustomTable / ResourceTable',
-  Tooltip: 'CustomTooltip',
-  Avatar: 'UserAvatar',
-  Accordion: 'CustomAccordion',
-  Dialog: 'ConfirmDialog / FormDialog',
-  Pagination: 'Pagination (DS)',
-  Fab: 'Fab (DS)',
-  Menu: 'ActionMenu',
-  ToggleButton: 'ToggleButton (DS)',
-  ToggleButtonGroup: 'ToggleButtonGroup (DS)',
-  ButtonGroup: 'ButtonGroup (DS)',
-  Snackbar: 'CustomToaster',
-  Alert: 'CustomToaster',
-}
+export const EQUIVALENTS = [
+  { mui: ['TextField'], ds: ['CustomTextField'] },
+  { mui: ['Select'], ds: ['CustomSelect'] },
+  { mui: ['Autocomplete'], ds: ['MultiSelectAutocomplete'] },
+  { mui: ['Chip'], ds: ['CustomChip', 'ConnectionStatusChip'] },
+  { mui: ['Button'], ds: ['Button', 'LoadingButton', 'SaveButton'] },
+  { mui: ['IconButton'], ds: ['IconButton'] },
+  {
+    mui: ['Card', 'CardContent', 'CardHeader', 'CardActions'],
+    ds: [
+      'Card',
+      'CardContent',
+      'CardHeader',
+      'CardTitle',
+      'CardDescription',
+      'CardFooter',
+      'ServiceCard',
+    ],
+  },
+  {
+    mui: ['Table', 'TableContainer'],
+    ds: ['CustomTable', 'ResourceTable', 'TableToolbar'],
+  },
+  { mui: ['Tooltip'], ds: ['CustomTooltip'] },
+  { mui: ['Avatar'], ds: ['UserAvatar'] },
+  { mui: ['Accordion'], ds: ['CustomAccordion'] },
+  { mui: ['Dialog'], ds: ['ConfirmDialog', 'FormDialog'] },
+  { mui: ['Pagination'], ds: ['Pagination'] },
+  { mui: ['Fab'], ds: ['Fab'] },
+  { mui: ['Menu'], ds: ['ActionMenu'] },
+  { mui: ['ToggleButton'], ds: ['ToggleButton'] },
+  { mui: ['ToggleButtonGroup'], ds: ['ToggleButtonGroup'] },
+  { mui: ['ButtonGroup'], ds: ['ButtonGroup'] },
+  { mui: ['Snackbar', 'Alert'], ds: ['CustomToaster'] },
+]
+
+/** MUI 名 → 置き換え先の表示（未準拠の報告に使う） */
+export const DS_EQUIVALENT = Object.fromEntries(
+  EQUIVALENTS.flatMap((e) => e.mui.map((m) => [m, e.ds.join(' / ')]))
+)
+
+/** 分子に数える DS 部品名 */
+const DS_COUNTED = new Set(EQUIVALENTS.flatMap((e) => e.ds))
 
 const TARGETS = [
   ['saas-dashboard', 'apps/saas-dashboard/src'],
@@ -123,6 +146,8 @@ const analyze = (dir) => {
   const bypass = new Map()
   const bySite = []
   let dsUse = 0
+  // MUI に同等品が無い DS 部品。分子には数えないが、情報としては出す
+  const dsOnly = new Map()
   for (const file of walk(join(ROOT, dir))) {
     const src = readFileSync(file, 'utf8')
     const { map, typeOnly } = parseImports(src)
@@ -133,7 +158,8 @@ const analyze = (dir) => {
       const mod = map.get(name)
       if (!mod) continue
       if (isDs(mod)) {
-        dsUse++
+        if (DS_COUNTED.has(name)) dsUse++
+        else dsOnly.set(name, (dsOnly.get(name) ?? 0) + 1)
       } else if (isMui(mod) && DS_EQUIVALENT[name]) {
         bypass.set(name, (bypass.get(name) ?? 0) + 1)
         const line = src.slice(0, m.index).split('\n').length
@@ -146,7 +172,7 @@ const analyze = (dir) => {
       }
     }
   }
-  return { dsUse, bypass, bySite }
+  return { dsUse, bypass, bySite, dsOnly }
 }
 
 const strict = process.argv.includes('--strict')
@@ -173,6 +199,15 @@ const total = totalDs + totalBypass
 console.log(
   '\n  合計:',
   `DS ${totalDs} / MUI 直 ${totalBypass} → ${total ? ((totalDs / total) * 100).toFixed(1) : '—'}%`
+)
+
+const dsOnlyTotal = rows.reduce(
+  (n, r) => n + [...r.dsOnly.values()].reduce((a, c) => a + c, 0),
+  0
+)
+console.log(
+  `  参考: MUI に同等品が無い DS 部品の利用 ${dsOnlyTotal} 箇所`,
+  '（PageHeader / SectionTitle / KazeLogo 等。分子には数えない）'
 )
 
 const sites = rows.flatMap((r) => r.bySite)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,14 +28,27 @@ export default defineConfig({
     },
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      // json-summary があると coverage/coverage-summary.json から
+      // 数値をそのまま読める（自動化・報告用）
+      reporter: ['text', 'json', 'json-summary', 'html'],
+      // 除外するのは「生成物」だけにする。ソースを都合よく外すと
+      // 数字は上がるが実態を表さなくなる。
+      //
+      // storybook-static を外していなかったため、minify 済みの
+      // ベンダーバンドルだけで 114,000 statements (全体の 69%) が
+      // 0% として計上され、実態 27.5% が 8.5% と表示されていた。
+      // 末尾スラッシュだけの 'dist/' はルート直下しか外せず、
+      // apps/*/dist が残るので ** で書く。
       exclude: [
-        'node_modules/',
+        '**/node_modules/**',
+        '**/dist/**',
+        'coverage/**',
+        'storybook-static/**',
+        'gh-pages/**',
+        'figma-plugin/code.js',
         'src/test/',
         'src/**/*.stories.tsx',
         'src/**/*.d.ts',
-        'dist/',
-        'coverage/',
         '**/*.config.{js,ts}',
       ],
     },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,6 @@
 /// <reference types="vitest" />
 /// <reference path="./src/test/vitest-matchers.d.ts" />
-import { defineConfig } from 'vitest/config'
+import { coverageConfigDefaults, defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
@@ -39,17 +39,17 @@ export default defineConfig({
       // 0% として計上され、実態 27.5% が 8.5% と表示されていた。
       // 末尾スラッシュだけの 'dist/' はルート直下しか外せず、
       // apps/*/dist が残るので ** で書く。
+      // coverage.exclude は既定値を「置き換える」ので、自前の配列だけを
+      // 書くと vitest が元から外していたもの（テストファイル、*.d.ts、
+      // 各種 config 等）まで対象に戻る。既定を展開したうえで足す。
       exclude: [
-        '**/node_modules/**',
         '**/dist/**',
-        'coverage/**',
         'storybook-static/**',
         'gh-pages/**',
         'figma-plugin/code.js',
         'src/test/',
         'src/**/*.stories.tsx',
-        'src/**/*.d.ts',
-        '**/*.config.{js,ts}',
+        ...coverageConfigDefaults.exclude,
       ],
     },
   },


### PR DESCRIPTION
## 1. カバレッジ計測の修正

`pnpm test:all` が **8.5%** と表示していましたが、**これは誤りでした**。coverage の `exclude` に `storybook-static/` が無く、minify 済みのベンダーバンドルだけで **114,000 statements（全体の 69%）が 0% として計上**されていました。

| | Statements | 対象ファイル | 生成物の混入 |
|---|---|---|---|
| 修正前 | 8.50% | 465 | 195 件 |
| 修正後 | **27.41%** | 270 | **0 件** |

- `dist/` は末尾スラッシュだけだとルート直下しか外せず `apps/*/dist` が残るため `**/dist/**` に変更
- `storybook-static` / `gh-pages` / `figma-plugin/code.js` を追加
- **除外するのは生成物だけ**にしました。ソースを都合よく外せば数字は上がりますが実態を表さなくなるので、`scripts/` 等は対象に残しています
- `reporter` に `json-summary` を追加。`coverage/coverage-summary.json` から数値を直接読めます（今回それが無くて手計算していました）

### 実態（領域別 Statements）

| 領域 | ファイル | カバー率 |
|---|---|---|
| `src/themes/`（トークン・テーマ） | 10 | **86.7%** |
| `src/components/ui/ChatSupport/` | 24 | 59.8% |
| `packages/` | 5 | 47.2% |
| `src/components/`（DS 本体） | 92 | 44.1% |
| `src/utils/` | 8 | 25.8% |
| `src/layouts/` | 17 | 4.7% |
| **`apps/`（プロダクト3本）** | 59 | **2.7%** |

土台（テーマ・トークン）は厚く、プロダクト側はほぼ素通しという分布が見えるようになりました。

## 2. DS 準拠率の計測を追加

`scripts/ds-adoption.mjs` / `pnpm ds:adoption`

「**DS に同等品があるのに MUI を直接使っている箇所**」を数えます。import 元を解決したうえで JSX の実利用回数を数えるので、grep の件数とは別物です。

`Box` / `Grid` / `Stack` / `Typography` のようなレイアウト原始要素は DS に同等品が無く直接使うのが正しいため、**分母から外しています**。ここを混ぜると「準拠率 20%」のような実態と無関係な数字になります。

| アプリ | DS 使用 | MUI 直 | DS 準拠率 |
|---|---|---|---|
| saas-dashboard | 239 | 0 | **100.0%** |
| kaze-eats | 100 | 0 | **100.0%** |
| sky-kaze | 57 | 12 | 82.6% |
| LP | 2 | 0 | 100.0% |
| **合計** | **398** | **12** | **97.1%** |

未準拠はファイルと行番号付きで出力します。`--strict` で exit 1 にできます（CI に載せるかは別途判断）。

sky-kaze の 12 箇所（`TextField` 9 / `Chip` 3）は次の PR で DS へ寄せます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PtyboWRPPoLSn4ptQFdpj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * デザインシステム（DS）コンポーネントの利用状況を確認できるチェックコマンドを追加しました。
  * 未準拠のコンポーネント利用箇所を、ファイル名・行番号付きで確認できます。
  * 厳格モードでは、未準拠箇所がある場合にチェックが失敗します。

* **改善**
  * テストカバレッジで、JSON形式の概要とHTMLレポートを出力できるようになりました。
  * 生成物や対象外ディレクトリを除外し、カバレッジ結果の精度を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->