### PR TITLE
feat: プロダクト固有だった StatCard / EmptyState を DS へ引き上げ、カバレッジ計測の穴を塞ぐ

### DIFF
--- a/apps/kaze-eats/src/pages/CartPage.tsx
+++ b/apps/kaze-eats/src/pages/CartPage.tsx
@@ -12,6 +12,7 @@ import { CustomTextField } from '@/components/Form/CustomTextField'
 import { Button } from '@/components/ui/Button'
 import { LoadingButton } from '@/components/ui/button/loadingButton'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
+import { EmptyState } from '@/components/ui/feedback'
 import { IconButton } from '@/components/ui/icon-button'
 import { toast } from '@/components/ui/toast'
 
@@ -67,26 +68,16 @@ export const CartPage = () => {
             <ArrowBackIcon />
           </IconButton>
         </Box>
-        <Box sx={{ textAlign: 'center', py: 10 }}>
-          <ShoppingCartOutlinedIcon
-            sx={{ fontSize: 64, color: 'text.disabled', mb: 2 }}
-            aria-hidden='true'
-          />
-          <Typography
-            variant='h5'
-            sx={{ fontWeight: 700, mb: 1, letterSpacing: '-0.01em' }}>
-            Your cart is empty
-          </Typography>
-          <Typography
-            variant='body1'
-            color='text.secondary'
-            sx={{ mb: 4, maxWidth: 360, mx: 'auto' }}>
-            Add items from a restaurant to get started
-          </Typography>
-          <Button variant='default' onClick={() => navigate('/')}>
-            Browse Restaurants
-          </Button>
-        </Box>
+        <EmptyState
+          icon={<ShoppingCartOutlinedIcon />}
+          title='Your cart is empty'
+          description='Add items from a restaurant to get started'
+          action={
+            <Button variant='default' onClick={() => navigate('/')}>
+              Browse Restaurants
+            </Button>
+          }
+        />
       </Box>
     )
   }

--- a/apps/kaze-eats/src/pages/HomePage.tsx
+++ b/apps/kaze-eats/src/pages/HomePage.tsx
@@ -12,6 +12,7 @@ import { CustomTextField } from '@/components/Form/CustomTextField'
 import { Button } from '@/components/ui/Button'
 import { Card, CardContent } from '@/components/ui/Card'
 import { CustomChip } from '@/components/ui/chip'
+import { EmptyState } from '@/components/ui/feedback'
 import { elevation } from '@/themes/elevation'
 import { motionOf } from '@/themes/motion'
 
@@ -460,41 +461,25 @@ export const HomePage = () => {
             ))}
             {filteredRestaurants.length === 0 && (
               <Grid size={12}>
-                <Box
-                  sx={{
-                    textAlign: 'center',
-                    py: 10,
-                    px: 3,
-                  }}>
-                  <SearchIcon
-                    sx={{ fontSize: 48, color: 'text.disabled', mb: 2 }}
-                    aria-hidden='true'
-                  />
-                  <Typography
-                    variant='h6'
-                    color='text.secondary'
-                    sx={{ fontWeight: 600, mb: 0.5 }}>
-                    No restaurants found
-                  </Typography>
-                  <Typography
-                    variant='body2'
-                    color='text.secondary'
-                    sx={{ mb: 3 }}>
-                    Try a different search or category
-                  </Typography>
-                  <Button
-                    variant='outline'
-                    onClick={() => {
-                      setSearch('')
-                      setSelectedCategory('all')
-                    }}>
-                    <ArrowForwardIcon
-                      sx={{ fontSize: 18, mr: 0.5 }}
-                      aria-hidden='true'
-                    />
-                    View all restaurants
-                  </Button>
-                </Box>
+                <EmptyState
+                  icon={<SearchIcon />}
+                  title='No restaurants found'
+                  description='Try a different search or category'
+                  action={
+                    <Button
+                      variant='outline'
+                      onClick={() => {
+                        setSearch('')
+                        setSelectedCategory('all')
+                      }}>
+                      <ArrowForwardIcon
+                        sx={{ fontSize: 18, mr: 0.5 }}
+                        aria-hidden='true'
+                      />
+                      View all restaurants
+                    </Button>
+                  }
+                />
               </Grid>
             )}
           </Grid>

--- a/apps/saas-dashboard/src/pages/DashboardPage.tsx
+++ b/apps/saas-dashboard/src/pages/DashboardPage.tsx
@@ -3,8 +3,6 @@ import AttachMoneyIcon from '@mui/icons-material/AttachMoney'
 import ContactsIcon from '@mui/icons-material/Contacts'
 import FolderIcon from '@mui/icons-material/Folder'
 import TaskAltIcon from '@mui/icons-material/TaskAlt'
-import TrendingDownIcon from '@mui/icons-material/TrendingDown'
-import TrendingUpIcon from '@mui/icons-material/TrendingUp'
 import { Box, Grid, Typography, LinearProgress } from '@mui/material'
 import dayjs from 'dayjs'
 import { useState } from 'react'
@@ -15,11 +13,10 @@ import { MiniCalendar } from '@/components/ui/calendar'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
 import { CustomChip } from '@/components/ui/chip'
 import { Fab } from '@/components/ui/fab'
+import { StatCard } from '@/components/ui/stat-card'
 import { StatusTag } from '@/components/ui/tag'
 import type { StatusType } from '@/components/ui/tag'
 import { PageHeader } from '@/components/ui/text'
-import { elevation } from '@/themes/elevation'
-import { KAZE_EYEBROW, KAZE_PRINT } from '@/themes/kazeMixins'
 import { motionOf } from '@/themes/motion'
 
 import { activities } from '~/data/activity'
@@ -103,108 +100,31 @@ export const DashboardPage = () => {
           const iconConfig = kpiIconConfig[kpi.icon]
           return (
             <Grid size={{ xs: 12, sm: 6, md: 3 }} key={kpi.id}>
-              <Card
-                sx={{
-                  // 影スケールが mode 別に生成されるため light/dark 分岐は不要
-                  transition: motionOf(
-                    ['box-shadow', 'transform', 'border-color'],
-                    'short'
-                  ),
-                  '&:hover': {
-                    transform: 'translateY(-2px)',
-                    boxShadow: (theme) => theme.shadows[elevation.floating],
-                  },
-                }}>
-                <CardContent sx={{ p: 2.5, '&:last-child': { pb: 2.5 } }}>
+              <StatCard
+                interactive
+                label={kpi.title}
+                value={kpi.value}
+                trend={{
+                  direction: kpi.change > 0 ? 'up' : 'down',
+                  value: `${kpi.change > 0 ? '+' : ''}${kpi.change}%`,
+                  caption: kpi.changeLabel,
+                }}
+                icon={
                   <Box
                     sx={{
+                      width: 44,
+                      height: 44,
+                      borderRadius: 2,
                       display: 'flex',
-                      justifyContent: 'space-between',
-                      alignItems: 'flex-start',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      bgcolor: iconConfig.bgColor,
+                      color: iconConfig.color,
                     }}>
-                    <Box sx={{ flex: 1 }}>
-                      <Typography
-                        variant='body2'
-                        color='text.secondary'
-                        sx={{
-                          ...KAZE_EYEBROW,
-                          mb: 0.75,
-                          fontSize: '0.68rem',
-                          color: 'text.secondary',
-                        }}>
-                        {kpi.title}
-                      </Typography>
-                      <Typography
-                        variant='h4'
-                        sx={{
-                          ...KAZE_PRINT,
-                          fontSize: { xs: '1.9rem', sm: '2.2rem' },
-                          letterSpacing: '-0.025em',
-                        }}>
-                        {kpi.value}
-                      </Typography>
-                      <Box
-                        sx={{
-                          display: 'inline-flex',
-                          alignItems: 'center',
-                          mt: 1.5,
-                          gap: 0.5,
-                          bgcolor:
-                            kpi.change > 0
-                              ? 'rgba(70, 171, 74, 0.08)'
-                              : 'rgba(218, 55, 55, 0.08)',
-                          px: 1,
-                          py: 0.25,
-                          borderRadius: 1,
-                        }}>
-                        {kpi.change > 0 ? (
-                          <TrendingUpIcon
-                            sx={{ fontSize: 16, color: 'success.textContrast' }}
-                            aria-hidden='true'
-                          />
-                        ) : (
-                          <TrendingDownIcon
-                            sx={{ fontSize: 16, color: 'error.textContrast' }}
-                            aria-hidden='true'
-                          />
-                        )}
-                        <Typography
-                          variant='caption'
-                          sx={{
-                            color:
-                              kpi.change > 0
-                                ? 'success.textContrast'
-                                : 'error.textContrast',
-                            fontWeight: 600,
-                          }}>
-                          {kpi.change > 0 ? '+' : ''}
-                          {kpi.change}%
-                        </Typography>
-                        <Typography
-                          variant='caption'
-                          color='text.secondary'
-                          sx={{ fontSize: '0.7rem' }}>
-                          {kpi.changeLabel}
-                        </Typography>
-                      </Box>
-                    </Box>
-                    <Box
-                      sx={{
-                        width: 44,
-                        height: 44,
-                        borderRadius: 2,
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        bgcolor: iconConfig.bgColor,
-                        color: iconConfig.color,
-                        flexShrink: 0,
-                      }}>
-                      {iconConfig.icon}
-                    </Box>
+                    {iconConfig.icon}
                   </Box>
-                </CardContent>
-              </Card>
+                }
+              />
             </Grid>
           )
         })}

--- a/apps/saas-dashboard/src/pages/DashboardPage.tsx
+++ b/apps/saas-dashboard/src/pages/DashboardPage.tsx
@@ -107,8 +107,8 @@ export const DashboardPage = () => {
                 trend={{
                   direction: kpi.change > 0 ? 'up' : 'down',
                   value: `${kpi.change > 0 ? '+' : ''}${kpi.change}%`,
-                  caption: kpi.changeLabel,
                 }}
+                caption={kpi.changeLabel}
                 icon={
                   <Box
                     sx={{

--- a/apps/sky-kaze/src/__tests__/readableStatusColor.test.ts
+++ b/apps/sky-kaze/src/__tests__/readableStatusColor.test.ts
@@ -1,0 +1,107 @@
+// ステータス色の明度補正 ユニットテスト
+//
+// ここは「見た目の調整」ではなく、置かれる面で読めることを保証する計算。
+// 壊れても画面は出るので、テストが無いと気づけない。
+
+import { describe, expect, it } from 'vitest'
+
+import { CONTRAST_THRESHOLD, contrastRatioOf } from '@/themes/contrast'
+
+import {
+  PANEL_BACKGROUNDS,
+  readableOnTint,
+  readableStatusColor,
+} from '~/utils/readableStatusColor'
+
+import { DRIVER_STATUS_COLOR } from '~/data/simulation'
+import { STATUS_COLORS } from '~/data/logistics'
+
+const MODES = ['light', 'dark'] as const
+
+describe('readableStatusColor', () => {
+  it.each(MODES)('%s: パネルの実効背景で本文 AA を満たす', (mode) => {
+    const bg = PANEL_BACKGROUNDS.standard[mode]
+    for (const color of Object.values(STATUS_COLORS)) {
+      expect(
+        contrastRatioOf(readableStatusColor(color, mode), bg),
+        `${mode} / ${color}`
+      ).toBeGreaterThanOrEqual(CONTRAST_THRESHOLD.text)
+    }
+  })
+
+  it.each(MODES)('%s: ドライバーの状態色も同じ基準を満たす', (mode) => {
+    const bg = PANEL_BACKGROUNDS.standard[mode]
+    for (const color of Object.values(DRIVER_STATUS_COLOR)) {
+      expect(
+        contrastRatioOf(readableStatusColor(color, mode), bg),
+        `${mode} / ${color}`
+      ).toBeGreaterThanOrEqual(CONTRAST_THRESHOLD.text)
+    }
+  })
+
+  it('補正前のブランド色そのままでは基準に届かないものがある', () => {
+    // 補正が「何もしていない」わけではないことを示す。
+    // 全部が元から基準を満たしているなら、この関数は不要ということになる
+    const bg = PANEL_BACKGROUNDS.standard.dark
+    const raw = Object.values(STATUS_COLORS).map((c) => contrastRatioOf(c, bg))
+    expect(Math.min(...raw)).toBeLessThan(CONTRAST_THRESHOLD.text)
+  })
+
+  it('同じ入力には同じ値を返す（キャッシュしても結果が変わらない）', () => {
+    const a = readableStatusColor('#8B5CF6', 'dark')
+    const b = readableStatusColor('#8B5CF6', 'dark')
+    expect(a).toBe(b)
+  })
+
+  it('モードが違えば別の値になりうる', () => {
+    const light = readableStatusColor('#3B82F6', 'light')
+    const dark = readableStatusColor('#3B82F6', 'dark')
+    expect(typeof light).toBe('string')
+    expect(typeof dark).toBe('string')
+    // 明暗が逆の面に同じ色を置けば、どちらかは必ず割れる
+    expect(light).not.toBe(dark)
+  })
+})
+
+describe('readableOnTint', () => {
+  it('自身の色を薄く敷いた面の上でも本文 AA を満たす', () => {
+    // Chip は面に alpha 0.12 で自分の色を敷く。素のパネル面で測ると
+    // 足りているように見えて、実際に描かれる面では割れる
+    const surface = '#FFFFFF'
+    for (const color of Object.values(STATUS_COLORS)) {
+      const ink = readableOnTint(color, surface)
+      const tinted = surface // 合成後の面は関数内部で作られる
+      expect(contrastRatioOf(ink, tinted), color).toBeGreaterThan(0)
+    }
+  })
+
+  it('tint の濃さを変えると結果も変わりうる', () => {
+    const light = readableOnTint('#F59E0B', '#FFFFFF', 0.12)
+    const heavy = readableOnTint('#F59E0B', '#FFFFFF', 0.5)
+    expect(typeof light).toBe('string')
+    expect(typeof heavy).toBe('string')
+  })
+
+  it('同じ入力には同じ値を返す', () => {
+    expect(readableOnTint('#22C55E', '#242424')).toBe(
+      readableOnTint('#22C55E', '#242424')
+    )
+  })
+})
+
+describe('PANEL_BACKGROUNDS', () => {
+  it('半透明のパネルを下地に合成した solid 値を持つ', () => {
+    for (const kind of ['standard', 'emphasized'] as const) {
+      for (const mode of MODES) {
+        expect(PANEL_BACKGROUNDS[kind][mode]).toMatch(/^#[0-9a-f]{6}$/i)
+      }
+    }
+  })
+
+  it('強調パネルは標準より不透明なので、下地の影響が小さい', () => {
+    // 標準と強調が同値なら、合成が効いていないということ
+    expect(PANEL_BACKGROUNDS.standard.dark).not.toBe(
+      PANEL_BACKGROUNDS.emphasized.dark
+    )
+  })
+})

--- a/apps/sky-kaze/src/__tests__/readableStatusColor.test.ts
+++ b/apps/sky-kaze/src/__tests__/readableStatusColor.test.ts
@@ -5,7 +5,12 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { CONTRAST_THRESHOLD, contrastRatioOf } from '@/themes/contrast'
+import {
+  CONTRAST_THRESHOLD,
+  composite,
+  contrastRatioOf,
+  parseColor,
+} from '@/themes/contrast'
 
 import {
   PANEL_BACKGROUNDS,
@@ -63,23 +68,41 @@ describe('readableStatusColor', () => {
   })
 })
 
+/** 実装と同じ手順で「実際に描かれる面」を作る */
+const tintedSurface = (color: string, surface: string, alpha = 0.12) => {
+  const c = composite({ ...parseColor(color), a: alpha }, parseColor(surface))
+  return `#${[c.r, c.g, c.b].map((v) => Math.round(v).toString(16).padStart(2, '0')).join('')}`
+}
+
 describe('readableOnTint', () => {
-  it('自身の色を薄く敷いた面の上でも本文 AA を満たす', () => {
-    // Chip は面に alpha 0.12 で自分の色を敷く。素のパネル面で測ると
-    // 足りているように見えて、実際に描かれる面では割れる
-    const surface = '#FFFFFF'
-    for (const color of Object.values(STATUS_COLORS)) {
-      const ink = readableOnTint(color, surface)
-      const tinted = surface // 合成後の面は関数内部で作られる
-      expect(contrastRatioOf(ink, tinted), color).toBeGreaterThan(0)
+  it.each(['#FFFFFF', '#242424'])(
+    '%s の上に色を薄く敷いた面で本文 AA を満たす',
+    (surface) => {
+      // Chip は面に alpha 0.12 で自分の色を敷く。素の面で測ると
+      // 足りているように見えて、実際に描かれる面では割れる。
+      // **合成後の面に対して測らないと、この関数の意味を検証していない**
+      for (const color of Object.values(STATUS_COLORS)) {
+        const ink = readableOnTint(color, surface)
+        expect(
+          contrastRatioOf(ink, tintedSurface(color, surface)),
+          `${surface} / ${color}`
+        ).toBeGreaterThanOrEqual(CONTRAST_THRESHOLD.text)
+      }
     }
+  )
+
+  it('補正しなければ届かない色がある（関数が実際に効いている）', () => {
+    const surface = '#FFFFFF'
+    const raw = Object.values(STATUS_COLORS).map((c) =>
+      contrastRatioOf(c, tintedSurface(c, surface))
+    )
+    expect(Math.min(...raw)).toBeLessThan(CONTRAST_THRESHOLD.text)
   })
 
-  it('tint の濃さを変えると結果も変わりうる', () => {
+  it('tint が濃いほど面が沈むので、文字側も変わる', () => {
     const light = readableOnTint('#F59E0B', '#FFFFFF', 0.12)
-    const heavy = readableOnTint('#F59E0B', '#FFFFFF', 0.5)
-    expect(typeof light).toBe('string')
-    expect(typeof heavy).toBe('string')
+    const heavy = readableOnTint('#F59E0B', '#FFFFFF', 0.6)
+    expect(light).not.toBe(heavy)
   })
 
   it('同じ入力には同じ値を返す', () => {

--- a/apps/sky-kaze/src/components/CompleteView.tsx
+++ b/apps/sky-kaze/src/components/CompleteView.tsx
@@ -9,7 +9,7 @@ import FileDownloadIcon from '@mui/icons-material/FileDownload'
 import NoteAddIcon from '@mui/icons-material/NoteAdd'
 import ReplayIcon from '@mui/icons-material/Replay'
 import StarIcon from '@mui/icons-material/Star'
-import { Box, Grid, Typography, alpha } from '@mui/material'
+import { Box, Grid, Typography, alpha, useTheme } from '@mui/material'
 import { useState } from 'react'
 import { toast } from 'sonner'
 
@@ -20,6 +20,7 @@ import { CustomChip } from '@/components/ui/chip'
 import { ConfirmDialog } from '@/components/ui/dialog'
 import { FormDialog } from '@/components/ui/dialog'
 import { IconButton } from '@/components/ui/icon-button'
+import { StatCard } from '@/components/ui/stat-card'
 import { SectionTitle } from '@/components/ui/text/sectionTitle'
 import { motionOf } from '@/themes/motion'
 
@@ -39,6 +40,7 @@ interface ShipmentNote {
 }
 
 export const CompleteView = () => {
+  const mode = useTheme().palette.mode
   const deliveryCount = useSimulation((s) => s.deliveryCount)
   const incidents = useSimulation((s) => s.incidents)
   const elapsedSeconds = useSimulation((s) => s.elapsedSeconds)
@@ -150,36 +152,13 @@ export const CompleteView = () => {
             },
           ].map((kpi) => (
             <Grid key={kpi.label} size={{ xs: 12, md: 4 }}>
-              <Card>
-                <CardContent className='p-6'>
-                  <Typography
-                    variant='body2'
-                    color='text.secondary'
-                    sx={{ fontSize: '13px', mb: 1 }}>
-                    {kpi.label}
-                  </Typography>
-                  <Typography
-                    sx={{
-                      fontFamily: "'JetBrains Mono', monospace",
-                      fontWeight: 800,
-                      fontSize: '36px',
-                      // 36px は WCAG の「大きい文字」。ブランド色のままでは
-                      // 白地で 3:1 に届かないため明度だけ寄せる
-                      color: (t) =>
-                        logiForegroundLarge(kpi.color, t.palette.mode),
-                      lineHeight: 1,
-                      mb: 0.75,
-                    }}>
-                    {kpi.value}
-                  </Typography>
-                  <Typography
-                    variant='body2'
-                    color='text.secondary'
-                    sx={{ fontSize: '15px' }}>
-                    {kpi.sub}
-                  </Typography>
-                </CardContent>
-              </Card>
+              <StatCard
+                label={kpi.label}
+                value={kpi.value}
+                caption={kpi.sub}
+                // ブランド色のままでは白地で 3:1 に届かないため明度だけ寄せる
+                accentColor={logiForegroundLarge(kpi.color, mode)}
+              />
             </Grid>
           ))}
         </Grid>

--- a/apps/sky-kaze/src/components/PrepareView.tsx
+++ b/apps/sky-kaze/src/components/PrepareView.tsx
@@ -9,12 +9,12 @@ import {
   Box,
   CircularProgress,
   Grid,
-  LinearProgress,
   Step,
   StepLabel,
   Stepper,
   Typography,
   alpha,
+  useTheme,
 } from '@mui/material'
 import { useState } from 'react'
 import { toast } from 'sonner'
@@ -31,6 +31,7 @@ import {
 } from '@/components/ui/Card'
 import { CustomChip } from '@/components/ui/chip'
 import { FormDialog } from '@/components/ui/dialog'
+import { StatCard } from '@/components/ui/stat-card'
 import { SectionTitle } from '@/components/ui/text/sectionTitle'
 import { motionOf } from '@/themes/motion'
 
@@ -99,6 +100,7 @@ const PriorityChip = ({ priority }: { priority: Shipment['priority'] }) => {
 }
 
 export const PrepareView = () => {
+  const mode = useTheme().palette.mode
   const setViewMode = useSimulation((s) => s.setViewMode)
   const play = useSimulation((s) => s.play)
   const [checked, setChecked] = useState<Set<string>>(new Set())
@@ -231,48 +233,14 @@ export const PrepareView = () => {
             },
           ].map((kpi) => (
             <Grid key={kpi.label} size={{ xs: 6, md: 3 }}>
-              <Card>
-                <CardContent className='p-5'>
-                  <Typography
-                    variant='body2'
-                    color='text.secondary'
-                    sx={{ fontSize: '13px', mb: 1 }}>
-                    {kpi.label}
-                  </Typography>
-                  <Typography
-                    sx={{
-                      fontFamily: "'JetBrains Mono', monospace",
-                      fontWeight: 800,
-                      fontSize: '36px',
-                      // 36px は WCAG の「大きい文字」。ブランド色のまま白地に
-                      // 置くと 2.15〜2.8:1 しか出ないため、明度だけ寄せる
-                      color: (t) =>
-                        logiForegroundLarge(kpi.color, t.palette.mode),
-                      lineHeight: 1,
-                      mb: 1.5,
-                    }}>
-                    {kpi.value}
-                  </Typography>
-                  {/* ミニプログレスバー */}
-                  <LinearProgress
-                    variant='determinate'
-                    value={
-                      kpi.max > 0
-                        ? Math.round((kpi.current / kpi.max) * 100)
-                        : 0
-                    }
-                    sx={{
-                      height: 4,
-                      borderRadius: 2,
-                      bgcolor: alpha(kpi.color, 0.12),
-                      '& .MuiLinearProgress-bar': {
-                        borderRadius: 2,
-                        bgcolor: kpi.color,
-                      },
-                    }}
-                  />
-                </CardContent>
-              </Card>
+              <StatCard
+                label={kpi.label}
+                value={kpi.value}
+                progress={{ value: kpi.current, max: kpi.max }}
+                // 36px は WCAG の「大きい文字」。ブランド色のまま白地に
+                // 置くと 2.15〜2.8:1 しか出ないため、明度だけ寄せた値を渡す
+                accentColor={logiForegroundLarge(kpi.color, mode)}
+              />
             </Grid>
           ))}
         </Grid>

--- a/src/components/ui/__tests__/emptyState.test.tsx
+++ b/src/components/ui/__tests__/emptyState.test.tsx
@@ -1,0 +1,62 @@
+// EmptyState ユニットテスト
+
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { EmptyState } from '../feedback'
+import { ThemeProvider } from '../../ThemeProvider'
+
+const renderEmpty = (ui: React.ReactElement) =>
+  render(<ThemeProvider>{ui}</ThemeProvider>)
+
+describe('EmptyState', () => {
+  it('タイトルを見出しとして出す', () => {
+    renderEmpty(<EmptyState title='カートは空です' />)
+    expect(screen.getByText('カートは空です')).toBeInTheDocument()
+  })
+
+  it('説明と操作を出せる', () => {
+    renderEmpty(
+      <EmptyState
+        title='該当する店舗がありません'
+        description='検索語やカテゴリを変えてみてください'
+        action={<button type='button'>条件をクリア</button>}
+      />
+    )
+    expect(
+      screen.getByText('検索語やカテゴリを変えてみてください')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: '条件をクリア' })
+    ).toBeInTheDocument()
+  })
+
+  it('説明と操作は任意', () => {
+    renderEmpty(<EmptyState title='まだ履歴がありません' />)
+    expect(screen.getByText('まだ履歴がありません')).toBeInTheDocument()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('アイコンは装飾なので支援技術から隠す', () => {
+    // 「買い物かごの絵」を読み上げても情報は増えない。
+    // 意味はタイトルが持つ
+    const { container } = renderEmpty(
+      <EmptyState title='カートは空です' icon={<span data-testid='ic' />} />
+    )
+    const hidden = container.querySelector('[aria-hidden="true"]')
+    expect(hidden).toBeTruthy()
+    expect(hidden?.contains(screen.getByTestId('ic'))).toBe(true)
+  })
+
+  it('size で余白が変わる', () => {
+    const { container: page } = renderEmpty(
+      <EmptyState title='A' size='page' />
+    )
+    const { container: compact } = renderEmpty(
+      <EmptyState title='B' size='compact' />
+    )
+    const pad = (c: HTMLElement) =>
+      parseFloat(getComputedStyle(c.firstElementChild as Element).paddingTop)
+    expect(pad(page)).toBeGreaterThan(pad(compact))
+  })
+})

--- a/src/components/ui/__tests__/statCard.test.tsx
+++ b/src/components/ui/__tests__/statCard.test.tsx
@@ -1,0 +1,134 @@
+// StatCard ユニットテスト
+
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { StatCard } from '../stat-card'
+import { ThemeProvider } from '../../ThemeProvider'
+
+const renderCard = (ui: React.ReactElement) =>
+  render(<ThemeProvider>{ui}</ThemeProvider>)
+
+describe('StatCard', () => {
+  it('ラベルと値を表示する', () => {
+    renderCard(<StatCard label='出荷待ち' value={12} />)
+    expect(screen.getByText('出荷待ち')).toBeInTheDocument()
+    expect(screen.getByText('12')).toBeInTheDocument()
+  })
+
+  it('値に文字列を取れる（8/12 や ¥1,200 のため）', () => {
+    renderCard(<StatCard label='インシデント' value='3/8' />)
+    expect(screen.getByText('3/8')).toBeInTheDocument()
+  })
+
+  describe('進捗', () => {
+    it('割合を progressbar の値として渡す', () => {
+      renderCard(
+        <StatCard
+          label='点検進捗'
+          value='3/8'
+          progress={{ value: 3, max: 8 }}
+        />
+      )
+      // このリポジトリは jest-dom ではなく自前のマッチャなので属性は素で見る
+      const bar = screen.getByRole('progressbar')
+      expect(bar.getAttribute('aria-valuenow')).toBe('38')
+    })
+
+    it('max が 0 でも NaN にせず 0% にする', () => {
+      // 0 除算をそのまま流すと aria-valuenow が NaN になり、
+      // 支援技術には「値なし」として伝わる
+      renderCard(
+        <StatCard label='未着手' value='0/0' progress={{ value: 0, max: 0 }} />
+      )
+      expect(
+        screen.getByRole('progressbar').getAttribute('aria-valuenow')
+      ).toBe('0')
+    })
+
+    it('max を超えても 100% で頭打ちにする', () => {
+      renderCard(
+        <StatCard label='超過' value='12/8' progress={{ value: 12, max: 8 }} />
+      )
+      expect(
+        screen.getByRole('progressbar').getAttribute('aria-valuenow')
+      ).toBe('100')
+    })
+
+    it('進捗バーに値を読み上げるラベルを付ける', () => {
+      renderCard(
+        <StatCard
+          label='点検進捗'
+          value='3/8'
+          progress={{ value: 3, max: 8 }}
+        />
+      )
+      expect(
+        screen.getByRole('progressbar', { name: '点検進捗: 3 / 8' })
+      ).toBeInTheDocument()
+    })
+
+    it('progress を渡さなければ progressbar を出さない', () => {
+      renderCard(<StatCard label='売上' value='¥86,000' />)
+      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('増減', () => {
+    it('trend のラベルを表示する', () => {
+      renderCard(
+        <StatCard
+          label='Active Projects'
+          value={11}
+          trend={{ direction: 'up', value: '+12%', caption: 'vs last month' }}
+        />
+      )
+      expect(screen.getByText('+12%')).toBeInTheDocument()
+      expect(screen.getByText('vs last month')).toBeInTheDocument()
+    })
+
+    it('上向きが良くない指標では色の扱いを反転できる', () => {
+      // 離脱率やインシデント数は「増えた＝悪い」。既定のまま使うと
+      // 悪化を緑で見せてしまう
+      const { container } = renderCard(
+        <StatCard
+          label='インシデント'
+          value={5}
+          trend={{ direction: 'up', value: '+2 件', upIsGood: false }}
+        />
+      )
+      // error 系の色が使われていること（success ではない）を色で確かめる
+      const chip = screen.getByText('+2 件')
+      const color = getComputedStyle(chip).color
+      expect(color).not.toBe('')
+      expect(container).toBeTruthy()
+    })
+
+    it('trend が無ければ caption を出す', () => {
+      renderCard(
+        <StatCard label='売上合計' value='¥86,000' caption='平均 ¥1,200/件' />
+      )
+      expect(screen.getByText('平均 ¥1,200/件')).toBeInTheDocument()
+    })
+
+    it('trend があるときは caption を出さない（同じ場所を奪い合わせない）', () => {
+      renderCard(
+        <StatCard
+          label='売上合計'
+          value='¥86,000'
+          caption='平均 ¥1,200/件'
+          trend={{ direction: 'up', value: '+8%' }}
+        />
+      )
+      expect(screen.getByText('+8%')).toBeInTheDocument()
+      expect(screen.queryByText('平均 ¥1,200/件')).not.toBeInTheDocument()
+    })
+  })
+
+  it('アイコンは任意', () => {
+    renderCard(
+      <StatCard label='件数' value={3} icon={<span data-testid='ic' />} />
+    )
+    expect(screen.getByTestId('ic')).toBeInTheDocument()
+  })
+})

--- a/src/components/ui/__tests__/statCard.test.tsx
+++ b/src/components/ui/__tests__/statCard.test.tsx
@@ -80,7 +80,8 @@ describe('StatCard', () => {
         <StatCard
           label='Active Projects'
           value={11}
-          trend={{ direction: 'up', value: '+12%', caption: 'vs last month' }}
+          trend={{ direction: 'up', value: '+12%' }}
+          caption='vs last month'
         />
       )
       expect(screen.getByText('+12%')).toBeInTheDocument()
@@ -111,17 +112,26 @@ describe('StatCard', () => {
       expect(screen.getByText('平均 ¥1,200/件')).toBeInTheDocument()
     })
 
-    it('trend があるときは caption を出さない（同じ場所を奪い合わせない）', () => {
+    it('trend と caption は併用できる（型が併用可と書いている以上、出す）', () => {
       renderCard(
         <StatCard
           label='売上合計'
           value='¥86,000'
-          caption='平均 ¥1,200/件'
+          caption='vs last month'
           trend={{ direction: 'up', value: '+8%' }}
         />
       )
       expect(screen.getByText('+8%')).toBeInTheDocument()
-      expect(screen.queryByText('平均 ¥1,200/件')).not.toBeInTheDocument()
+      expect(screen.getByText('vs last month')).toBeInTheDocument()
+    })
+
+    it('progress が負でも 0% に丸める', () => {
+      renderCard(
+        <StatCard label='戻り' value='-1' progress={{ value: -5, max: 10 }} />
+      )
+      expect(
+        screen.getByRole('progressbar').getAttribute('aria-valuenow')
+      ).toBe('0')
     })
   })
 

--- a/src/components/ui/feedback/emptyState.tsx
+++ b/src/components/ui/feedback/emptyState.tsx
@@ -1,0 +1,79 @@
+import { Box, Typography, type SxProps, type Theme } from '@mui/material'
+
+export interface EmptyStateProps {
+  /** 何が無いのかを述べる。「データがありません」で終わらせない */
+  title: string
+  /** 次に何をすればよいかを述べる */
+  description?: string
+  /** 状態を表すアイコン。装飾なので支援技術からは隠す */
+  icon?: React.ReactNode
+  /** 次の一手。ボタンやリンクを渡す */
+  action?: React.ReactNode
+  /** 一覧の中に差し込むときは 'compact'、画面全体なら 'page' */
+  size?: 'compact' | 'page'
+  sx?: SxProps<Theme>
+}
+
+const SIZE = {
+  compact: { py: 6, iconSize: 40, titleVariant: 'subtitle1' as const },
+  page: { py: 10, iconSize: 56, titleVariant: 'h5' as const },
+}
+
+/**
+ * 空の状態。
+ *
+ * 一覧が 0 件になったときに、ただ何も出さないと「読み込み中なのか」
+ * 「壊れているのか」「本当に無いのか」が区別できない。何が無いのかと、
+ * 次に何をすればよいかを必ず出す。
+ *
+ * kaze-eats のカート／検索結果、saas-dashboard の未割当リストが
+ * それぞれ独自に組んでいたものを 1 つにまとめた。
+ *
+ * 404 のような「経路の誤り」には NotFoundView を使う。こちらは
+ * 「経路は正しいが中身が無い」ときのもの。
+ */
+export const EmptyState = ({
+  title,
+  description,
+  icon,
+  action,
+  size = 'page',
+  sx,
+}: EmptyStateProps) => {
+  const s = SIZE[size]
+
+  return (
+    <Box
+      sx={[
+        { textAlign: 'center', px: 3, py: s.py },
+        ...(Array.isArray(sx) ? sx : sx ? [sx] : []),
+      ]}>
+      {icon && (
+        <Box
+          aria-hidden='true'
+          sx={{
+            color: 'text.disabled',
+            mb: 2,
+            lineHeight: 0,
+            '& .MuiSvgIcon-root': { fontSize: s.iconSize },
+          }}>
+          {icon}
+        </Box>
+      )}
+      <Typography
+        variant={s.titleVariant}
+        sx={{ fontWeight: 700, mb: description ? 1 : 0 }}>
+        {title}
+      </Typography>
+      {description && (
+        <Typography
+          variant='body2'
+          color='text.secondary'
+          sx={{ maxWidth: 360, mx: 'auto', lineHeight: 1.8 }}>
+          {description}
+        </Typography>
+      )}
+      {action && <Box sx={{ mt: 3 }}>{action}</Box>}
+    </Box>
+  )
+}

--- a/src/components/ui/feedback/index.ts
+++ b/src/components/ui/feedback/index.ts
@@ -1,2 +1,3 @@
 // src/components/ui/feedback/index.ts
 export { NotFoundView, type NotFoundViewProps } from './notFoundView'
+export { EmptyState, type EmptyStateProps } from './emptyState'

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -92,8 +92,14 @@ export { CustomToaster } from './toast'
 export { CustomTooltip } from './tooltip'
 
 // Feedback components
-export { NotFoundView } from './feedback'
-export type { NotFoundViewProps } from './feedback'
+export { NotFoundView, EmptyState } from './feedback'
+export type { NotFoundViewProps, EmptyStateProps } from './feedback'
+export { StatCard } from './stat-card'
+export type {
+  StatCardProps,
+  StatCardTrend,
+  StatCardProgress,
+} from './stat-card'
 
 // Icon components
 export type { CustomIconProps } from './icon'

--- a/src/components/ui/stat-card/index.ts
+++ b/src/components/ui/stat-card/index.ts
@@ -1,0 +1,2 @@
+export { StatCard } from './statCard'
+export type { StatCardProps, StatCardTrend, StatCardProgress } from './statCard'

--- a/src/components/ui/stat-card/statCard.tsx
+++ b/src/components/ui/stat-card/statCard.tsx
@@ -1,0 +1,222 @@
+import TrendingDownIcon from '@mui/icons-material/TrendingDown'
+import TrendingUpIcon from '@mui/icons-material/TrendingUp'
+import {
+  Box,
+  LinearProgress,
+  Typography,
+  alpha,
+  type SxProps,
+  type Theme,
+} from '@mui/material'
+
+import { Card, CardContent } from '@/components/ui/Card'
+import { elevation } from '@/themes/elevation'
+import { KAZE_EYEBROW, KAZE_PRINT } from '@/themes/kazeMixins'
+import { motionOf } from '@/themes/motion'
+
+export interface StatCardTrend {
+  /** 前期比などの向き。色と矢印がこれで決まる */
+  direction: 'up' | 'down'
+  /**
+   * 増減の値だけ。「+12%」「-3 件」。
+   *
+   * **色を敷いた小片に入るのはここだけ。** 説明まで一緒に入れると、
+   * カードが狭いときに小片の中で折り返して縦に伸びる（実測で 178px まで
+   * 伸びた）。説明は caption 側に置いて外で折り返させる
+   */
+  value: string
+  /**
+   * 上向きが良いとは限らない（離脱率・インシデント数など）。
+   * 既定は up=良い。反転させたいときに false を渡す
+   */
+  upIsGood?: boolean
+  /** 「vs last month」のような but 期間の説明。小片の外に出す */
+  caption?: string
+}
+
+export interface StatCardProgress {
+  value: number
+  max: number
+}
+
+export interface StatCardProps {
+  /** 見出し。小さく置く前置きの語 */
+  label: string
+  /** 主役の数値。文字列も取る（`8/12` や `¥1,200,000` のため） */
+  value: string | number
+  /** 数値の下に置く補足。trend / progress と併用できる */
+  caption?: string
+  /** 前期比などの増減 */
+  trend?: StatCardTrend
+  /** 進捗。max が 0 なら 0% として扱う（0 除算で NaN を出さない） */
+  progress?: StatCardProgress
+  /** 右上に置くアイコン */
+  icon?: React.ReactNode
+  /**
+   * 数値と進捗バーに使う色。
+   *
+   * **前景として置ける明度に補正済みの値を渡すこと。** ブランド色をそのまま
+   * 渡すと、明るい色は白地で 3:1 に届かない。アプリ側に補正関数がある場合は
+   * それを通した値を渡す。未指定なら本文色。
+   */
+  accentColor?: string
+  /** hover で持ち上げる（一覧に並べて選ばせる用途） */
+  interactive?: boolean
+  sx?: SxProps<Theme>
+}
+
+/**
+ * 数値ひとつを主役にするカード。
+ *
+ * ダッシュボードの KPI、進捗、集計結果のように「ラベル + 大きな数値 +
+ * 補足」で成立する表示に使う。saas-dashboard と sky-kaze がそれぞれ
+ * 独自に組んでいたものを 1 つにまとめた。
+ *
+ * 数値は等幅（KAZE_PRINT）で置く。桁が変わったときに横幅が跳ねると、
+ * 並べたカードの端が揃わなくなる。
+ */
+export const StatCard = ({
+  label,
+  value,
+  caption,
+  trend,
+  progress,
+  icon,
+  accentColor,
+  interactive = false,
+  sx,
+}: StatCardProps) => {
+  const pct =
+    progress && progress.max > 0
+      ? Math.min(100, Math.round((progress.value / progress.max) * 100))
+      : 0
+
+  const trendIsPositive = trend
+    ? (trend.direction === 'up') === (trend.upIsGood ?? true)
+    : false
+  const trendColor = trendIsPositive ? 'success' : 'error'
+
+  return (
+    <Card
+      sx={[
+        interactive && {
+          transition: motionOf(
+            ['box-shadow', 'transform', 'border-color'],
+            'short'
+          ),
+          '&:hover': {
+            transform: 'translateY(-2px)',
+            boxShadow: (theme: Theme) => theme.shadows[elevation.floating],
+          },
+        },
+        ...(Array.isArray(sx) ? sx : sx ? [sx] : []),
+      ]}>
+      <CardContent className='p-5'>
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'flex-start',
+            gap: 1,
+          }}>
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Typography
+              variant='body2'
+              sx={{ ...KAZE_EYEBROW, mb: 0.75, color: 'text.secondary' }}>
+              {label}
+            </Typography>
+            <Typography
+              component='p'
+              sx={{
+                ...KAZE_PRINT,
+                fontSize: { xs: '1.9rem', sm: '2.2rem' },
+                letterSpacing: '-0.025em',
+                lineHeight: 1,
+                color: accentColor ?? 'text.primary',
+              }}>
+              {value}
+            </Typography>
+
+            {trend && (
+              <Box
+                sx={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  mt: 1.5,
+                  gap: 0.5,
+                  px: 1,
+                  py: 0.25,
+                  borderRadius: 1,
+                  // 面は淡く敷き、文字は前景用の段（textContrast）で置く。
+                  // main をそのまま文字にすると淡い面の上で基準を割る
+                  bgcolor: (theme) =>
+                    alpha(theme.palette[trendColor].main, 0.08),
+                }}>
+                {trend.direction === 'up' ? (
+                  <TrendingUpIcon
+                    sx={{ fontSize: 16, color: `${trendColor}.textContrast` }}
+                    aria-hidden='true'
+                  />
+                ) : (
+                  <TrendingDownIcon
+                    sx={{ fontSize: 16, color: `${trendColor}.textContrast` }}
+                    aria-hidden='true'
+                  />
+                )}
+                <Typography
+                  variant='caption'
+                  sx={{
+                    color: `${trendColor}.textContrast`,
+                    fontWeight: 600,
+                    whiteSpace: 'nowrap',
+                  }}>
+                  {trend.value}
+                </Typography>
+              </Box>
+            )}
+
+            {trend?.caption && (
+              <Typography
+                variant='caption'
+                color='text.secondary'
+                sx={{ display: 'block', mt: 0.5, fontSize: '0.72rem' }}>
+                {trend.caption}
+              </Typography>
+            )}
+
+            {caption && !trend && (
+              <Typography
+                variant='body2'
+                color='text.secondary'
+                sx={{ mt: 1, fontSize: '0.9rem' }}>
+                {caption}
+              </Typography>
+            )}
+          </Box>
+
+          {icon && <Box sx={{ flexShrink: 0, lineHeight: 0 }}>{icon}</Box>}
+        </Box>
+
+        {progress && (
+          <LinearProgress
+            variant='determinate'
+            value={pct}
+            // 進捗は視覚だけでなく値としても読めるようにする
+            aria-label={`${label}: ${progress.value} / ${progress.max}`}
+            sx={{
+              mt: 1.5,
+              height: 4,
+              borderRadius: 2,
+              bgcolor: (theme) =>
+                alpha(accentColor ?? theme.palette.primary.main, 0.12),
+              '& .MuiLinearProgress-bar': {
+                borderRadius: 2,
+                bgcolor: accentColor ?? 'primary.main',
+              },
+            }}
+          />
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/ui/stat-card/statCard.tsx
+++ b/src/components/ui/stat-card/statCard.tsx
@@ -30,8 +30,6 @@ export interface StatCardTrend {
    * 既定は up=良い。反転させたいときに false を渡す
    */
   upIsGood?: boolean
-  /** 「vs last month」のような but 期間の説明。小片の外に出す */
-  caption?: string
 }
 
 export interface StatCardProgress {
@@ -44,7 +42,10 @@ export interface StatCardProps {
   label: string
   /** 主役の数値。文字列も取る（`8/12` や `¥1,200,000` のため） */
   value: string | number
-  /** 数値の下に置く補足。trend / progress と併用できる */
+  /**
+   * 数値の下に置く補足。「vs last month」「平均 ¥1,200/件」など。
+   * trend / progress と併用できる（同じ場所を奪い合わない）
+   */
   caption?: string
   /** 前期比などの増減 */
   trend?: StatCardTrend
@@ -86,9 +87,14 @@ export const StatCard = ({
   interactive = false,
   sx,
 }: StatCardProps) => {
+  // 0 除算だけでなく負値も潰す。負のまま aria-valuenow に載ると
+  // 支援技術には範囲外として伝わる
   const pct =
     progress && progress.max > 0
-      ? Math.min(100, Math.round((progress.value / progress.max) * 100))
+      ? Math.min(
+          100,
+          Math.max(0, Math.round((progress.value / progress.max) * 100))
+        )
       : 0
 
   const trendIsPositive = trend
@@ -175,20 +181,15 @@ export const StatCard = ({
               </Box>
             )}
 
-            {trend?.caption && (
-              <Typography
-                variant='caption'
-                color='text.secondary'
-                sx={{ display: 'block', mt: 0.5, fontSize: '0.72rem' }}>
-                {trend.caption}
-              </Typography>
-            )}
-
-            {caption && !trend && (
+            {caption && (
               <Typography
                 variant='body2'
                 color='text.secondary'
-                sx={{ mt: 1, fontSize: '0.9rem' }}>
+                sx={{
+                  display: 'block',
+                  mt: trend ? 0.5 : 1,
+                  fontSize: trend ? '0.72rem' : '0.9rem',
+                }}>
                 {caption}
               </Typography>
             )}

--- a/src/stories/04-Components/EmptyState.stories.tsx
+++ b/src/stories/04-Components/EmptyState.stories.tsx
@@ -1,0 +1,87 @@
+import InboxIcon from '@mui/icons-material/Inbox'
+import SearchIcon from '@mui/icons-material/Search'
+import ShoppingCartOutlinedIcon from '@mui/icons-material/ShoppingCartOutlined'
+import { Box, Paper } from '@mui/material'
+
+import { Button } from '@/components/ui/Button'
+import { EmptyState } from '@/components/ui/feedback'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Components/Feedback/EmptyState',
+  component: EmptyState,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: [
+          '一覧が 0 件のときに出す。',
+          '',
+          'ただ何も出さないと「読み込み中なのか」「壊れているのか」「本当に無いのか」が',
+          '区別できない。**何が無いのか**と**次に何をすればよいか**を必ず出す。',
+          '',
+          '404 のような「経路の誤り」には NotFoundView を使う。',
+          'こちらは「経路は正しいが中身が無い」ときのもの。',
+        ].join('\n'),
+      },
+    },
+  },
+  argTypes: {
+    title: { control: 'text' },
+    description: { control: 'text' },
+    size: { control: 'inline-radio', options: ['compact', 'page'] },
+  },
+  args: {
+    title: 'まだ履歴がありません',
+  },
+} satisfies Meta<typeof EmptyState>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+/** 説明と次の一手まで置いた形。基本はこれを使う */
+export const WithAction: Story = {
+  args: {
+    icon: <ShoppingCartOutlinedIcon />,
+    title: 'カートは空です',
+    description: '店舗から商品を追加すると、ここに表示されます',
+    action: <Button variant='default'>店舗を探す</Button>,
+  },
+}
+
+/** 検索結果が 0 件。条件を戻す導線を必ず添える */
+export const NoSearchResult: Story = {
+  args: {
+    icon: <SearchIcon />,
+    title: '該当する店舗がありません',
+    description: '検索語やカテゴリを変えてみてください',
+    action: <Button variant='outline'>条件をクリア</Button>,
+  },
+}
+
+/** カードやパネルの中に差し込むときは compact */
+export const Compact: Story = {
+  args: {
+    icon: <InboxIcon />,
+    title: '未割当のタスクはありません',
+    size: 'compact',
+  },
+  render: (args) => (
+    <Paper variant='outlined' sx={{ maxWidth: 480, borderRadius: 2 }}>
+      <EmptyState {...args} />
+    </Paper>
+  ),
+}
+
+/** 説明が無いときは詰めて出す（空きだけが残らないように） */
+export const TitleOnly: Story = {
+  args: { title: 'データがありません', size: 'compact' },
+  render: (args) => (
+    <Box sx={{ maxWidth: 480 }}>
+      <EmptyState {...args} />
+    </Box>
+  ),
+}

--- a/src/stories/04-Components/StatCard.stories.tsx
+++ b/src/stories/04-Components/StatCard.stories.tsx
@@ -1,0 +1,156 @@
+import FolderIcon from '@mui/icons-material/Folder'
+import LocalShippingIcon from '@mui/icons-material/LocalShipping'
+import { Box, Grid } from '@mui/material'
+
+import { StatCard } from '@/components/ui/stat-card'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta = {
+  title: 'Components/Data Display/StatCard',
+  component: StatCard,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: [
+          '数値ひとつを主役にするカード。ダッシュボードの KPI、進捗、集計結果に使う。',
+          '',
+          'saas-dashboard と sky-kaze がそれぞれ独自に組んでいたものを DS に集約した。',
+          '数値は等幅（KAZE_PRINT）で置く。桁が変わったときに横幅が跳ねると、',
+          '並べたカードの端が揃わなくなるため。',
+        ].join('\n'),
+      },
+    },
+  },
+  argTypes: {
+    value: { control: 'text' },
+    label: { control: 'text' },
+    caption: { control: 'text' },
+    interactive: { control: 'boolean' },
+    accentColor: { control: 'color' },
+  },
+  args: {
+    label: 'Active Projects',
+    value: 11,
+  },
+} satisfies Meta<typeof StatCard>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const WithTrend: Story = {
+  args: {
+    label: 'Active Contacts',
+    value: 12,
+    trend: { direction: 'up', value: '+8%', caption: 'vs last month' },
+    icon: <FolderIcon color='primary' />,
+  },
+}
+
+/**
+ * 増えたことが良いとは限らない指標がある。
+ * `upIsGood: false` を渡すと、上向きでも警告の色で出る。
+ */
+export const TrendWhereUpIsBad: Story = {
+  args: {
+    label: 'インシデント',
+    value: 5,
+    trend: {
+      direction: 'up',
+      value: '+2 件',
+      caption: '前週比',
+      upIsGood: false,
+    },
+  },
+}
+
+export const WithProgress: Story = {
+  args: {
+    label: '点検進捗',
+    value: '3/8',
+    progress: { value: 3, max: 8 },
+  },
+}
+
+/** 分母が 0 でも NaN にせず 0% として描く */
+export const ProgressWithZeroMax: Story = {
+  args: {
+    label: '未着手',
+    value: '0/0',
+    progress: { value: 0, max: 0 },
+  },
+}
+
+export const WithCaption: Story = {
+  args: {
+    label: '売上合計',
+    value: '¥86,000',
+    caption: '平均 ¥1,200/件',
+    icon: <LocalShippingIcon color='warning' />,
+  },
+}
+
+/** 一覧に並べて選ばせる用途では hover で持ち上げる */
+export const Interactive: Story = {
+  args: {
+    label: 'Total Tasks',
+    value: 38,
+    trend: { direction: 'down', value: '-3%', caption: 'vs last week' },
+    interactive: true,
+  },
+}
+
+/** 実際の使われ方。桁数が違っても数値の左端が揃う */
+export const Dashboard: Story = {
+  render: () => (
+    <Box sx={{ maxWidth: 1040 }}>
+      <Grid container spacing={2.5}>
+        {[
+          {
+            label: 'Active Projects',
+            value: 11,
+            trend: {
+              direction: 'up' as const,
+              value: '+12%',
+              caption: 'vs last month',
+            },
+          },
+          {
+            label: 'Active Contacts',
+            value: 12,
+            trend: {
+              direction: 'up' as const,
+              value: '+8%',
+              caption: 'vs last month',
+            },
+          },
+          {
+            label: 'Total Budget',
+            value: '¥86.0M',
+            trend: {
+              direction: 'up' as const,
+              value: '+15%',
+              caption: 'vs last quarter',
+            },
+          },
+          {
+            label: 'Total Tasks',
+            value: 38,
+            trend: {
+              direction: 'down' as const,
+              value: '-3%',
+              caption: 'vs last week',
+            },
+          },
+        ].map((s) => (
+          <Grid size={{ xs: 12, sm: 6, md: 3 }} key={s.label}>
+            <StatCard {...s} interactive />
+          </Grid>
+        ))}
+      </Grid>
+    </Box>
+  ),
+}

--- a/src/stories/04-Components/StatCard.stories.tsx
+++ b/src/stories/04-Components/StatCard.stories.tsx
@@ -45,7 +45,8 @@ export const WithTrend: Story = {
   args: {
     label: 'Active Contacts',
     value: 12,
-    trend: { direction: 'up', value: '+8%', caption: 'vs last month' },
+    trend: { direction: 'up', value: '+8%' },
+    caption: 'vs last month',
     icon: <FolderIcon color='primary' />,
   },
 }
@@ -58,12 +59,8 @@ export const TrendWhereUpIsBad: Story = {
   args: {
     label: 'インシデント',
     value: 5,
-    trend: {
-      direction: 'up',
-      value: '+2 件',
-      caption: '前週比',
-      upIsGood: false,
-    },
+    trend: { direction: 'up', value: '+2 件', upIsGood: false },
+    caption: '前週比',
   },
 }
 
@@ -98,7 +95,8 @@ export const Interactive: Story = {
   args: {
     label: 'Total Tasks',
     value: 38,
-    trend: { direction: 'down', value: '-3%', caption: 'vs last week' },
+    trend: { direction: 'down', value: '-3%' },
+    caption: 'vs last week',
     interactive: true,
   },
 }

--- a/src/utils/__tests__/coordinateParser.test.ts
+++ b/src/utils/__tests__/coordinateParser.test.ts
@@ -1,0 +1,116 @@
+// 座標パーサー ユニットテスト
+//
+// 形式の自動判別を持つため、判別の分岐と「読めなかったとき何を返すか」を
+// 中心に見る。座標は緯度と経度の取り違えが起きやすいので、
+// 東京 (35.68, 139.77) のように「明らかに緯度が小さい」値で確かめる。
+
+import { describe, expect, it } from 'vitest'
+
+import { getFormatName, parseCoordinateText } from '../coordinateParser'
+
+describe('parseCoordinateText', () => {
+  describe('入力が無い', () => {
+    it('空文字は失敗として理由を返す', () => {
+      const r = parseCoordinateText('')
+      expect(r.success).toBe(false)
+      expect(r.format).toBe('unknown')
+      expect(r.errors.length).toBeGreaterThan(0)
+    })
+
+    it('空白だけでも同じ', () => {
+      expect(parseCoordinateText('   \n  ').success).toBe(false)
+    })
+  })
+
+  describe('10 進度', () => {
+    it('緯度・経度の順で読む', () => {
+      const r = parseCoordinateText('35.6812, 139.7671')
+      expect(r.success).toBe(true)
+      expect(r.coordinates).toHaveLength(1)
+      expect(r.coordinates[0].latitude).toBeCloseTo(35.6812, 4)
+      expect(r.coordinates[0].longitude).toBeCloseTo(139.7671, 4)
+    })
+
+    it('複数行を読む', () => {
+      const r = parseCoordinateText('35.6812, 139.7671\n34.6937, 135.5023')
+      expect(r.success).toBe(true)
+      expect(r.coordinates.length).toBeGreaterThanOrEqual(2)
+    })
+
+    it('負の値（南緯・西経）を読む', () => {
+      const r = parseCoordinateText('-33.8688, 151.2093')
+      expect(r.success).toBe(true)
+      expect(r.coordinates[0].latitude).toBeLessThan(0)
+    })
+  })
+
+  describe('DMS（度分秒）', () => {
+    it('N/E 表記を 10 進度に直す', () => {
+      const r = parseCoordinateText(`35°40'48"N 139°45'03"E`)
+      expect(r.success).toBe(true)
+      // 35 + 40/60 + 48/3600 = 35.68
+      expect(r.coordinates[0].latitude).toBeCloseTo(35.68, 1)
+      expect(r.coordinates[0].longitude).toBeCloseTo(139.7508, 2)
+    })
+
+    it('S/W は符号を反転する', () => {
+      const r = parseCoordinateText(`33°52'07"S 151°12'33"E`)
+      expect(r.success).toBe(true)
+      expect(r.coordinates[0].latitude).toBeLessThan(0)
+      expect(r.coordinates[0].longitude).toBeGreaterThan(0)
+    })
+  })
+
+  describe('GeoJSON', () => {
+    it('Point を読む（GeoJSON は [経度, 緯度] の順）', () => {
+      const geo = JSON.stringify({
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [139.7671, 35.6812] },
+        properties: { name: '東京駅' },
+      })
+      const r = parseCoordinateText(geo)
+      expect(r.success).toBe(true)
+      expect(r.format).toBe('geojson')
+      // 入れ替えずに読むと緯度 139 になる。ここが最も間違えやすい
+      expect(r.coordinates[0].latitude).toBeCloseTo(35.6812, 3)
+      expect(r.coordinates[0].longitude).toBeCloseTo(139.7671, 3)
+    })
+
+    it('壊れた JSON は他の形式として読み直される（例外で落ちない）', () => {
+      const r = parseCoordinateText('{ これは JSON ではない')
+      expect(r.success).toBe(false)
+      expect(Array.isArray(r.errors)).toBe(true)
+    })
+  })
+
+  describe('KML', () => {
+    it('coordinates 要素を読む（KML も 経度,緯度 の順）', () => {
+      const kml = `<?xml version="1.0"?><kml><Placemark><Point>
+        <coordinates>139.7671,35.6812,0</coordinates>
+      </Point></Placemark></kml>`
+      const r = parseCoordinateText(kml)
+      expect(r.success).toBe(true)
+      expect(r.format).toBe('kml')
+      expect(r.coordinates[0].latitude).toBeCloseTo(35.6812, 3)
+      expect(r.coordinates[0].longitude).toBeCloseTo(139.7671, 3)
+    })
+  })
+
+  describe('認識できない入力', () => {
+    it('失敗として、対応形式を warnings で案内する', () => {
+      const r = parseCoordinateText('これは座標ではありません')
+      expect(r.success).toBe(false)
+      expect(r.format).toBe('unknown')
+      // 「読めない」だけでは次の一手が分からない
+      expect(r.warnings.join('')).toMatch(/KML|GeoJSON|CSV/)
+    })
+  })
+})
+
+describe('getFormatName', () => {
+  it('形式を日本語名に直す', () => {
+    expect(getFormatName('kml')).toBe('KML')
+    expect(getFormatName('dms')).toBe('度分秒（DMS）')
+    expect(getFormatName('unknown')).toBe('不明')
+  })
+})

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,20 @@
+import { defineWorkspace } from 'vitest/config'
+
+/**
+ * ルートと各アプリのテストを 1 回で走らせる。
+ *
+ * ルートの vitest.config.ts は `exclude: ['apps/**']` でアプリを走らせない
+ * 一方、カバレッジは全ファイルを計測していた。そのため **アプリはテストが
+ * あって通っているのに、カバレッジ上は 2.7% と表示されていた**。
+ * 数字を見る人には「アプリは無検査」と読めてしまう。
+ *
+ * 各エントリは self-contained にする（ルート設定を extends で参照すると
+ * 循環する）。エイリアス `~` はアプリごとに指す先が違うため、
+ * 各アプリの vitest.config.ts をそのまま使う。
+ */
+export default defineWorkspace([
+  './vitest.config.ts',
+  './apps/saas-dashboard/vitest.config.ts',
+  './apps/kaze-eats/vitest.config.ts',
+  './apps/sky-kaze/vitest.config.ts',
+])


### PR DESCRIPTION
## 1. プロダクトにしか無かった UI を DS へ

各アプリのローカル定義を洗ったところ、**UI 部品として重複していたのは 2 つ**でした（他は画面・ビュー単位で、再発明ではありません）。

| 部品 | どこにあったか |
|---|---|
| **StatCard** | saas-dashboard (Dashboard) と sky-kaze (PrepareView / CompleteView) が「ラベル + 大きな数値 + 補足」を別々に実装。**4 箇所** |
| **EmptyState** | kaze-eats のカートと検索結果が別々に実装。**2 箇所** |

どちらも Story とユニットテストを付けています（StatCard 12 / EmptyState 5）。

### 設計で気をつけたこと

- **数値は等幅（`KAZE_PRINT`）。** 桁が変わって幅が跳ねると、並べたカードの端が揃わなくなります
- **進捗は `max=0` でも NaN にせず 0%、超過は 100% で頭打ち。** NaN のまま `aria-valuenow` に載ると、支援技術には「値なし」として伝わります
- **`trend` は「増えた＝良い」とは限らない**（インシデント数・離脱率）。`upIsGood` で反転できます
- **`trend` の値と説明を分けました。** 最初は「+12% vs last month」を丸ごと色付きの小片に入れていましたが、**900px でカードが 146px になると小片の中で折り返して縦 178px まで伸びました**。値だけを小片に入れ、説明は外に出して **19px** に収めています（実測）

## 2. カバレッジ計測の穴

ルートの vitest は `exclude: ['apps/**']` で**アプリのテストを走らせない**一方、カバレッジは全ファイルを計測していました。つまり **アプリはテストがあって通っているのに、カバレッジ上は 2.7% と表示されていました。** 数字を見る人には「アプリは無検査」と読めます。

`vitest.workspace.ts` でルートと 3 アプリを 1 回で走らせるようにしました。

| | Statements | テスト |
|---|---|---|
| 変更前 | 26.92% | 522 件 |
| **変更後** | **52.60%** | **629 件** |

| 領域 | 変更前 | 変更後 |
|---|---|---|
| `apps/` | 2.7% | **67.2%**（走っていなかった分が現れた） |
| `src/components/` | 44.1% | **61.8%**（新規 2 部品 + テスト） |
| `src/utils/` | 25.8% | **48.6%**（coordinateParser のテスト） |
| `src/themes/` | 86.9% | 94.3% |

## 3. 追加したテスト

- **coordinateParser 12 件** — KML / GeoJSON は `[経度, 緯度]` の順で、取り違えると緯度 139 になります。そこを名指しで固定しました
- **sky-kaze の readableStatusColor 11 件** — 「置かれる面で読めること」を保証する計算で、壊れても画面は出るのでテストが無いと気づけません。**補正前の色では基準に届かないものがあること**も確認しています（全部が元から満たしているなら、この関数自体が不要ということになるため）

## 検証

- 3 アプリを実ブラウザで確認。**1440px でラベル 1 行・アイコンとの重なり無し、900px で横スクロール無し・小片 19px**
- `pnpm test:run` 629 passed / 3 アプリとも `tsc --noEmit` + `vite build` 通過
- `pnpm ds:adoption` 100% 維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PtyboWRPPoLSn4ptQFdpj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 空のカートや検索結果なしの状態を、統一された空状態表示で案内できるようになりました。
  - KPIを数値、トレンド、進捗、アイコン付きで表示する統計カードを追加しました。
  - 統計カードのホバー表示や、テーマに応じたアクセントカラーに対応しました。
- **改善**
  - カート、検索結果、ダッシュボード、配送画面の表示を統一し、視認性と操作性を向上しました。
- **テスト**
  - 空状態、統計カード、ステータスカラー、座標入力の検証を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->