### PR TITLE
refactor(sky-kaze): MUI 直書きの入力・チップを DS コンポーネントへ寄せる

### DIFF
--- a/apps/sky-kaze/src/components/CompleteView.tsx
+++ b/apps/sky-kaze/src/components/CompleteView.tsx
@@ -9,10 +9,11 @@ import FileDownloadIcon from '@mui/icons-material/FileDownload'
 import NoteAddIcon from '@mui/icons-material/NoteAdd'
 import ReplayIcon from '@mui/icons-material/Replay'
 import StarIcon from '@mui/icons-material/Star'
-import { Box, Grid, Typography, TextField, alpha } from '@mui/material'
+import { Box, Grid, Typography, alpha } from '@mui/material'
 import { useState } from 'react'
 import { toast } from 'sonner'
 
+import { CustomTextField } from '@/components/Form/CustomTextField'
 import { Button } from '@/components/ui/Button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
 import { CustomChip } from '@/components/ui/chip'
@@ -620,7 +621,11 @@ export const CompleteView = () => {
         }}
         submitText='追加'
         submitDisabled={!noteText.trim()}>
-        <TextField
+        {/* placeholder はラベルの代わりにならない（フォーカスすると消え、
+            支援技術にも名前として渡らない）。DS の CustomTextField は
+            ラベルを必須にしているので、ここで明示する */}
+        <CustomTextField
+          label='メモ'
           autoFocus
           fullWidth
           multiline

--- a/apps/sky-kaze/src/components/DriverPanel.tsx
+++ b/apps/sky-kaze/src/components/DriverPanel.tsx
@@ -5,14 +5,7 @@
 import AccessTimeIcon from '@mui/icons-material/AccessTime'
 import CloseIcon from '@mui/icons-material/Close'
 import SpeedIcon from '@mui/icons-material/Speed'
-import {
-  Box,
-  Typography,
-  Chip,
-  alpha,
-  keyframes,
-  useMediaQuery,
-} from '@mui/material'
+import { Box, Typography, alpha, keyframes, useMediaQuery } from '@mui/material'
 import { useMemo } from 'react'
 
 // インシデント行の赤パルスアニメーション
@@ -27,6 +20,7 @@ const shimmer = keyframes`
   100% { transform: translateX(100%); }
 `
 
+import { CustomChip } from '@/components/ui/chip'
 import { IconButton } from '@/components/ui/icon-button'
 import { motionOf } from '@/themes/motion'
 
@@ -172,7 +166,7 @@ export const DriverPanel = () => {
                   </Typography>
                 </Box>
                 <Box sx={{ textAlign: 'right', flexShrink: 0 }}>
-                  <Chip
+                  <CustomChip
                     label={DRIVER_STATUS_LABEL[dp.status]}
                     size='small'
                     sx={{
@@ -271,7 +265,7 @@ export const DriverPanel = () => {
       <Box sx={{ px: 2, py: 1.5 }}>
         {/* ステータス + 速度 + ETA */}
         <Box sx={{ display: 'flex', gap: 1, mb: 1.5, flexWrap: 'wrap' }}>
-          <Chip
+          <CustomChip
             label={DRIVER_STATUS_LABEL[selected.status]}
             size='small'
             sx={{
@@ -503,7 +497,7 @@ export const DriverPanel = () => {
               </Typography>
             </Box>
 
-            <Chip
+            <CustomChip
               label={STATUS_LABELS[shipment.status]}
               size='small'
               sx={{

--- a/apps/sky-kaze/src/components/PrepareView.tsx
+++ b/apps/sky-kaze/src/components/PrepareView.tsx
@@ -10,17 +10,17 @@ import {
   CircularProgress,
   Grid,
   LinearProgress,
-  MenuItem,
   Step,
   StepLabel,
   Stepper,
-  TextField,
   Typography,
   alpha,
 } from '@mui/material'
 import { useState } from 'react'
 import { toast } from 'sonner'
 
+import { CustomSelect } from '@/components/Form/CustomSelect'
+import { CustomTextField } from '@/components/Form/CustomTextField'
 import { Button } from '@/components/ui/Button'
 import {
   Card,
@@ -74,6 +74,18 @@ const STEP_DESCRIPTIONS = [
   '出荷予定の荷物を確認してください',
   '全8項目をチェックすると次に進めます',
   'ドライバーの割当状況を確認してください',
+]
+
+/** CustomSelect は MenuItem の children ではなく options 配列を受け取る */
+const HUB_OPTIONS = HUBS.map((h) => ({
+  value: h.code,
+  label: `${h.code} — ${h.name}`,
+}))
+
+const PRIORITY_OPTIONS = [
+  { value: 'standard', label: '標準' },
+  { value: 'express', label: '速達' },
+  { value: 'same_day', label: '当日' },
 ]
 
 const PriorityChip = ({ priority }: { priority: Shipment['priority'] }) => {
@@ -715,7 +727,7 @@ export const PrepareView = () => {
           !newShipment.destinationHub
         }>
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2.5, mt: 1 }}>
-          <TextField
+          <CustomTextField
             label='内容物'
             placeholder='例: 電子部品 型番ABC-1234 500個'
             fullWidth
@@ -726,7 +738,7 @@ export const PrepareView = () => {
             }
           />
           <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 2 }}>
-            <TextField
+            <CustomTextField
               label='送り主（会社名）'
               placeholder='例: 田中電機株式会社'
               value={newShipment.senderCompany}
@@ -734,7 +746,7 @@ export const PrepareView = () => {
                 setNewShipment((p) => ({ ...p, senderCompany: e.target.value }))
               }
             />
-            <TextField
+            <CustomTextField
               label='届け先（会社名）'
               placeholder='例: 鈴木自動車部品'
               value={newShipment.receiverCompany}
@@ -747,65 +759,50 @@ export const PrepareView = () => {
             />
           </Box>
           <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 2 }}>
-            <TextField
+            <CustomSelect
               label='出発拠点'
-              select
               required
               value={newShipment.originHub}
-              onChange={(e) =>
-                setNewShipment((p) => ({ ...p, originHub: e.target.value }))
-              }>
-              {HUBS.map((h) => (
-                <MenuItem key={h.code} value={h.code}>
-                  {h.code} — {h.name}
-                </MenuItem>
-              ))}
-            </TextField>
-            <TextField
+              options={HUB_OPTIONS}
+              onChange={(_, value) =>
+                setNewShipment((p) => ({ ...p, originHub: String(value) }))
+              }
+            />
+            <CustomSelect
               label='到着拠点'
-              select
               required
               value={newShipment.destinationHub}
-              onChange={(e) =>
-                setNewShipment((p) => ({
-                  ...p,
-                  destinationHub: e.target.value,
-                }))
-              }>
-              {HUBS.map((h) => (
-                <MenuItem key={h.code} value={h.code}>
-                  {h.code} — {h.name}
-                </MenuItem>
-              ))}
-            </TextField>
+              options={HUB_OPTIONS}
+              onChange={(_, value) =>
+                setNewShipment((p) => ({ ...p, destinationHub: String(value) }))
+              }
+            />
           </Box>
           <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 2 }}>
-            <TextField
+            <CustomTextField
               label='重量 (kg)'
               type='number'
               placeholder='例: 500'
               value={newShipment.weight}
+              // フォーカス中のホイールで値が勝手に変わるのを止める
+              onWheel={(e) => (e.target as HTMLElement).blur()}
               onChange={(e) =>
                 setNewShipment((p) => ({ ...p, weight: e.target.value }))
               }
             />
-            <TextField
+            <CustomSelect
               label='優先度'
-              select
               value={newShipment.priority}
-              onChange={(e) =>
+              options={PRIORITY_OPTIONS}
+              onChange={(_, value) =>
                 setNewShipment((p) => ({
                   ...p,
-                  priority: e.target.value as
-                    'standard' | 'express' | 'same_day',
+                  priority: value as 'standard' | 'express' | 'same_day',
                 }))
-              }>
-              <MenuItem value='standard'>標準</MenuItem>
-              <MenuItem value='express'>速達</MenuItem>
-              <MenuItem value='same_day'>当日</MenuItem>
-            </TextField>
+              }
+            />
           </Box>
-          <TextField
+          <CustomTextField
             label='特記事項'
             placeholder='例: 冷蔵必須、天地無用、時間指定あり'
             multiline


### PR DESCRIPTION
計測で唯一の未準拠だった sky-kaze の 12 箇所を DS に寄せ、**プロダクト 3 本すべてが DS 準拠率 100%** になりました。

| アプリ | 変更前 | 変更後 |
|---|---|---|
| saas-dashboard | 100.0% | 100.0% |
| kaze-eats | 100.0% | 100.0% |
| **sky-kaze** | **82.6%**（DS 57 / MUI 直 12） | **100.0%**（DS 69 / MUI 直 0） |
| **合計** | 97.1% | **100.0%** |

## 変更

- **PrepareView**: `TextField` 5 → `CustomTextField`、`TextField select` 3 → `CustomSelect`（MenuItem の children ではなく `options` 配列を取るため `HUB_OPTIONS` / `PRIORITY_OPTIONS` を定義）
- **CompleteView**: `TextField` 1 → `CustomTextField`
- **DriverPanel**: `Chip` 3 → `CustomChip`

## ついでに直したもの

- **CompleteView のメモ欄にラベルが無かった。** placeholder だけで、フォーカスすると消え、支援技術にも名前として渡らない状態でした。`CustomTextField` はラベルを必須にしているので「メモ」を明示しています
- **重量 (kg) は `type='number'` で、フォーカス中にホイールを回すと値が勝手に変わる。** `onWheel` で blur して止めました

## 見た目の変更

DS の `CustomTextField` はラベルを枠内に浮かせず**上に置きます**（静的ラベル + 太字）。フィールドの高さが 58px → 67px になり、ダイアログ全体は 641px。**ビューポートは超えません**。

## 検証（実ブラウザ）

- 変更前後でダイアログの全フィールドを計測して比較
- **8 項目すべてで label と input が id で紐づく**ことを確認（変更前は select 3 つが `div` のまま名前を持っていませんでした）
- 出発拠点の select を**実クリックで開き**、`HUB_OPTIONS` の 13 件が並ぶこと、選択が state に反映されること（`YKH-W — 横浜港湾倉庫`）、必須未入力の間は送信ボタンが `disabled` のままであることを確認
- 監視フェーズで `CustomChip` 13 個が従来どおりの色・高さで描画されることを確認
- `pnpm test:run` 522 passed / `tsc --noEmit` + `vite build` 通過

> 合成クリックでは MUI の Select は開きません（mousedown で開くため）。Playwright の実クリックで操作して確認しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PtyboWRPPoLSn4ptQFdpj