### PR TITLE
fix: @emotion/babel-plugin を明示依存にする

### DIFF
--- a/apps/kaze-eats/package.json
+++ b/apps/kaze-eats/package.json
@@ -13,5 +13,8 @@
   },
   "dependencies": {
     "kaze-ux": "workspace:*"
+  },
+  "devDependencies": {
+    "@emotion/babel-plugin": "^11.13.5"
   }
 }

--- a/apps/saas-dashboard/package.json
+++ b/apps/saas-dashboard/package.json
@@ -13,5 +13,8 @@
   },
   "dependencies": {
     "kaze-ux": "workspace:*"
+  },
+  "devDependencies": {
+    "@emotion/babel-plugin": "^11.13.5"
   }
 }

--- a/apps/sky-kaze/package.json
+++ b/apps/sky-kaze/package.json
@@ -13,5 +13,8 @@
   },
   "dependencies": {
     "kaze-ux": "workspace:*"
+  },
+  "devDependencies": {
+    "@emotion/babel-plugin": "^11.13.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "zustand": "^5.0.14"
   },
   "devDependencies": {
+    "@emotion/babel-plugin": "^11.13.5",
     "@eslint/js": "^9.39.5",
     "@figma/plugin-typings": "^1.133.0",
     "@fullhuman/postcss-purgecss": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
         specifier: ^5.0.14
         version: 5.0.14(@types/react@18.3.31)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
     devDependencies:
+      '@emotion/babel-plugin':
+        specifier: ^11.13.5
+        version: 11.13.5
       '@eslint/js':
         specifier: ^9.39.5
         version: 9.39.5
@@ -318,18 +321,30 @@ importers:
       kaze-ux:
         specifier: workspace:*
         version: link:../..
+    devDependencies:
+      '@emotion/babel-plugin':
+        specifier: ^11.13.5
+        version: 11.13.5
 
   apps/saas-dashboard:
     dependencies:
       kaze-ux:
         specifier: workspace:*
         version: link:../..
+    devDependencies:
+      '@emotion/babel-plugin':
+        specifier: ^11.13.5
+        version: 11.13.5
 
   apps/sky-kaze:
     dependencies:
       kaze-ux:
         specifier: workspace:*
         version: link:../..
+    devDependencies:
+      '@emotion/babel-plugin':
+        specifier: ^11.13.5
+        version: 11.13.5
 
   mcp:
     dependencies:
@@ -348,7 +363,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.6.1
-        version: 1.6.1(@types/node@20.19.43)(@vitest/browser@4.1.4)(@vitest/ui@1.6.1)(jsdom@29.0.2)(sass@1.102.0)
+        version: 1.6.1(@types/node@20.19.43)(@vitest/browser@4.1.4(vite@5.4.21(@types/node@20.19.43)(sass@1.102.0))(vitest@1.6.1))(@vitest/ui@1.6.1)(jsdom@29.0.2)(sass@1.102.0)
 
   packages/system-design-export:
     dependencies:
@@ -364,7 +379,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.6.1
-        version: 1.6.1(@types/node@20.19.43)(@vitest/browser@4.1.4)(@vitest/ui@1.6.1)(jsdom@29.0.2)(sass@1.102.0)
+        version: 1.6.1(@types/node@20.19.43)(@vitest/browser@4.1.4(vite@5.4.21(@types/node@20.19.43)(sass@1.102.0))(vitest@1.6.1))(@vitest/ui@1.6.1)(jsdom@29.0.2)(sass@1.102.0)
 
 packages:
 
@@ -471,14 +486,6 @@ packages:
 
   '@babel/helper-globals@7.29.7':
     resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-imports@7.27.1':
-    resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-imports@7.28.6':
-    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-imports@7.29.7':
@@ -6363,20 +6370,6 @@ snapshots:
 
   '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-module-imports@7.27.1':
-    dependencies:
-      '@babel/traverse': 7.29.8
-      '@babel/types': 7.29.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-imports@7.28.6':
-    dependencies:
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-module-imports@7.29.7':
     dependencies:
       '@babel/traverse': 7.29.8
@@ -6387,7 +6380,7 @@ snapshots:
   '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.28.5
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
@@ -6622,8 +6615,8 @@ snapshots:
 
   '@emotion/babel-plugin@11.13.5':
     dependencies:
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/runtime': 7.28.4
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/runtime': 7.29.7
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
       '@emotion/serialize': 1.3.3
@@ -9404,7 +9397,7 @@ snapshots:
       pathe: 1.1.2
       picocolors: 1.1.1
       sirv: 2.0.4
-      vitest: 1.6.1(@types/node@20.19.43)(@vitest/browser@4.1.4)(@vitest/ui@1.6.1)(jsdom@29.0.2)(sass@1.102.0)
+      vitest: 1.6.1(@types/node@20.19.43)(@vitest/browser@4.1.4)(@vitest/ui@1.6.1)(jsdom@24.1.3)(sass@1.102.0)
 
   '@vitest/utils@1.6.1':
     dependencies:
@@ -9689,7 +9682,7 @@ snapshots:
 
   babel-plugin-macros@3.1.0:
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
       cosmiconfig: 7.1.0
       resolve: 1.22.12
 
@@ -13339,6 +13332,43 @@ snapshots:
       fsevents: 2.3.3
       sass: 1.102.0
 
+  vitest@1.6.1(@types/node@20.19.43)(@vitest/browser@4.1.4(vite@5.4.21(@types/node@20.19.43)(sass@1.102.0))(vitest@1.6.1))(@vitest/ui@1.6.1)(jsdom@29.0.2)(sass@1.102.0):
+    dependencies:
+      '@vitest/expect': 1.6.1
+      '@vitest/runner': 1.6.1
+      '@vitest/snapshot': 1.6.1
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      acorn-walk: 8.3.4
+      chai: 4.5.0
+      debug: 4.4.3
+      execa: 8.0.1
+      local-pkg: 0.5.1
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      std-env: 3.10.0
+      strip-literal: 2.1.1
+      tinybench: 2.9.0
+      tinypool: 0.8.4
+      vite: 5.4.21(@types/node@20.19.43)(sass@1.102.0)
+      vite-node: 1.6.1(@types/node@20.19.43)(sass@1.102.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.43
+      '@vitest/browser': 4.1.4(vite@5.4.21(@types/node@20.19.43)(sass@1.102.0))(vitest@1.6.1)
+      '@vitest/ui': 1.6.1(vitest@1.6.1)
+      jsdom: 29.0.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vitest@1.6.1(@types/node@20.19.43)(@vitest/browser@4.1.4)(@vitest/ui@1.6.1)(jsdom@24.1.3)(sass@1.102.0):
     dependencies:
       '@vitest/expect': 1.6.1
@@ -13366,43 +13396,6 @@ snapshots:
       '@vitest/browser': 4.1.4(vite@5.4.21(@types/node@20.19.43)(sass@1.102.0))(vitest@1.6.1)
       '@vitest/ui': 1.6.1(vitest@1.6.1)
       jsdom: 24.1.3
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vitest@1.6.1(@types/node@20.19.43)(@vitest/browser@4.1.4)(@vitest/ui@1.6.1)(jsdom@29.0.2)(sass@1.102.0):
-    dependencies:
-      '@vitest/expect': 1.6.1
-      '@vitest/runner': 1.6.1
-      '@vitest/snapshot': 1.6.1
-      '@vitest/spy': 1.6.1
-      '@vitest/utils': 1.6.1
-      acorn-walk: 8.3.4
-      chai: 4.5.0
-      debug: 4.4.3
-      execa: 8.0.1
-      local-pkg: 0.5.1
-      magic-string: 0.30.21
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      std-env: 3.10.0
-      strip-literal: 2.1.1
-      tinybench: 2.9.0
-      tinypool: 0.8.4
-      vite: 5.4.21(@types/node@20.19.43)(sass@1.102.0)
-      vite-node: 1.6.1(@types/node@20.19.43)(sass@1.102.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 20.19.43
-      '@vitest/browser': 4.1.4(vite@5.4.21(@types/node@20.19.43)(sass@1.102.0))(vitest@1.6.1)
-      '@vitest/ui': 1.6.1(vitest@1.6.1)
-      jsdom: 29.0.2
     transitivePeerDependencies:
       - less
       - lightningcss


### PR DESCRIPTION
## 背景

`vite.config.ts` が babel プラグインとして `@emotion/babel-plugin` を名前で要求しているが、`package.json` に一度も入っていない推移依存だった。

4 ワークスペースすべてで `require.resolve('@emotion/babel-plugin')` が失敗する状態で、pnpm が hoist した `.pnpm/node_modules` 経由で偶然解決していただけだった。

実際に `Cannot find package '@emotion/babel-plugin'` で `build-storybook` が preview の生成に失敗する事象を踏んだ。`pnpm install` で復旧したが、hoist の状態に依存している以上は再発しうるし、hoist 設定を変えた時点で無言で壊れる。

## 変更

ルートと `apps/*` 3 つの devDependencies に `@emotion/babel-plugin` を追加。参照している 4 ワークスペースすべてに入れている。

## 検証

- 追加前は 4 ワークスペースすべてで `require.resolve` が NG、追加後はすべて OK
- `build-storybook` が完走（232 ファイル、`iframe.html` 生成）
- テスト 632 件が通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jav2H6vtcjoLJk6N34N8hD