### PR TITLE
feat: 本番の共有枠（無料枠）を実際に動かす

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,8 @@ VITE_OPENAI_MODEL=gpt-5.6-luna
 # - lib/ratelimit.ts による DAILY_LIMIT 適用
 # - X-User-API-Key ヘッダーで自前キー利用時はレート制限免除
 
-# このURLが設定されていればChatSupportは Backend Mode で動作する
+# 本番ビルドは未設定でも自動的に Backend Mode（同一オリジンの /api/ai）になる。
+# 設定するのは「別オリジンのバックエンドへ向けたいとき」だけ。
 # 例: https://kaze-ux.vercel.app
 VITE_API_BASE=
 
@@ -35,10 +36,19 @@ VITE_API_BASE=
 # GOOGLE_GENERATIVE_AI_API_KEY=...
 # (互換: GEMINI_API_KEY=...)
 
-# レート制限の上限（IP / 日）。デフォルト 30
-# DAILY_LIMIT=30
+# レート制限の上限（IP / 日）。デフォルト 20
+# DAILY_LIMIT=20
 
-# Upstash Redis (本番レート制限の永続化)
-# 設定がない場合は in-memory フォールバック（開発専用）
+# Upstash Redis（任意）
+# 未設定なら in-memory カウンタで動く。サーバーレスはインスタンスごとに
+# 状態が消えるため、その場合に止まるのはバーストだけで、利用者ごとの通算
+# 回数は数えられない。回数の目安はクライアント側 (dailyUsageLimit.ts) が持つ。
+# 厳密な上限が要るときだけ設定する。
 # UPSTASH_REDIS_REST_URL=https://...
 # UPSTASH_REDIS_REST_TOKEN=...
+
+# ----------------------------------------------------------------------------
+# 請求額の天井は OpenAI 側の予算上限で設ける。
+# Origin 許可リストは他サイトのブラウザを止めるが、Origin ヘッダーを付けた
+# 直接リクエストは通るため、上限設定が唯一の硬い天井になる。
+# ----------------------------------------------------------------------------

--- a/lib/ratelimit.ts
+++ b/lib/ratelimit.ts
@@ -1,6 +1,15 @@
 // レート制限
-// - Upstash Redis 設定があれば slidingWindow で本番運用
-// - 設定がない場合は in-memory フォールバック（開発専用）
+//
+// 現行構成では外部ストアを使わないため、実際に動くのは in-memory 経路。
+// サーバーレスは呼び出しごとにインスタンスが変わるので、これで止まるのは
+// 「同じインスタンスに連続で当たったバースト」だけで、利用者ごとの通算回数は
+// 数えられない。回数の目安はクライアント側 (dailyUsageLimit.ts) が持ち、
+// 請求額の天井は OpenAI 側の予算上限で設ける。
+//
+// UPSTASH_REDIS_REST_URL / _TOKEN を設定すれば slidingWindow の本実装に
+// 切り替わり、そこで初めて IP ごとの厳密な上限になる。導入しない限りは
+// 上の前提で運用する。
+//
 // - IP ベース、X-Vercel-Forwarded-For を優先
 
 import { Ratelimit } from '@upstash/ratelimit'
@@ -10,7 +19,7 @@ import { Redis } from '@upstash/redis'
 // 設定
 // ---------------------------------------------------------------------------
 
-const DEFAULT_DAILY_LIMIT = 30
+const DEFAULT_DAILY_LIMIT = 20
 const DAILY_LIMIT = (() => {
   const raw = process.env.DAILY_LIMIT
   if (!raw) return DEFAULT_DAILY_LIMIT
@@ -55,7 +64,7 @@ const getUpstashRatelimit = (): Ratelimit | null => {
 }
 
 // ---------------------------------------------------------------------------
-// In-memory フォールバック（開発専用）
+// In-memory カウンタ（外部ストア未設定時の実経路。バースト抑止のみ）
 // ---------------------------------------------------------------------------
 
 interface InMemoryEntry {
@@ -63,6 +72,7 @@ interface InMemoryEntry {
   resetAt: number
 }
 
+// インスタンスに紐づくため、スケールアウトすると各インスタンスが別々に数える
 const inMemoryStore = new Map<string, InMemoryEntry>()
 const DAY_MS = 24 * 60 * 60 * 1000
 

--- a/src/components/ui/ChatSupport/ChatSupport.tsx
+++ b/src/components/ui/ChatSupport/ChatSupport.tsx
@@ -8,6 +8,7 @@ import { useCallback } from 'react'
 import { motionOf } from '@/themes/motion'
 
 import BookConciergeIcon from './BookConciergeIcon'
+import { isBackendMode } from './chatAiService'
 import { ChatHeader } from './components/ChatHeader'
 import { ChatInput } from './components/ChatInput'
 import { ChatMessageList } from './components/ChatMessageList'
@@ -170,7 +171,7 @@ export const ChatSupport = ({ currentStory }: ChatSupportProps) => {
             message={message}
             isTyping={isTyping}
             submitShortcutLabel={submitShortcutLabel}
-            hasApiKey={!!config.apiKey}
+            aiAvailable={!!config.apiKey || isBackendMode()}
             inputRef={inputRef}
             onMessageChange={setMessage}
             onKeyDown={(e) => handleKeyDown(e, onSend)}

--- a/src/components/ui/ChatSupport/__tests__/chatAiService.test.ts
+++ b/src/components/ui/ChatSupport/__tests__/chatAiService.test.ts
@@ -4,6 +4,8 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { resolveBackendMode } from '../chatAiService'
+
 import type { ChatSupportConfig } from '../chatSupportTypes'
 
 // `ai` モジュールの generateText をモック
@@ -418,5 +420,26 @@ describe('callAI (backend mode)', () => {
       const result = await callAI(baseConfig, userMessage)
       expect(result).toContain('トークン上限')
     })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveBackendMode — バックエンド経由にするかの判定
+//
+// 本番ビルドでは VITE_API_BASE 未設定でもバックエンド経由にする。
+// 設定漏れ 1 回で AI が無言で動かなくなる形にしないため。
+// ---------------------------------------------------------------------------
+
+describe('resolveBackendMode', () => {
+  it('本番ビルドなら API_BASE が空でもバックエンド経由（同一オリジンの /api/ai）', () => {
+    expect(resolveBackendMode('', true)).toBe(true)
+  })
+
+  it('開発では API_BASE が空ならブラウザ直呼び（従来動作）', () => {
+    expect(resolveBackendMode('', false)).toBe(false)
+  })
+
+  it('API_BASE が設定されていれば開発でもバックエンド経由（別オリジン用の逃げ道）', () => {
+    expect(resolveBackendMode('https://api.example.com', false)).toBe(true)
   })
 })

--- a/src/components/ui/ChatSupport/__tests__/dailyUsageLimit.test.ts
+++ b/src/components/ui/ChatSupport/__tests__/dailyUsageLimit.test.ts
@@ -8,6 +8,7 @@ import {
   consumeUse,
   isLimitReached,
   isUsingDefaultKey,
+  isUsingSharedQuota,
   limitReachedMessage,
   localDateKey,
   readUsage,
@@ -138,5 +139,35 @@ describe('上限メッセージ', () => {
     expect(msg).toContain(String(DAILY_LIMIT))
     expect(msg).toContain('API キー')
     expect(msg).toContain('設定')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isUsingSharedQuota — 共有枠（無料枠）を使っているかの判定
+//
+// 本番ビルドは既定キーを空にするため、既定キーとの一致では判定できない。
+// バックエンドがキーを持つ場合、ブラウザ側にキーが無いのが正常な状態になる。
+// ---------------------------------------------------------------------------
+
+describe('isUsingSharedQuota', () => {
+  it('自前キーがあれば対象外（バックエンド経由でも無制限）', () => {
+    expect(isUsingSharedQuota('sk-own', '', true)).toBe(false)
+    expect(isUsingSharedQuota('sk-own', 'sk-default', false)).toBe(false)
+  })
+
+  it('キーが無くバックエンド経由なら対象（本番の無料枠）', () => {
+    // 既定キーが空でも共有枠は成立する。この経路が無いと本番で一度も数えない
+    expect(isUsingSharedQuota('', '', true)).toBe(true)
+    expect(isUsingSharedQuota(undefined, '', true)).toBe(true)
+  })
+
+  it('バックエンドが無くても既定キーが焼き込まれていれば対象（従来動作）', () => {
+    expect(isUsingSharedQuota('', 'sk-default', false)).toBe(true)
+    expect(isUsingSharedQuota('sk-default', 'sk-default', false)).toBe(true)
+  })
+
+  it('供給元がどこにも無ければ対象外（FAQ のみで AI を呼ばない）', () => {
+    expect(isUsingSharedQuota('', '', false)).toBe(false)
+    expect(isUsingSharedQuota(undefined, '', false)).toBe(false)
   })
 })

--- a/src/components/ui/ChatSupport/chatAiService.ts
+++ b/src/components/ui/ChatSupport/chatAiService.ts
@@ -1,8 +1,9 @@
 // ChatSupport AI API呼び出しサービス（AI SDK v6 + ハイブリッドモード）
 //
-// モード切替:
-// - VITE_API_BASE が設定されていれば → バックエンドプロキシ (/api/ai) 経由
-// - 設定されていなければ → ブラウザから AI SDK 直接呼び出し（旧来動作）
+// モード切替 (resolveBackendMode):
+// - 本番ビルド → 常にバックエンドプロキシ経由 (同一オリジンの /api/ai)
+// - VITE_API_BASE 設定時 → そのオリジンのプロキシ経由 (別オリジン運用)
+// - どちらでもない (開発) → ブラウザから AI SDK 直接呼び出し
 //
 // バックエンド経由のメリット:
 // - APIキーがブラウザに露出しない（サーバー env vars に保管）
@@ -21,7 +22,23 @@ import type { ChatSupportConfig } from './chatSupportTypes'
 // ---------------------------------------------------------------------------
 
 const API_BASE = (import.meta.env.VITE_API_BASE as string | undefined) || ''
-const isBackendMode = (): boolean => API_BASE.length > 0
+
+/**
+ * バックエンド (api/ai.ts) 経由で呼ぶかどうか。
+ *
+ * 本番ビルドでは常に true にする。VITE_API_BASE の設定漏れ 1 回で AI が
+ * 無言で動かなくなる形にしない（本番ビルドで資格情報を機械的に空にして
+ * いるのと同じ理由。.storybook/main.cjs 参照）。
+ *
+ * 同一オリジン配信なので API_BASE は空のままでよく、fetch は相対
+ * `/api/ai` になる。別オリジンのバックエンドへ向けたいときだけ
+ * VITE_API_BASE を設定する。
+ */
+export const resolveBackendMode = (apiBase: string, isProd: boolean): boolean =>
+  apiBase.length > 0 || isProd
+
+export const isBackendMode = (): boolean =>
+  resolveBackendMode(API_BASE, import.meta.env.PROD === true)
 
 // ---------------------------------------------------------------------------
 // 構造化エラー: UI 側でクォータ表示・自前キー入力 CTA を出すために型で区別
@@ -135,7 +152,7 @@ const callViaBackend = async (
     }
     throw new AIQuotaError(
       data.remaining ?? 0,
-      data.limit ?? 30,
+      data.limit ?? 20,
       data.reset ?? 0
     )
   }

--- a/src/components/ui/ChatSupport/components/ChatHeader.tsx
+++ b/src/components/ui/ChatSupport/components/ChatHeader.tsx
@@ -23,6 +23,7 @@ import {
   Trash2,
 } from 'lucide-react'
 
+import { isBackendMode } from '../chatAiService'
 import { DEFAULT_API_KEY, DEFAULT_MODEL } from '../chatSupportConstants'
 
 import type {
@@ -176,7 +177,7 @@ export const ChatHeader = ({
             </IconButton>
           </Stack>
           <Typography sx={{ opacity: 0.6, fontSize: 12, whiteSpace: 'nowrap' }}>
-            {!config.apiKey && !DEFAULT_API_KEY
+            {!config.apiKey && !DEFAULT_API_KEY && !isBackendMode()
               ? 'FAQモード'
               : config.model || DEFAULT_MODEL}
           </Typography>

--- a/src/components/ui/ChatSupport/components/ChatInput.tsx
+++ b/src/components/ui/ChatSupport/components/ChatInput.tsx
@@ -7,7 +7,8 @@ interface ChatInputProps {
   message: string
   isTyping: boolean
   submitShortcutLabel: string
-  hasApiKey: boolean
+  /** AI 対話が使えるか（自前キー or バックエンドの共有枠） */
+  aiAvailable: boolean
   inputRef: React.RefObject<HTMLInputElement | null>
   onMessageChange: (v: string) => void
   onKeyDown: (e: React.KeyboardEvent) => void
@@ -18,7 +19,7 @@ export const ChatInput = ({
   message,
   isTyping,
   submitShortcutLabel,
-  hasApiKey,
+  aiAvailable,
   inputRef,
   onMessageChange,
   onKeyDown,
@@ -52,7 +53,7 @@ export const ChatInput = ({
           maxRows={8}
           inputRef={inputRef}
           placeholder={
-            hasApiKey
+            aiAvailable
               ? `質問を入力... (${submitShortcutLabel}で送信)`
               : `FAQモード: 質問を入力... (${submitShortcutLabel}で送信)`
           }

--- a/src/components/ui/ChatSupport/components/ChatSettings.tsx
+++ b/src/components/ui/ChatSupport/components/ChatSettings.tsx
@@ -30,6 +30,7 @@ import {
   Sparkles,
 } from 'lucide-react'
 
+import { isBackendMode } from '../chatAiService'
 import {
   DEFAULT_API_KEY,
   DEFAULT_MODEL,
@@ -100,7 +101,9 @@ export const ChatSettings = ({
             現在の設定
           </Typography>
           {isUsingDefaultKey ? (
-            DEFAULT_API_KEY ? (
+            // 共有枠の供給元は「焼き込まれた既定キー」か「バックエンド」。
+            // 本番は既定キーが空なので、これを見ないと常に FAQ 表記になる
+            DEFAULT_API_KEY || isBackendMode() ? (
               <>
                 <Typography
                   variant='caption'

--- a/src/components/ui/ChatSupport/dailyUsageLimit.ts
+++ b/src/components/ui/ChatSupport/dailyUsageLimit.ts
@@ -1,19 +1,24 @@
 /**
- * デフォルト API キー利用時の 1 日あたり回数制限。
+ * 共有枠 (無料枠) 利用時の 1 日あたり回数制限。
  *
  * 自分のキーを登録する利点が無いと、共有キーだけが使われてコストが読めない。
  * 「無制限に使えること」を自前キーの利点にする。
  *
- * 制限の対象はデフォルトキーを使っているときだけで、
+ * 制限の対象は共有枠を使っているときだけで、
  * - 自前キーを登録している人は無制限（現状維持）
- * - デフォルトキーが未設定（FAQ モード）は AI を呼ばないので対象外
+ * - 共有枠の供給元がどこにも無ければ AI を呼ばないので対象外（FAQ モード）
  *
- * 記録はブラウザの localStorage なので、消せば回避できる。サーバーを
- * 持たない構成での抑止としてはこれが上限で、厳密な保証ではない。
+ * 記録はブラウザの localStorage に置く。バックエンド (api/ai.ts) は存在するが
+ * 共有ストレージを持たないため、サーバー側に「利用者ごとの通算回数」を置けない
+ * (Vercel のサーバーレスは呼び出しごとにインスタンスが変わり、in-memory の
+ * カウンタは残らない)。
+ *
+ * したがってこの上限が止められるのは通常利用だけで、シークレットウィンドウを
+ * 開けば新しい 20 回が始まる。請求額の天井は OpenAI 側の予算上限で設ける。
  */
 
 /** 1 日あたりの上限回数 */
-export const DAILY_LIMIT = 30
+export const DAILY_LIMIT = 20
 
 export const USAGE_STORAGE_KEY = 'storybook_chat_usage'
 
@@ -120,6 +125,28 @@ export const isUsingDefaultKey = (
   apiKey: string | undefined,
   defaultApiKey: string
 ): boolean => Boolean(defaultApiKey) && (!apiKey || apiKey === defaultApiKey)
+
+/**
+ * 共有枠（無料枠）を使っているかどうか。回数制限の対象はこれ。
+ *
+ * `isUsingDefaultKey` はバンドルに焼き込まれた既定キーがある前提の判定で、
+ * 本番ビルドでは既定キーを空にしているため常に false になる。バックエンド
+ * 経由ではキーはサーバーが持っていてブラウザからは見えないので、
+ * 「既定キーと一致するか」では判定できない。
+ *
+ * 判定はこの 2 段:
+ *   1. 自前キーを登録している → 無制限（対象外）
+ *   2. そうでなく、共有枠の供給元がある（バックエンド経由 or 既定キーあり）→ 対象
+ */
+export const isUsingSharedQuota = (
+  apiKey: string | undefined,
+  defaultApiKey: string,
+  backendMode: boolean
+): boolean => {
+  const hasOwnKey = Boolean(apiKey) && apiKey !== defaultApiKey
+  if (hasOwnKey) return false
+  return backendMode || Boolean(defaultApiKey)
+}
 
 /** 上限到達時に出す案内文 */
 export const limitReachedMessage = (): string =>

--- a/src/components/ui/ChatSupport/hooks/useChatMessage.ts
+++ b/src/components/ui/ChatSupport/hooks/useChatMessage.ts
@@ -7,12 +7,12 @@
 
 import { useState, useMemo, useEffect, useCallback } from 'react'
 
-import { callAI, extractContent } from '../chatAiService'
+import { callAI, extractContent, isBackendMode } from '../chatAiService'
 import { DEFAULT_API_KEY, SYSTEM_PROMPT } from '../chatSupportConstants'
 import {
   consumeUse,
   isLimitReached,
-  isUsingDefaultKey,
+  isUsingSharedQuota,
   limitReachedMessage,
 } from '../dailyUsageLimit'
 import {
@@ -184,14 +184,15 @@ export const useChatMessage = ({
   )
 
   /**
-   * デフォルトキーの日次上限に達しているか。
+   * 共有枠（無料枠）の日次上限に達しているか。
    *
    * 到達していたら AI を呼ばず、案内文と FAQ 回答を 1 通で返す。
    * 「送っても何も起きない」状態にはしない。
    */
   const blockedByDailyLimit = useCallback(
     (query: string): boolean => {
-      if (!isUsingDefaultKey(config.apiKey, DEFAULT_API_KEY)) return false
+      if (!isUsingSharedQuota(config.apiKey, DEFAULT_API_KEY, isBackendMode()))
+        return false
       if (!isLimitReached()) return false
 
       const faqAnswer = findFaqAnswer(query)
@@ -245,7 +246,10 @@ export const useChatMessage = ({
       setMessages((prev) => [...prev, newUserMessage])
       clearInput()
 
-      if (!config.apiKey) {
+      // AI を呼べるのは「自前キーがある」か「バックエンドが共有キーを持つ」場合。
+      // バックエンドモードではブラウザ側にキーが無いのが正常なので、
+      // config.apiKey の有無だけで FAQ に落とすと無料枠が一度も動かない。
+      if (!config.apiKey && !isBackendMode()) {
         respondWithFaq(userText)
         return
       }
@@ -253,7 +257,8 @@ export const useChatMessage = ({
 
       // API を呼ぶ直前に数える。成功時だけ数えると、失敗が返り続ける
       // 状況で上限が効かず、コストを抑えるという目的を果たせない
-      if (isUsingDefaultKey(config.apiKey, DEFAULT_API_KEY)) consumeUse()
+      if (isUsingSharedQuota(config.apiKey, DEFAULT_API_KEY, isBackendMode()))
+        consumeUse()
 
       setIsTyping(true)
       try {
@@ -319,12 +324,14 @@ export const useChatMessage = ({
       }
       setMessages((prev) => [...prev, userMsg])
 
-      if (!config.apiKey) {
+      // handleSend と同じ判定。バックエンドモードではブラウザにキーが無い
+      if (!config.apiKey && !isBackendMode()) {
         respondWithFaq(query)
         return
       }
       if (blockedByDailyLimit(query)) return
-      if (isUsingDefaultKey(config.apiKey, DEFAULT_API_KEY)) consumeUse()
+      if (isUsingSharedQuota(config.apiKey, DEFAULT_API_KEY, isBackendMode()))
+        consumeUse()
 
       setIsTyping(true)
       semanticSearch(config.apiKey, query)


### PR DESCRIPTION
## 現状

公開ビルドでは AI が**一度も動いていませんでした**。設定パネルは「APIキー未設定 / FAQモードのみ」と表示し、送信しても FAQ が返るだけでした。

バックエンド (`api/ai.ts`)・レート制限 (`lib/ratelimit.ts`)・自前キー免除・クォータエラー型は既に実装済みで、**足りなかったのは結線だけ**でした。

## 原因は 3 つ。いずれも「キーがブラウザにある」前提の判定

| # | 箇所 | 症状 |
|:--|:--|:--|
| 1 | `chatAiService.ts` `isBackendMode()` | `VITE_API_BASE` が空だと false。同一オリジンなら相対 `/api/ai` で足りるのに、空文字が「バックエンド無し」の意味になっていた |
| 2 | `useChatMessage.ts` `handleSend` | `config.apiKey` の有無だけで FAQ に落ちる。バックエンド経由ではブラウザにキーが無いのが正常 |
| 3 | `dailyUsageLimit.ts` `isUsingDefaultKey` | `Boolean(defaultApiKey)` を要求するが本番の既定キーは空。**`consumeUse` が一度も実行されていなかった** |

## 変更

本番ビルドは常にバックエンド経由にします。`VITE_API_BASE` は別オリジン用の逃げ道として残します。設定漏れ 1 回で AI が無言で止まる形にしない、という判断は本番ビルドで資格情報を機械的に空にしているのと同じ理由です。

共有枠の判定を `isUsingSharedQuota` に分け、供給元がバックエンドの場合も対象にしました。上限は 20 回/日でクライアント・サーバー・案内文を揃えています。

UI 表記 3 箇所（入力欄・ヘッダー・設定パネル）が「FAQモード」のままだったのも直しました。`ChatInput` の prop は実態に合わせて `aiAvailable` へ改名しています。

## 検証（実ブラウザ）

`storybook-static` を配信して実測しました。ビルドが通ることは動作の証拠にならないためです。

- `POST /api/ai` が実際に発行されることを確認（同一オリジン）
- 入力欄・ヘッダー・設定パネルが AI 対話モード表記になることを確認
- 設定パネルが「**本日の残り 19 / 20 回**」を表示。送信 1 回が実際に数えられている（ここが動いていなかった箇所）
- 新規テスト 7 件は、**実装を修正前に戻すと 2 件が赤になる**ことを確認済み

## 既知の制約（意図的）

共有ストレージを使わない構成のため、回数制限は**端末ごとの目安**です。シークレットウィンドウを開けば新しい 20 回が始まります。サーバー側の in-memory カウンタはインスタンスごとに消えるので、止まるのはバーストだけです。`lib/ratelimit.ts` の「開発専用」というコメントは現行構成では誤りなので直しました。

**請求額の天井は OpenAI 側の予算上限で設けてください。** Origin 許可リストは他サイトのブラウザを止めますが、Origin ヘッダーを付けた直接リクエストは通るため、予算上限が唯一の硬い天井になります。

## デプロイ前に必要な設定（Vercel / Production・Preview）

```
OPENAI_API_KEY   サーバー側のみ。VITE_ を付けない
DAILY_LIMIT      20（未設定でも既定 20）
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWcX4dEpxLBL7gQdwSw5Se

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
- APIキーがなくても、バックエンド経由でAIチャットを利用できるようになりました。
- 同一オリジンのAPIを自動利用し、必要に応じて接続先を設定できます。

## 改善
- 共有利用枠の日次上限を30回から20回に変更しました。
- 自前のAPIキー利用時やFAQモードでは、共有利用枠の制限対象外になりました。
- バックエンド利用時のチャット表示と利用可能状態を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->