### PR TITLE
fix: 共有ビルドに資格情報を焼き込まない / 匿名化検査の穴を塞ぐ

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -84,10 +84,12 @@ jobs:
           fi
 
       # Storybookのビルド
+      # 資格情報はビルドに渡さない。define した値はバンドルに平文で残り、
+      # 配信された時点で無認証の GET で取得できる。AI を動かす場合は
+      # VITE_API_BASE のバックエンド経由か、利用者自身のキー入力を使う。
       - name: Build Storybook
         if: steps.target.outputs.target == 'all' || steps.target.outputs.target == 'storybook'
         env:
-          VITE_OPENAI_API_KEY: ${{ secrets.VITE_OPENAI_API_KEY }}
           VITE_OPENAI_MODEL: 'gpt-4.1-nano'
         run: |
           pnpm run build-storybook

--- a/.storybook/main.cjs
+++ b/.storybook/main.cjs
@@ -95,15 +95,24 @@ const config = {
         },
       },
       // 環境変数をdefineに追加
+      //
+      // 資格情報は build（configType === 'PRODUCTION'）では常に空にする。
+      // define した値はバンドルに平文で焼き込まれ、配信された時点で
+      // 無認証の GET で誰でも取得できるため、共有ビルドに載せてはいけない。
+      // 環境変数の設定漏れに頼らず、ビルド種別で機械的に落とす。
+      // 公開ビルドで AI を動かす場合は VITE_API_BASE のバックエンド経由か、
+      // 利用者が自分のキーを入力する運用（設定パネル）を使う。
       define: {
         'import.meta.env.VITE_APP_PASSWORD': JSON.stringify(
           freshEnv.VITE_APP_PASSWORD || ''
         ),
         'import.meta.env.VITE_MAPBOX_ACCESS_TOKEN': JSON.stringify(
-          freshEnv.VITE_MAPBOX_ACCESS_TOKEN || ''
+          configType === 'PRODUCTION'
+            ? ''
+            : freshEnv.VITE_MAPBOX_ACCESS_TOKEN || ''
         ),
         'import.meta.env.VITE_OPENAI_API_KEY': JSON.stringify(
-          freshEnv.VITE_OPENAI_API_KEY || ''
+          configType === 'PRODUCTION' ? '' : freshEnv.VITE_OPENAI_API_KEY || ''
         ),
         'import.meta.env.VITE_OPENAI_MODEL': JSON.stringify(
           freshEnv.VITE_OPENAI_MODEL || 'gpt-5.6-luna'

--- a/scripts/check-anonymity.mjs
+++ b/scripts/check-anonymity.mjs
@@ -82,10 +82,14 @@ const deriveIdentity = () => {
   return [...values].map((value) => ({
     value,
     // URL とメールはそれ自体が十分に固有なので素の部分一致でよい。
-    // 素の名前は単語の一部に埋もれるので境界を要求する
+    // 素の名前は単語の一部に埋もれるので境界を要求する。
+    //
+    // どちらも大文字小文字を無視する。GitHub のアカウント名は表記を変えても
+    // 同じアカウントに解決するため、小文字で書かれた 1 箇所が
+    // 検査を素通りすれば匿名化は破れる（区別する実装で実際に素通りした）
     re: /@|:\/\//.test(value)
-      ? null
-      : new RegExp(`(?<![A-Za-z0-9])${escape(value)}(?![A-Za-z0-9])`),
+      ? new RegExp(escape(value), 'i')
+      : new RegExp(`(?<![A-Za-z0-9])${escape(value)}(?![A-Za-z0-9])`, 'i'),
   }))
 }
 
@@ -159,13 +163,11 @@ for (const target of present) {
     }
     const rel = file.replace(ROOT + '/', '')
 
-    for (const { value, re } of identity) {
+    for (const { re } of identity) {
       // URL / メールは素の部分一致、素の名前は単語境界で見る。
       // 境界を見ないと、架空の人名 "Daichi Saito" の中の "aito" のような
       // 部分一致を拾って誤検出になる（実際に一度そうなった）
-      const hit = re ? re.test(content) : content.includes(value)
-      if (re) re.lastIndex = 0
-      if (hit) findings.push({ file: rel, rule: 'identity' })
+      if (re.test(content)) findings.push({ file: rel, rule: 'identity' })
     }
     for (const rule of GENERIC_RULES) {
       rule.re.lastIndex = 0

--- a/scripts/check-anonymity.mjs
+++ b/scripts/check-anonymity.mjs
@@ -17,6 +17,7 @@
  */
 
 import { execSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { dirname, extname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -100,7 +101,26 @@ const GENERIC_RULES = [
     re: /https?:\/\/(www\.)?(twitter\.com|x\.com|linkedin\.com\/in|facebook\.com|instagram\.com|note\.com|qiita\.com|zenn\.dev)\/[A-Za-z0-9_./-]+/gi,
     why: '個人のソーシャルへの導線',
   },
+  // 資格情報。身元の問題ではなく事故そのものなので、匿名化と一緒に必ず見る。
+  //
+  // これが無かったために、本番の Storybook バンドルに OpenAI の実キーが
+  // 平文で配信されていながら、この検査は緑を返し続けた。ローカルの成果物は
+  // 同じ位置が空文字になるため、ソース走査・git 履歴走査・ローカル成果物走査は
+  // すべて偽陰性になる（本番 URL に当てて初めて出る）。
+  {
+    id: 'secret',
+    redact: true,
+    re: /\b(?:sk-(?:proj|ant|svcacct|live|test)-[A-Za-z0-9_-]{20,}|sk-[A-Za-z0-9]{40,}|AIza[A-Za-z0-9_-]{30,}|(?:pk|sk)\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}|gh[pousr]_[A-Za-z0-9]{30,}|xox[baprs]-[A-Za-z0-9-]{10,}|AKIA[0-9A-Z]{16})\b/g,
+    why: 'API キー・アクセストークンがバンドルに焼き込まれている',
+  },
 ]
+
+/** 資格情報を、特定はできるが再利用はできない形に落とす */
+const redact = (secret) =>
+  `${secret.slice(0, 8)}… (${secret.length} 文字 / sha256:${createHash('sha256')
+    .update(secret)
+    .digest('hex')
+    .slice(0, 12)})`
 
 const walk = (dir, out = []) => {
   if (!existsSync(dir)) return out
@@ -153,7 +173,10 @@ for (const target of present) {
         findings.push({
           file: rel,
           rule: rule.id,
-          hit: m[0].slice(0, 80),
+          // 資格情報は値そのものを出さない。どのキーかを特定できるだけの
+          // 情報（接頭・長さ・ハッシュ先頭）に落とす。検査ログが二次的な
+          // 漏洩経路になっては本末転倒なので
+          hit: rule.redact ? redact(m[0]) : m[0].slice(0, 80),
           why: rule.why,
         })
       }

--- a/scripts/sanitize-manifests.mjs
+++ b/scripts/sanitize-manifests.mjs
@@ -26,7 +26,39 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
-const TARGET_DIRS = ['storybook-static/manifests', 'dist/storybook/manifests']
+
+/** 出力先を固定で列挙しない。`build-storybook -o <dir>` で出力先を変えられる以上、
+ * 決め打ちにすると素通りして絶対パスが残る（実際に素通りすることを確認済み）。
+ * リポジトリ配下の manifests ディレクトリを探して回る。
+ * 引数で明示された場合はそちらを優先する。 */
+const SKIP_DIRS = new Set(['node_modules', '.git', 'src', 'apps', 'packages'])
+
+const findManifestDirs = (dir, depth = 0, out = []) => {
+  if (depth > 4) return out
+  let entries
+  try {
+    entries = readdirSync(dir)
+  } catch {
+    return out
+  }
+  for (const name of entries) {
+    if (SKIP_DIRS.has(name) || name.startsWith('.git')) continue
+    const p = join(dir, name)
+    try {
+      if (!statSync(p).isDirectory()) continue
+    } catch {
+      continue
+    }
+    if (name === 'manifests') out.push(p)
+    else findManifestDirs(p, depth + 1, out)
+  }
+  return out
+}
+
+const args = process.argv.slice(2).filter((a) => !a.startsWith('-'))
+const TARGET_DIRS = args.length
+  ? args.map((a) => join(ROOT, a))
+  : findManifestDirs(ROOT)
 
 /** 絶対パスの形で残っているものを相対へ。ROOT 以外の絶対パスも潰す */
 const stripAbsolute = (text) =>
@@ -38,9 +70,9 @@ const stripAbsolute = (text) =>
 let changed = 0
 let scanned = 0
 
-for (const rel of TARGET_DIRS) {
-  const dir = join(ROOT, rel)
+for (const dir of TARGET_DIRS) {
   if (!existsSync(dir)) continue
+  const rel = dir.replace(ROOT + '/', '')
   for (const name of readdirSync(dir)) {
     const file = join(dir, name)
     if (!statSync(file).isFile()) continue


### PR DESCRIPTION
## 背景

共有ビルドに資格情報が焼き込まれうる経路が開いていた。`define` した値はバンドルに文字列リテラルとして残るため、配信された時点で取得可能になる。

手元のビルドでは同じ位置が空文字になるため、ソース走査・git 履歴走査・ローカル成果物走査ではいずれも検出できない。検査が緑でも塞がっていない、という状態になっていた。

## 変更

### 資格情報をビルドに焼き込まない (4ca9264)

- `.storybook/main.cjs`: `configType === 'PRODUCTION'` のとき `VITE_OPENAI_API_KEY` と `VITE_MAPBOX_ACCESS_TOKEN` を常に空にする。dev では従来どおり `.env` の値を使う
- `.github/workflows/deploy-pages.yml`: ビルドへの secret 注入を削除

環境変数の設定に依存する防ぎ方では、設定が戻った時点で再発する。ビルド種別で機械的に落とす形にした。

### 匿名化検査の穴を塞ぐ (1d8be28)

- `scripts/check-anonymity.mjs`: secret ルールを追加。この検査は資格情報を 1 つも見ていなかった
- `scripts/check-anonymity.mjs`: identity の照合が大文字小文字を区別していた。アカウント名は表記を変えても同じアカウントに解決するため、小文字表記の 1 箇所で破れる
- `scripts/sanitize-manifests.mjs`: 対象ディレクトリを決め打ちしていた。`build-storybook -o <dir>` で出力先を変えると素通りし、manifests にビルドしたマシンの絶対パスが残る。配下を探して回る形にし、引数での明示も受ける

検出時も値そのものは出力しない。接頭とハッシュ先頭だけを表示する。検査ログが二次的な漏洩経路にならないようにするため。

## 検証

- カナリア値を環境変数に入れて `build-storybook` を実行し、出力に含まれないことを確認。値が空だから出なかったのではなく、ガードが効くことの確認
- 検査器を既知の違反に当てて検出すること、既知の正解で誤検出しないことの両方を確認
- 小文字表記と正式表記の 2 ファイルを置いたプローブで、両方を検出することを確認（従来は小文字が素通り）
- 決め打ちに含まれないディレクトリを作り、サニタイザが発見して相対化することを確認
- 出荷中の成果物 456 ファイルで誤検出が出ないことを確認

## 注意

この変更は再発を止めるもので、既に配信されたものを取り消すものではない。運用側の対応は別途。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jav2H6vtcjoLJk6N34N8hD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **セキュリティ**
  * 本番ビルドにAPIキーやアクセストークンを含めないよう強化しました。
  * 資格情報の検出・匿名化処理を改善し、ログ上の機密情報を保護します。
* **改善**
  * マニフェストの検査対象を自動探索できるようになり、複数の配置に対応しました。
  * 識別子の検出精度を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->