### PR TITLE
chore: アプリからの MUI 直 import を ESLint で止め、対応表を単一ソース化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,25 @@ This project uses both Japanese and English:
 - `<Grid item xs={12}>` → `<Grid size={{ xs: 12 }}>`
 - ハードコード色値 → トークン参照 (`primary.main`)
 - `window.confirm()` → `ConfirmDialog` コンポーネント
+- **アプリから MUI の UI 部品を直 import**（DS に同等品があるもの）→ DS を使う
 - 詳細: `foundations/prohibited.md`
+
+### DS ファースト（アプリを作るとき）
+
+プロダクトの UI は Storybook に定義された DS コンポーネントで組む。
+`apps/*/src` と `src/pages` では、**DS に同等品がある MUI 部品の直 import を
+ESLint が error で止める**（`TextField` → `CustomTextField` 等）。
+
+`Box` / `Grid` / `Stack` / `Typography` のようなレイアウト原始要素は DS に
+同等品が無いため対象外で、直接使ってよい。
+
+対応表の単一ソースは `scripts/ds-equivalents.mjs`。ESLint と計測が同じ表を
+見るので、DS に部品を足したらここだけ更新すればよい。
+
+```bash
+pnpm ds:adoption          # 準拠率を測る
+pnpm ds:adoption --strict # 未準拠があれば exit 1
+```
 
 ### 機械可読データ
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,6 +9,11 @@ import eslintPluginTailwindCSS from 'eslint-plugin-tailwindcss'
 import eslintPluginUnusedImports from 'eslint-plugin-unused-imports'
 import tseslint from 'typescript-eslint'
 
+import {
+  DS_EQUIVALENT,
+  RESTRICTED_MUI_IMPORTS,
+} from './scripts/ds-equivalents.mjs'
+
 export default tseslint.config({
   ignores: [
     '**/node_modules',
@@ -202,6 +207,30 @@ export default tseslint.config({
       }
     ],
     ...eslintPluginReactHooks.configs.recommended.rules,
+  },
+}, {
+  // プロダクト側から MUI を直に取らせない（DS に同等品があるものだけ）
+  //
+  // 対象はアプリと LP だけ。DS 本体 (src/components) は MUI を包む側なので
+  // 当然 MUI を import する。Storybook の story も比較のために直に使う。
+  //
+  // 一覧は scripts/ds-equivalents.mjs が単一ソース。計測 (pnpm ds:adoption)
+  // と同じ表を見るので、片方だけ更新されて食い違うことがない。
+  name: 'kaze/ds-first',
+  files: ['apps/*/src/**/*.{ts,tsx}', 'src/pages/**/*.{ts,tsx}'],
+  rules: {
+    'no-restricted-imports': [
+      'error',
+      {
+        // 名前ごとに 1 エントリにする。まとめて 1 つの message にすると
+        // 対応表 20 件分が毎回出て、肝心の置き換え先が読み取れない
+        paths: RESTRICTED_MUI_IMPORTS.map((name) => ({
+          name: '@mui/material',
+          importNames: [name],
+          message: `DS の ${DS_EQUIVALENT[name]} を使ってください。レイアウト原始要素 (Box / Grid / Stack / Typography 等) は対象外です。`,
+        })),
+      },
+    ],
   },
 }, {
   name: 'eslint-config-prettier',

--- a/scripts/ds-adoption.mjs
+++ b/scripts/ds-adoption.mjs
@@ -17,63 +17,9 @@ import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { DS_COUNTED, DS_EQUIVALENT } from './ds-equivalents.mjs'
+
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
-
-/**
- * MUI の部品と DS の同等品の対応。**両方向を機械可読にする。**
- *
- * - `mui` を MUI から直接 import していたら未準拠（分母の一方）
- * - `ds` を DS から import していたら準拠（分子）
- *
- * **分子は「対応表に載っている DS 部品」だけを数える。** `@/components`
- * から来たもの全部を数えると、MUI に同等品が無い部品（PageHeader /
- * SectionTitle / KazeLogo 等）まで分子に入り、準拠率を過大に見せる。
- *
- * DS 側に部品を足したら、ここにも足す。
- */
-export const EQUIVALENTS = [
-  { mui: ['TextField'], ds: ['CustomTextField'] },
-  { mui: ['Select'], ds: ['CustomSelect'] },
-  { mui: ['Autocomplete'], ds: ['MultiSelectAutocomplete'] },
-  { mui: ['Chip'], ds: ['CustomChip', 'ConnectionStatusChip'] },
-  { mui: ['Button'], ds: ['Button', 'LoadingButton', 'SaveButton'] },
-  { mui: ['IconButton'], ds: ['IconButton'] },
-  {
-    mui: ['Card', 'CardContent', 'CardHeader', 'CardActions'],
-    ds: [
-      'Card',
-      'CardContent',
-      'CardHeader',
-      'CardTitle',
-      'CardDescription',
-      'CardFooter',
-      'ServiceCard',
-    ],
-  },
-  {
-    mui: ['Table', 'TableContainer'],
-    ds: ['CustomTable', 'ResourceTable', 'TableToolbar'],
-  },
-  { mui: ['Tooltip'], ds: ['CustomTooltip'] },
-  { mui: ['Avatar'], ds: ['UserAvatar'] },
-  { mui: ['Accordion'], ds: ['CustomAccordion'] },
-  { mui: ['Dialog'], ds: ['ConfirmDialog', 'FormDialog'] },
-  { mui: ['Pagination'], ds: ['Pagination'] },
-  { mui: ['Fab'], ds: ['Fab'] },
-  { mui: ['Menu'], ds: ['ActionMenu'] },
-  { mui: ['ToggleButton'], ds: ['ToggleButton'] },
-  { mui: ['ToggleButtonGroup'], ds: ['ToggleButtonGroup'] },
-  { mui: ['ButtonGroup'], ds: ['ButtonGroup'] },
-  { mui: ['Snackbar', 'Alert'], ds: ['CustomToaster'] },
-]
-
-/** MUI 名 → 置き換え先の表示（未準拠の報告に使う） */
-export const DS_EQUIVALENT = Object.fromEntries(
-  EQUIVALENTS.flatMap((e) => e.mui.map((m) => [m, e.ds.join(' / ')]))
-)
-
-/** 分子に数える DS 部品名 */
-const DS_COUNTED = new Set(EQUIVALENTS.flatMap((e) => e.ds))
 
 const TARGETS = [
   ['saas-dashboard', 'apps/saas-dashboard/src'],

--- a/scripts/ds-equivalents.mjs
+++ b/scripts/ds-equivalents.mjs
@@ -1,0 +1,59 @@
+/**
+ * MUI の部品と DS の同等品の対応表。**単一ソース。**
+ *
+ * ここを見る側が 2 つある。
+ * - `scripts/ds-adoption.mjs`: 準拠率の計測
+ * - `eslint.config.js`: アプリからの MUI 直 import の禁止
+ *
+ * 別々に持つと、DS に部品を足したときに片方だけ更新されて、
+ * 「計測では未準拠なのに lint は通る」状態になる。
+ *
+ * - `mui`: MUI から直接 import したら未準拠になる名前
+ * - `ds` : 同等品として数える DS 側の名前
+ */
+export const EQUIVALENTS = [
+  { mui: ['TextField'], ds: ['CustomTextField'] },
+  { mui: ['Select'], ds: ['CustomSelect'] },
+  { mui: ['Autocomplete'], ds: ['MultiSelectAutocomplete'] },
+  { mui: ['Chip'], ds: ['CustomChip', 'ConnectionStatusChip'] },
+  { mui: ['Button'], ds: ['Button', 'LoadingButton', 'SaveButton'] },
+  { mui: ['IconButton'], ds: ['IconButton'] },
+  {
+    mui: ['Card', 'CardContent', 'CardHeader', 'CardActions'],
+    ds: [
+      'Card',
+      'CardContent',
+      'CardHeader',
+      'CardTitle',
+      'CardDescription',
+      'CardFooter',
+      'ServiceCard',
+    ],
+  },
+  {
+    mui: ['Table', 'TableContainer'],
+    ds: ['CustomTable', 'ResourceTable', 'TableToolbar'],
+  },
+  { mui: ['Tooltip'], ds: ['CustomTooltip'] },
+  { mui: ['Avatar'], ds: ['UserAvatar'] },
+  { mui: ['Accordion'], ds: ['CustomAccordion'] },
+  { mui: ['Dialog'], ds: ['ConfirmDialog', 'FormDialog'] },
+  { mui: ['Pagination'], ds: ['Pagination'] },
+  { mui: ['Fab'], ds: ['Fab'] },
+  { mui: ['Menu'], ds: ['ActionMenu'] },
+  { mui: ['ToggleButton'], ds: ['ToggleButton'] },
+  { mui: ['ToggleButtonGroup'], ds: ['ToggleButtonGroup'] },
+  { mui: ['ButtonGroup'], ds: ['ButtonGroup'] },
+  { mui: ['Snackbar', 'Alert'], ds: ['CustomToaster'] },
+]
+
+/** MUI 名 → 置き換え先の表示 */
+export const DS_EQUIVALENT = Object.fromEntries(
+  EQUIVALENTS.flatMap((e) => e.mui.map((m) => [m, e.ds.join(' / ')]))
+)
+
+/** 準拠率の分子に数える DS 部品名 */
+export const DS_COUNTED = new Set(EQUIVALENTS.flatMap((e) => e.ds))
+
+/** MUI から直接 import したら止める名前 */
+export const RESTRICTED_MUI_IMPORTS = EQUIVALENTS.flatMap((e) => e.mui)


### PR DESCRIPTION
DS 準拠率 100% は今のところ**運用で守られているだけ**で、次のプロダクトで崩れます。仕組みで守ります。

## 変更

- **`apps/*/src` と `src/pages` に `no-restricted-imports` を追加。** DS に同等品がある MUI 部品（`TextField` / `Chip` / `Card` / `Dialog` 等 24 名）の直 import を **error** で止めます
- **DS 本体 (`src/components`) と Storybook の story は対象外。** DS は MUI を包む側なので当然 MUI を import しますし、story は比較のために直に使います
- `Box` / `Grid` / `Stack` / `Typography` 等のレイアウト原始要素は DS に同等品が無いので対象外

## 対応表を単一ソースに

`scripts/ds-equivalents.mjs` に切り出しました。**ESLint と計測（`pnpm ds:adoption`）が同じ表を見ます。**

別々に持つと、DS に部品を足したときに片方だけ更新されて「計測では未準拠なのに lint は通る」状態になります。

## エラーメッセージ

名前ごとに 1 エントリにしました。まとめて 1 つの `message` にすると対応表 20 件分が毎回出て、肝心の置き換え先が読み取れません（**実際に一度そうなったので直しました**）。

```
'Chip' import from '@mui/material' is restricted.
  DS の CustomChip / ConnectionStatusChip を使ってください。
  レイアウト原始要素 (Box / Grid / Stack / Typography 等) は対象外です。
```

## 検証（既知の正解と既知の違反の両方）

| ケース | 期待 | 結果 |
|---|---|---|
| リポジトリ全体（アプリ・LP・DS 本体） | 0 件 | ✅ 0 件 |
| アプリに `import { TextField, Chip } from '@mui/material'` | 2 件 error | ✅ それぞれ `CustomTextField` / `CustomChip` を名指し |
| 同じファイルで `Box` / `Typography` のみ | 通る | ✅ |
| DS 本体 `customChip.tsx` が MUI を直 import | 通る | ✅ |

`pnpm lint` / `pnpm test:run` 522 passed / `pnpm ds:adoption` 100%。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PtyboWRPPoLSn4ptQFdpj