### PR TITLE
chore(privacy): 共有ビルドから運営者個人へ辿れる情報を取り除く

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,9 +1,20 @@
 name: Deploy to GitHub Pages
 
+# 【一時的な措置】main への push で自動デプロイしない。
+#
+# GitHub Pages の URL はホスト名がそのままアカウント名になる
+# (`https://<アカウント名>.github.io/<リポジトリ名>/`)。
+# 成果物を匿名で共有している間は、この URL 自体が本人への導線になる。
+# 共有面は Vercel に一本化する。
+#
+# 【元に戻すとき】匿名で共有する必要がなくなったら、下の `push:` の
+# コメントを外すだけでよい。Pages 側の設定も再度有効にすること
+# (`gh api -X POST repos/{owner}/{repo}/pages -f build_type=workflow`)。
+# 手動実行 (workflow_dispatch) は残してあるので、設定を戻せばすぐ配信できる。
 on:
-  push:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
   workflow_dispatch:
     inputs:
       deploy_target:

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "preview": "vite preview",
     "storybook": "storybook dev -p 6007",
     "build-storybook": "storybook build",
+    "postbuild-storybook": "node scripts/sanitize-manifests.mjs",
     "build-all": "pnpm run build-storybook",
     "build:gh-pages": "vite build --mode gh-pages",
     "build:gh-pages:storybook": "storybook build -o gh-pages/storybook",
@@ -79,7 +80,8 @@
     "audit:contrast": "node scripts/audit-contrast.mjs",
     "check:brand": "node scripts/check-brand-terms.mjs",
     "ds:adoption": "node scripts/ds-adoption.mjs",
-    "capture:products": "node scripts/capture-products.mjs"
+    "capture:products": "node scripts/capture-products.mjs",
+    "check:anon": "node scripts/check-anonymity.mjs"
   },
   "peerDependencies": {
     "@emotion/react": "^11.13.5",

--- a/scripts/check-anonymity.mjs
+++ b/scripts/check-anonymity.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+/**
+ * 共有するビルド成果物に、運営者個人へ辿れる情報が混入していないか検査する。
+ *
+ * この成果物は URL で第三者に共有する。**共有されるのはビルド済みの
+ * dist / storybook-static** なので、ソースを直しただけでは意味がない。
+ * 実際、コードに 1 箇所書いた公開先 URL が、両方のバンドルに文字列として
+ * 載っていた。
+ *
+ *   pnpm check:anon        既定の出力先を検査
+ *   pnpm check:anon <dir>  ディレクトリを指定
+ *
+ * **探す文字列はこのファイルに書かない。** git の設定（remote / user /
+ * 過去のコミット作者）から実行時に導出する。ここにアカウント名を列挙すると、
+ * 匿名化のための検査ファイルが身元の一覧になってしまう。
+ * 導出できない環境（git 情報が無い CI 等）では、その分の検査は静かに飛ばす。
+ */
+
+import { execSync } from 'node:child_process'
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { dirname, extname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const DEFAULT_TARGETS = ['dist', 'storybook-static']
+
+/** テキストとして中身を見る拡張子。画像・フォントは対象外 */
+const TEXT_EXT = /\.(html|js|mjs|cjs|css|json|map|txt|svg|xml|webmanifest)$/i
+
+const git = (cmd) => {
+  try {
+    return execSync(`git ${cmd}`, {
+      cwd: ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * 検査すべき文字列を git から導出する。
+ *
+ * - remote URL: そのままと、owner / owner-repo の組み合わせ
+ * - user.name / user.email
+ * - 過去のコミット作者（複数人なら全員）
+ */
+const deriveIdentity = () => {
+  const values = new Set()
+  const add = (v) => {
+    const t = (v ?? '').trim()
+    // 2 文字以下は普通の単語に当たるので採らない
+    if (t.length > 2) values.add(t)
+  }
+
+  const remote = git('remote get-url origin')
+  if (remote) {
+    add(remote.replace(/\.git$/, ''))
+    // git@host:owner/repo / https://host/owner/repo の両方から owner を取る
+    const m = remote.match(/[:/]([^/:]+)\/([^/]+?)(\.git)?$/)
+    if (m) {
+      add(m[1])
+      add(`${m[1]}/${m[2]}`)
+    }
+  }
+  add(git('config user.email'))
+  add(git('config user.name'))
+  for (const line of git('log --format=%an%x09%ae -200').split('\n')) {
+    const [name, email] = line.split('\t')
+    add(name)
+    add(email)
+  }
+  // noreply の数字 ID も本人に紐づく
+  for (const v of [...values]) {
+    const m = v.match(/^(\d+)\+/)
+    if (m) add(m[1])
+  }
+
+  const escape = (t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return [...values].map((value) => ({
+    value,
+    // URL とメールはそれ自体が十分に固有なので素の部分一致でよい。
+    // 素の名前は単語の一部に埋もれるので境界を要求する
+    re: /@|:\/\//.test(value)
+      ? null
+      : new RegExp(`(?<![A-Za-z0-9])${escape(value)}(?![A-Za-z0-9])`),
+  }))
+}
+
+/** 身元に依らず、そこに有ってはいけないもの */
+const GENERIC_RULES = [
+  {
+    id: 'local-path',
+    re: /\/(Users|home)\/[A-Za-z0-9._-]+\//g,
+    why: 'ビルドしたマシンのユーザー名を含む絶対パス',
+  },
+  {
+    id: 'social-link',
+    re: /https?:\/\/(www\.)?(twitter\.com|x\.com|linkedin\.com\/in|facebook\.com|instagram\.com|note\.com|qiita\.com|zenn\.dev)\/[A-Za-z0-9_./-]+/gi,
+    why: '個人のソーシャルへの導線',
+  },
+]
+
+const walk = (dir, out = []) => {
+  if (!existsSync(dir)) return out
+  for (const e of readdirSync(dir)) {
+    const p = join(dir, e)
+    if (statSync(p).isDirectory()) walk(p, out)
+    else if (TEXT_EXT.test(extname(p))) out.push(p)
+  }
+  return out
+}
+
+const args = process.argv.slice(2).filter((a) => !a.startsWith('-'))
+const targets = (args.length ? args : DEFAULT_TARGETS).map((t) => join(ROOT, t))
+const present = targets.filter((t) => existsSync(t))
+
+if (!present.length) {
+  console.error(
+    `検査対象がありません: ${targets.map((t) => t.replace(ROOT + '/', '')).join(', ')}\n` +
+      'ビルドしてから実行してください（node scripts/vercel-build.mjs / pnpm build-storybook）。'
+  )
+  process.exit(1)
+}
+
+const identity = deriveIdentity()
+const findings = []
+let scanned = 0
+
+for (const target of present) {
+  for (const file of walk(target)) {
+    scanned++
+    let content
+    try {
+      content = readFileSync(file, 'utf8')
+    } catch {
+      continue
+    }
+    const rel = file.replace(ROOT + '/', '')
+
+    for (const { value, re } of identity) {
+      // URL / メールは素の部分一致、素の名前は単語境界で見る。
+      // 境界を見ないと、架空の人名 "Daichi Saito" の中の "aito" のような
+      // 部分一致を拾って誤検出になる（実際に一度そうなった）
+      const hit = re ? re.test(content) : content.includes(value)
+      if (re) re.lastIndex = 0
+      if (hit) findings.push({ file: rel, rule: 'identity' })
+    }
+    for (const rule of GENERIC_RULES) {
+      rule.re.lastIndex = 0
+      for (const m of content.matchAll(rule.re)) {
+        findings.push({
+          file: rel,
+          rule: rule.id,
+          hit: m[0].slice(0, 80),
+          why: rule.why,
+        })
+      }
+    }
+  }
+}
+
+const unique = [
+  ...new Map(findings.map((f) => [`${f.file}:${f.rule}:${f.hit}`, f])).values(),
+]
+
+const scope = present.map((p) => p.replace(ROOT + '/', '')).join(', ')
+
+if (!unique.length) {
+  console.log(
+    `✅ 共有物に身元へ辿れる情報なし (${scanned} ファイル / ${scope})` +
+      (identity.length
+        ? `\n   git から導出した ${identity.length} 種の識別子で照合`
+        : '\n   ⚠ git 情報を取得できず、識別子の照合は行っていません')
+  )
+  process.exit(0)
+}
+
+console.error(`❌ 共有物に ${unique.length} 件の混入があります\n`)
+for (const f of unique) {
+  // 見つかった値そのものは出さない。どこを直すかだけ示す
+  console.error(`  [${f.rule}] ${f.file}`)
+  if (f.why) console.error(`    ${f.hit}  → ${f.why}`)
+}
+console.error(
+  [
+    '',
+    'ソースを直したうえで、**ビルドし直してから**再検査してください。',
+    '作業ツリーだけ直しても、共有されるのはビルド済みの成果物です。',
+  ].join('\n')
+)
+process.exit(1)

--- a/scripts/sanitize-manifests.mjs
+++ b/scripts/sanitize-manifests.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * Storybook の manifests から、ビルドしたマシンの絶対パスを取り除く。
+ *
+ * `@storybook/addon-mcp` は `manifests/components.{json,html}` に
+ * コンポーネントの**絶対パス**を書き出す。
+ * `/Users/<ユーザー名>/dev/...` の形なので、成果物を第三者へ URL で共有すると
+ * ビルドした人のマシンのユーザー名がそのまま出る。
+ *
+ * ソースを grep しても見つからない（ビルド時に生成される）ため、
+ * 成果物側を見ないと気づけない。
+ *
+ * リポジトリ相対に書き換えるだけで、どのファイルかは変わらず読める。
+ *
+ * `build-storybook` の後に自動で走る（package.json の postbuild-storybook）。
+ */
+
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const TARGET_DIRS = ['storybook-static/manifests', 'dist/storybook/manifests']
+
+/** 絶対パスの形で残っているものを相対へ。ROOT 以外の絶対パスも潰す */
+const stripAbsolute = (text) =>
+  text
+    .split(ROOT + '/')
+    .join('')
+    .replace(/\/(Users|home)\/[A-Za-z0-9._-]+\//g, '')
+
+let changed = 0
+let scanned = 0
+
+for (const rel of TARGET_DIRS) {
+  const dir = join(ROOT, rel)
+  if (!existsSync(dir)) continue
+  for (const name of readdirSync(dir)) {
+    const file = join(dir, name)
+    if (!statSync(file).isFile()) continue
+    scanned++
+    const before = readFileSync(file, 'utf8')
+    const after = stripAbsolute(before)
+    if (after !== before) {
+      writeFileSync(file, after)
+      changed++
+      console.log(`  ✅ ${rel}/${name} の絶対パスを相対化`)
+    }
+  }
+}
+
+if (!scanned) {
+  // Storybook を建てていないときは何もしない（エラーにしない）
+  console.log('manifests がありません。何もしませんでした。')
+} else if (!changed) {
+  console.log(`絶対パスなし (${scanned} ファイル)`)
+}

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -975,7 +975,7 @@ export const LandingPage = () => {
                   {repositoryUrl && (
                     <Box
                       component='a'
-                      href={repositoryUrl ?? undefined}
+                      href={repositoryUrl}
                       target='_blank'
                       rel='noopener noreferrer'
                       sx={{

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -713,6 +713,8 @@ const SECTION_LEAD_SX = {
 
 // メインLPコンポーネント
 export const LandingPage = () => {
+  // 未設定なら null。ソース公開先への導線は既定で出さない
+  const repositoryUrl = APP_LINKS.repository()
   const theme = useTheme()
   const isDark = theme.palette.mode === 'dark'
   const containerRef = useRef<HTMLDivElement>(null)
@@ -970,39 +972,41 @@ export const LandingPage = () => {
                     <AutoStoriesIcon sx={{ fontSize: 18 }} />
                     Storybook
                   </Box>
-                  <Box
-                    component='a'
-                    href={APP_LINKS.github()}
-                    target='_blank'
-                    rel='noopener noreferrer'
-                    sx={{
-                      display: 'inline-flex',
-                      alignItems: 'center',
-                      gap: 1,
-                      px: 3.5,
-                      py: 1.5,
-                      borderRadius: 2,
-                      border: '1px solid',
-                      borderColor: isDark
-                        ? 'rgba(255,255,255,0.12)'
-                        : 'rgba(0,0,0,0.12)',
-                      color: 'text.primary',
-                      fontWeight: 600,
-                      fontSize: '0.9rem',
-                      textDecoration: 'none',
-                      transition: motionOf(
-                        ['transform', 'box-shadow'],
-                        'macro'
-                      ),
-                      '&:hover': {
-                        borderColor: 'primary.main',
-                        color: 'primary.textContrast',
-                        transform: 'translateY(-2px)',
-                      },
-                    }}>
-                    <GitHubIcon sx={{ fontSize: 18 }} />
-                    GitHub
-                  </Box>
+                  {repositoryUrl && (
+                    <Box
+                      component='a'
+                      href={repositoryUrl ?? undefined}
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      sx={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: 1,
+                        px: 3.5,
+                        py: 1.5,
+                        borderRadius: 2,
+                        border: '1px solid',
+                        borderColor: isDark
+                          ? 'rgba(255,255,255,0.12)'
+                          : 'rgba(0,0,0,0.12)',
+                        color: 'text.primary',
+                        fontWeight: 600,
+                        fontSize: '0.9rem',
+                        textDecoration: 'none',
+                        transition: motionOf(
+                          ['transform', 'box-shadow'],
+                          'macro'
+                        ),
+                        '&:hover': {
+                          borderColor: 'primary.main',
+                          color: 'primary.textContrast',
+                          transform: 'translateY(-2px)',
+                        },
+                      }}>
+                      <GitHubIcon sx={{ fontSize: 18 }} />
+                      GitHub
+                    </Box>
+                  )}
                 </Box>
               </motion.div>
             </Box>
@@ -1185,8 +1189,8 @@ export const LandingPage = () => {
                 step: '03',
                 title: 'コードを書く',
                 desc: 'pnpm install して開発開始。CLAUDE.md を読めば AI エージェントも DS 準拠コードを生成できます。',
-                link: APP_LINKS.github(),
-                linkLabel: 'GitHub',
+                link: repositoryUrl,
+                linkLabel: repositoryUrl ? 'GitHub' : undefined,
               },
             ].map((item, i) => (
               <motion.div
@@ -1233,21 +1237,23 @@ export const LandingPage = () => {
                     }}>
                     {item.desc}
                   </Typography>
-                  <Box
-                    component='a'
-                    href={item.link}
-                    {...(item.link.startsWith('http')
-                      ? { target: '_blank', rel: 'noopener noreferrer' }
-                      : {})}
-                    sx={{
-                      fontSize: '0.95rem',
-                      fontWeight: 600,
-                      color: 'primary.textContrast',
-                      textDecoration: 'none',
-                      '&:hover': { textDecoration: 'underline' },
-                    }}>
-                    {item.linkLabel} →
-                  </Box>
+                  {item.link && (
+                    <Box
+                      component='a'
+                      href={item.link}
+                      {...(item.link.startsWith('http')
+                        ? { target: '_blank', rel: 'noopener noreferrer' }
+                        : {})}
+                      sx={{
+                        fontSize: '0.95rem',
+                        fontWeight: 600,
+                        color: 'primary.textContrast',
+                        textDecoration: 'none',
+                        '&:hover': { textDecoration: 'underline' },
+                      }}>
+                      {item.linkLabel} →
+                    </Box>
+                  )}
                 </Box>
               </motion.div>
             ))}
@@ -1404,7 +1410,10 @@ export const LandingPage = () => {
               { label: 'Storybook', href: APP_LINKS.storybook() },
               { label: 'SaaS Demo', href: APP_LINKS.saas() },
               { label: 'KazeEats', href: APP_LINKS.kazeEats() },
-              { label: 'GitHub', href: APP_LINKS.github() },
+              // 公開先が設定されている時だけ出す（既定は出さない）
+              ...(repositoryUrl
+                ? [{ label: 'Source', href: repositoryUrl }]
+                : []),
             ].map((link) => (
               <Box
                 key={link.label}

--- a/src/utils/appLinks.ts
+++ b/src/utils/appLinks.ts
@@ -97,7 +97,17 @@ export const APP_LINKS = {
   saas: () => resolve('saas', '/saas/'),
   kazeEats: () => resolve('kazeEats', '/kaze-eats/'),
   skyKaze: () => resolve('skyKaze', '/sky-kaze/'),
-  github: () => 'https://github.com/BoxPistols/kaze-ux',
+  /**
+   * ソースの公開先。**既定は未設定（＝リンクを出さない）。**
+   *
+   * この成果物は第三者へ URL で共有することがあり、その際に運営者個人へ
+   * 辿れる導線を残さない。URL をコードに直接書くと、共有用ビルドにも
+   * 必ず載る（実際に dist と storybook-static の両方に混入していた）。
+   *
+   * 出したい場合だけ `VITE_PUBLIC_REPO_URL` を与える。未設定なら
+   * `null` を返し、呼び出し側はリンク自体を描画しない。
+   */
+  repository: (): string | null => import.meta.env.VITE_PUBLIC_REPO_URL || null,
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
成果物を第三者へ URL で共有する前提で、ビルド済みの `dist` / `storybook-static` に運営者個人へ辿れる情報が載らないようにする。

## なぜソースでなく成果物を見るか

共有されるのはビルド済みのファイルなので、ソースを直しただけでは確認にならない。実際、コードに 1 箇所書いた公開先 URL が `dist` と `storybook-static` の両方に文字列として載っていた。ソースの grep では見つからない混入（後述の 2 つ目）もある。

## 見つかった混入

**1. 公開先 URL のハードコード** — `appLinks.ts` の 1 行が、LP のバンドル・SaaS のバンドル・Storybook の Introduction に展開されていた。

既定を「未設定＝リンクを描画しない」に変更した。出したいときだけ `VITE_PUBLIC_REPO_URL` を渡す。LP の 3 箇所（ヒーローのボタン / GettingStarted のカード / フッター）を条件描画にした。

**2. Storybook manifests の絶対パス** — `@storybook/addon-mcp` が `manifests/components.{json,html}` に `/Users/<ユーザー名>/dev/...` を書き出していた。ビルド時に生成されるのでソースには存在しない。

`build-storybook` の後処理（`postbuild-storybook`）でリポジトリ相対に書き換える。どのファイルかは変わらず読めるので、addon の用途は損なわない。

## 再発防止

`pnpm check:anon` で成果物側を検査する。

- **探す文字列はスクリプトに書かない。** git の remote / user.name / user.email / 過去のコミット作者から実行時に導出する。列挙すると、匿名化のための検査ファイル自体が身元の一覧になる
- 出力にも一致した値は出さない。どのファイルのどのルールに当たったかだけ示す
- 素の名前は単語境界で照合する。境界を見ないとモックデータの人名 `Daichi Saito` の中の `aito` を拾う（実際に一度誤検出した）
- 身元に依らないルールとして、ローカル絶対パスと個人ソーシャルへのリンクも見る

## 確認

- フルビルドし直してから `pnpm check:anon` → 456 ファイルで 0 件
- `pnpm test:run` → 632 passed / 37 files
- `tsc --noEmit` / `pnpm lint` 通過

## このPRで解けないこと

リンクを消しても、リポジトリ自体が公開されていれば検索でも履歴でも辿れる。可視性・デプロイ先の名前・ソースマップの同梱は設定側の判断なので、別途あなたに確認する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - リポジトリURLが設定されている場合のみ、ヒーロー、Getting Started、フッターに関連リンクを表示するようになりました。
  - リポジトリURL未設定時は、関連するリンクやラベルを自動的に非表示にします。

- **改善**
  - Storybookのビルド成果物から環境依存の絶対パスを除去できるようになりました。
  - ビルド成果物に個人情報や不要な識別情報が含まれていないか確認できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->