### PR TITLE
feat: 配信中の成果物を検査する check:live を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,9 @@
     "check:brand": "node scripts/check-brand-terms.mjs",
     "ds:adoption": "node scripts/ds-adoption.mjs",
     "capture:products": "node scripts/capture-products.mjs",
-    "check:anon": "node scripts/check-anonymity.mjs"
+    "check:anon": "node scripts/check-anonymity.mjs",
+    "check:live": "node scripts/check-live-secrets.mjs",
+    "check:share": "pnpm run check:anon && pnpm run check:live"
   },
   "peerDependencies": {
     "@emotion/react": "^11.13.5",

--- a/scripts/__tests__/secret-patterns.test.ts
+++ b/scripts/__tests__/secret-patterns.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  findSecrets,
+  redactSecret,
+  secretRegExp,
+} from '../lib/secret-patterns.mjs'
+
+/**
+ * 検出パターンの検証。
+ *
+ * 実装をどう壊しても緑のままになるアサーションは書かない。
+ * 「既知の違反を検出すること」と「既知の正解で誤検出しないこと」の
+ * 両方を置く。片方だけだと、何も検出しない実装でも半分は通る。
+ *
+ * 鍵の形をした文字列をソースに直接書かない。書くとこのリポジトリ自身の
+ * Gitleaks / Secrets Detection が反応する。実行時に組み立てる。
+ */
+
+const body = (n: number, ch = 'A') => ch.repeat(n)
+
+/** 検出されるべきもの（実行時に組み立てる） */
+const POSITIVES: [string, string][] = [
+  ['OpenAI プロジェクト鍵', 'sk-' + 'proj-' + body(48)],
+  ['Anthropic 鍵', 'sk-' + 'ant-' + body(40)],
+  ['OpenAI 旧形式', 'sk-' + body(48)],
+  ['Google API 鍵', 'AIza' + body(35)],
+  ['Mapbox 公開トークン', 'pk' + '.eyJ' + body(20) + '.' + body(20)],
+  ['GitHub PAT', 'ghp' + '_' + body(36)],
+  ['Slack bot トークン', 'xoxb' + '-' + body(24)],
+  ['AWS アクセスキー', 'AKIA' + body(16, 'B')],
+]
+
+/** 検出されてはいけないもの。minify 済みバンドルに普通に出る形を含む */
+const NEGATIVES: [string, string][] = [
+  ['接頭辞だけ', 'sk-'],
+  ['短い sk-', 'sk-' + body(10)],
+  ['普通の単語', 'const skipList = ["a","b"]'],
+  ['ハイフン付きの識別子', 'eslint-config-prettier'],
+  ['base64 断片（短い）', 'AIza' + body(5)],
+  ['空文字への置換後', 'const DEFAULT_API_KEY = ""'],
+  ['ドット無しの pk', 'pk' + 'eyJ' + body(30)],
+]
+
+describe('secretRegExp', () => {
+  it.each(POSITIVES)('%s を検出する', (_label, value) => {
+    expect(secretRegExp().test(`const k="${value}"`)).toBe(true)
+  })
+
+  it.each(NEGATIVES)('%s を検出しない', (_label, value) => {
+    expect(secretRegExp().test(value)).toBe(false)
+  })
+
+  it('g フラグ付きでも呼び出しごとに状態を持ち越さない', () => {
+    const text = `a="${'sk-' + 'proj-' + body(48)}"`
+    // lastIndex の持ち越しがあると 2 回目が false になる
+    expect(secretRegExp().test(text)).toBe(true)
+    expect(secretRegExp().test(text)).toBe(true)
+  })
+})
+
+describe('findSecrets', () => {
+  it('同じ値が複数回出ても 1 件に畳む', () => {
+    const k = 'sk-' + 'proj-' + body(48)
+    expect(findSecrets(`${k} ... ${k} ... ${k}`)).toHaveLength(1)
+  })
+
+  it('異なる種類が混ざっていれば別々に返す', () => {
+    const a = 'sk-' + 'proj-' + body(48)
+    const b = 'AIza' + body(35)
+    expect(findSecrets(`${a} and ${b}`)).toHaveLength(2)
+  })
+
+  it('検出が無ければ空配列', () => {
+    expect(findSecrets('const DEFAULT_API_KEY = ""')).toEqual([])
+  })
+
+  it('返す値に元の資格情報を含まない', () => {
+    const k = 'sk-' + 'proj-' + body(48)
+    const [masked] = findSecrets(k)
+    expect(masked).not.toContain(body(48))
+    expect(masked).not.toBe(k)
+  })
+})
+
+describe('redactSecret', () => {
+  const k = 'sk-' + 'proj-' + body(48)
+
+  it('元の値をそのまま含まない', () => {
+    expect(redactSecret(k)).not.toContain(body(48))
+  })
+
+  it('どの鍵かを特定できる情報は残す', () => {
+    const masked = redactSecret(k)
+    expect(masked).toContain('sk-proj-')
+    expect(masked).toContain(`${k.length} 文字`)
+    expect(masked).toMatch(/sha256:[0-9a-f]{12}/)
+  })
+
+  it('値が違えばハッシュも違う', () => {
+    const other = 'sk-' + 'proj-' + body(48, 'B')
+    expect(redactSecret(k)).not.toBe(redactSecret(other))
+  })
+})

--- a/scripts/check-anonymity.mjs
+++ b/scripts/check-anonymity.mjs
@@ -17,10 +17,11 @@
  */
 
 import { execSync } from 'node:child_process'
-import { createHash } from 'node:crypto'
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { dirname, extname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+
+import { SECRET_PATTERN, redactSecret } from './lib/secret-patterns.mjs'
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
 const DEFAULT_TARGETS = ['dist', 'storybook-static']
@@ -114,17 +115,13 @@ const GENERIC_RULES = [
   {
     id: 'secret',
     redact: true,
-    re: /\b(?:sk-(?:proj|ant|svcacct|live|test)-[A-Za-z0-9_-]{20,}|sk-[A-Za-z0-9]{40,}|AIza[A-Za-z0-9_-]{30,}|(?:pk|sk)\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}|gh[pousr]_[A-Za-z0-9]{30,}|xox[baprs]-[A-Za-z0-9-]{10,}|AKIA[0-9A-Z]{16})\b/g,
+    // パターンの単一ソースは scripts/lib/secret-patterns.mjs。
+    // 本番 URL を見る check-live-secrets.mjs と同じものを使う。
+    // 片方だけに足すと「片方の検査では緑」を作れてしまう
+    re: new RegExp(`\\b(?:${SECRET_PATTERN})\\b`, 'g'),
     why: 'API キー・アクセストークンがバンドルに焼き込まれている',
   },
 ]
-
-/** 資格情報を、特定はできるが再利用はできない形に落とす */
-const redact = (secret) =>
-  `${secret.slice(0, 8)}… (${secret.length} 文字 / sha256:${createHash('sha256')
-    .update(secret)
-    .digest('hex')
-    .slice(0, 12)})`
 
 const walk = (dir, out = []) => {
   if (!existsSync(dir)) return out
@@ -178,7 +175,7 @@ for (const target of present) {
           // 資格情報は値そのものを出さない。どのキーかを特定できるだけの
           // 情報（接頭・長さ・ハッシュ先頭）に落とす。検査ログが二次的な
           // 漏洩経路になっては本末転倒なので
-          hit: rule.redact ? redact(m[0]) : m[0].slice(0, 80),
+          hit: rule.redact ? redactSecret(m[0]) : m[0].slice(0, 80),
           why: rule.why,
         })
       }

--- a/scripts/check-live-secrets.mjs
+++ b/scripts/check-live-secrets.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+/**
+ * **配信中の**成果物に資格情報が載っていないかを、本番 URL に当てて検査する。
+ *
+ *   pnpm check:live                      既定の共有 URL を検査
+ *   pnpm check:live https://example.com  URL を指定
+ *
+ * なぜローカル検査と別に要るか:
+ *
+ * ビルド時に `define` で埋め込まれる値は、**環境変数がある環境でしか
+ * 焼き込まれない**。手元には値が無いので同じ位置が空文字になり、
+ * ソース走査・git 履歴走査・ローカル成果物走査はすべて緑を返す。
+ * git に入っていないので Gitleaks や Secrets Detection も通る。
+ *
+ * 実際にこの穴で、本番の Storybook バンドルに OpenAI の実キーが平文で
+ * 配信されていた。見つけたのは本番 URL に curl を当てたときだけだった。
+ *
+ * 「デプロイされているか」「安全か」を静的な走査で判定しない。配信物を取る。
+ */
+
+import { findSecrets } from './lib/secret-patterns.mjs'
+
+const DEFAULT_BASE = 'https://kaze-ux.vercel.app'
+
+/** 走査する面。初期 HTML と、Storybook は iframe 側も見る */
+const SURFACES = [
+  '/',
+  '/storybook/',
+  '/storybook/iframe.html',
+  '/saas/',
+  '/kaze-eats/',
+  '/sky-kaze/',
+]
+
+const args = process.argv.slice(2).filter((a) => !a.startsWith('-'))
+const BASE = (args[0] || process.env.SHARE_BASE_URL || DEFAULT_BASE).replace(
+  /\/$/,
+  ''
+)
+
+const fetchText = async (url, timeoutMs = 45000) => {
+  const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) })
+  return { status: res.status, text: res.ok ? await res.text() : '' }
+}
+
+/** HTML から読み込まれる js を絶対 URL にして返す */
+const scriptUrls = (html, pageUrl) => {
+  const out = new Set()
+  for (const m of html.matchAll(/(?:src|href)="([^"]+\.js)"/g)) {
+    try {
+      out.add(new URL(m[1], pageUrl).href)
+    } catch {
+      // 解決できない参照は飛ばす
+    }
+  }
+  return [...out]
+}
+
+const findings = []
+const surfaceRows = []
+let chunkCount = 0
+let failed = false
+
+for (const path of SURFACES) {
+  const pageUrl = `${BASE}${path}`
+  let page
+  try {
+    page = await fetchText(pageUrl)
+  } catch (e) {
+    surfaceRows.push([path, '取得失敗', 0])
+    console.error(`  ⚠ ${path} を取得できません: ${e.message}`)
+    failed = true
+    continue
+  }
+
+  if (page.status !== 200) {
+    surfaceRows.push([path, String(page.status), 0])
+    continue
+  }
+
+  // HTML 自体にも埋め込まれうるので先に見る
+  for (const hit of findSecrets(page.text)) {
+    findings.push({ where: pageUrl, hit })
+  }
+
+  const urls = scriptUrls(page.text, pageUrl)
+  let hitsHere = 0
+  for (const url of urls) {
+    chunkCount++
+    try {
+      const chunk = await fetchText(url)
+      if (chunk.status !== 200) continue
+      for (const hit of findSecrets(chunk.text)) {
+        findings.push({ where: url, hit })
+        hitsHere++
+      }
+    } catch (e) {
+      console.error(`  ⚠ チャンクを取得できません ${url}: ${e.message}`)
+      failed = true
+    }
+  }
+  surfaceRows.push([path, '200', urls.length, hitsHere])
+}
+
+console.log(`配信中の成果物を検査: ${BASE}`)
+for (const [path, status, chunks, hits] of surfaceRows) {
+  const h = hits === undefined ? '' : `  資格情報 ${hits} 件`
+  console.log(
+    `  ${path.padEnd(26)} ${String(status).padEnd(8)} chunk ${chunks}${h}`
+  )
+}
+
+// 重複排除。同じ値が複数チャンクに載ることがある
+const unique = [...new Map(findings.map((f) => [f.hit, f])).values()]
+
+if (unique.length) {
+  console.error(`\n❌ 配信中の成果物に資格情報が ${unique.length} 件あります\n`)
+  for (const f of unique) {
+    console.error(`  ${f.hit}`)
+    console.error(`    ${f.where}`)
+  }
+  console.error(
+    [
+      '',
+      'まず鍵を失効させてください。失効できない場合は支出上限を設定したうえで、',
+      '焼き込み経路を塞いで再デプロイしてください。既に配信されたものは',
+      'デプロイし直しても取り消せません。',
+    ].join('\n')
+  )
+  process.exit(1)
+}
+
+if (failed) {
+  console.error(
+    '\n⚠ 一部を取得できませんでした。取得できた範囲では検出なしですが、' +
+      '未検査の面が残っています。'
+  )
+  process.exit(1)
+}
+
+console.log(
+  `\n✅ 配信中の成果物に資格情報なし (${chunkCount} チャンク / ${SURFACES.length} 面)\n` +
+    '   注: 初期 HTML から辿れるチャンクのみ。遅延ロードされるものは範囲外。'
+)

--- a/scripts/lib/secret-patterns.mjs
+++ b/scripts/lib/secret-patterns.mjs
@@ -1,0 +1,61 @@
+/**
+ * 資格情報の検出パターン。**ここが単一ソース。**
+ *
+ * ローカル成果物を見る check-anonymity.mjs と、本番 URL を見る
+ * check-live-secrets.mjs の両方がこれを読む。片方だけパターンを足すと、
+ * 「片方の検査では緑」という最悪の状態が作れてしまうため。
+ *
+ * 実際にそうなった。本番の Storybook バンドルに OpenAI の実キーが平文で
+ * 配信されている間、ローカルを見る検査は緑を返し続けた。ローカルビルドは
+ * 同じ位置が空文字になるからで、ソース走査・git 履歴走査・ローカル成果物
+ * 走査はすべて偽陰性になる。git に入っていないので Gitleaks も通る。
+ */
+
+import { createHash } from 'node:crypto'
+
+/**
+ * 検出パターン。
+ *
+ * 素の `sk-` + 20 文字では、minify 済みバンドルの base64 断片に当たる。
+ * 接頭辞が明確なもの（sk-proj- 等）と、十分に長いもの（40 文字以上）に
+ * 分けて誤検出を抑える。
+ */
+export const SECRET_PATTERN = [
+  // OpenAI / Anthropic（プロジェクト・サービスアカウント鍵を含む）
+  'sk-(?:proj|ant|svcacct|live|test)-[A-Za-z0-9_-]{20,}',
+  'sk-[A-Za-z0-9]{40,}',
+  // Google (Gemini / Maps)
+  'AIza[A-Za-z0-9_-]{30,}',
+  // Mapbox（pk も課金アカウントに紐づくので対象にする）
+  '(?:pk|sk)\\.eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}',
+  // GitHub
+  'gh[pousr]_[A-Za-z0-9]{30,}',
+  // Slack
+  'xox[baprs]-[A-Za-z0-9-]{10,}',
+  // AWS
+  'AKIA[0-9A-Z]{16}',
+].join('|')
+
+/** 毎回新しい RegExp を返す。g フラグ付きの使い回しは lastIndex で事故る */
+export const secretRegExp = () => new RegExp(`\\b(?:${SECRET_PATTERN})\\b`, 'g')
+
+/**
+ * 資格情報を、特定はできるが再利用はできない形に落とす。
+ *
+ * 検出結果は CI のログにもターミナルにも残る。値をそのまま出すと、
+ * 漏洩を検出する仕組み自体が二次的な漏洩経路になる。
+ */
+export const redactSecret = (secret) =>
+  `${secret.slice(0, 8)}… (${secret.length} 文字 / sha256:${createHash('sha256')
+    .update(secret)
+    .digest('hex')
+    .slice(0, 12)})`
+
+/** テキストから資格情報を検出し、マスク済みの一覧を返す（重複は 1 件に畳む） */
+export const findSecrets = (text) => {
+  const seen = new Map()
+  for (const m of text.matchAll(secretRegExp())) {
+    if (!seen.has(m[0])) seen.set(m[0], redactSecret(m[0]))
+  }
+  return [...seen.values()]
+}


### PR DESCRIPTION
## 背景

既存の `check:anon` はローカルのビルド成果物しか見ない。

ビルド時に `define` で埋め込まれる値は、環境変数がある環境でしか焼き込まれない。手元では同じ位置が空文字になるため、この検査は構造的に偽陰性を出す。git に入らない経路なので Gitleaks / Secrets Detection も通る。

実際にこの穴で、配信物に資格情報が載ったまま全ての検査が緑だった。見つかったのは配信 URL に直接当てたときだけだった。

## 変更

- `scripts/lib/secret-patterns.mjs` — 検出パターンの単一ソース。ローカル検査と配信物検査が同じ定義を読む。片方だけに足すと「片方の検査では緑」を作れてしまうため
- `scripts/check-live-secrets.mjs` — 配信 URL の 6 面を走査。初期 HTML とそこから辿れるチャンクを取得して検査する。URL は引数か `SHARE_BASE_URL` で差し替えられる
- `pnpm check:share` — ローカルと配信物を続けて回す

検出しても値そのものは出力しない。接頭・長さ・ハッシュ先頭のみ。検出の仕組みがログ経由の二次的な漏洩経路にならないようにするため。

## 検証

- 既知の違反 8 種を検出することをテストで固定
- 誤検出しやすい 7 種（接頭辞だけ、短い断片、`eslint-config-prettier` のような普通の識別子、空文字置換後の形）で反応しないことも固定。片方だけだと何も検出しない実装でも半分通る
- パターンを意図的に壊すとテストが 6 件落ちることを確認。緑を見ただけで信用しないため
- 配信中の 6 面 13 チャンクに対して実行し、検出 0 件を確認

## 注意

走査対象は初期 HTML から辿れるチャンクのみで、遅延ロードされるものは範囲外。この限界は実行時の出力にも明記している。

鍵の形をした文字列はテストにも直接書かず実行時に組み立てている。書くとこのリポジトリ自身の Secrets Detection が反応するため。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jav2H6vtcjoLJk6N34N8hD