### PR TITLE
fix(a11y): フォントを 12px 以上・ウェイトを 400/700 の 2 値に統一

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -86,7 +86,7 @@
   code.sbdocs-title.sb-unstyled {
     /* background-color: #00006608 !important; */
     border: 1px solid #00006615 !important;
-    font-weight: 500 !important;
+    font-weight: 400 !important;
     font-size: 14px !important;
     /* color: #3e3e63 !important; */
     letter-spacing: 0.025ch;
@@ -133,13 +133,13 @@
   /* Link styles */
   a,
   a:-webkit-any-link {
-    font-weight: 500;
+    font-weight: 400;
     transition: 0.3s;
     line-height: 1.25;
   }
 
   li a {
-    font-weight: 500;
+    font-weight: 400;
     transition: 0.3s;
     line-height: 1.25;
   }
@@ -165,7 +165,7 @@
 
   ::marker {
     color: var(--color-TextSecondary) !important;
-    font-weight: 500 !important;
+    font-weight: 400 !important;
     transition: 0.3s !important;
     line-height: 1.25 !important;
   }
@@ -197,7 +197,7 @@
     font-size: 14px;
     line-height: 1.75;
     color: var(--color-TextSecondary);
-    font-weight: 600;
+    font-weight: 700;
     cursor: pointer;
     transition: 0.3s;
   }

--- a/apps/kaze-eats/src/App.tsx
+++ b/apps/kaze-eats/src/App.tsx
@@ -198,7 +198,7 @@ const AppContent = ({
               </Box>
               <Typography
                 sx={{
-                  fontWeight: 800,
+                  fontWeight: 700,
                   fontSize: { xs: '1.25rem', md: '1.4rem' },
                   letterSpacing: '-0.03em',
                   color: 'text.primary',
@@ -309,7 +309,7 @@ const AppContent = ({
                 minWidth: 64,
                 '& .MuiSvgIcon-root': { fontSize: 24 },
                 '& .MuiBottomNavigationAction-label': {
-                  fontSize: '0.7rem',
+                  fontSize: '0.86rem',
                   mt: 0.25,
                 },
               }}

--- a/apps/kaze-eats/src/pages/CartPage.tsx
+++ b/apps/kaze-eats/src/pages/CartPage.tsx
@@ -95,7 +95,7 @@ export const CartPage = () => {
 
       <Typography
         variant='h4'
-        sx={{ fontWeight: 800, mb: 0.5, letterSpacing: '-0.02em' }}>
+        sx={{ fontWeight: 700, mb: 0.5, letterSpacing: '-0.02em' }}>
         Checkout
       </Typography>
       <Typography variant='body1' color='text.secondary' sx={{ mb: 4 }}>
@@ -124,7 +124,7 @@ export const CartPage = () => {
                       py: 2,
                     }}>
                     <Box sx={{ flex: 1 }}>
-                      <Typography variant='body1' sx={{ fontWeight: 600 }}>
+                      <Typography variant='body1' sx={{ fontWeight: 700 }}>
                         {item.name}
                       </Typography>
                       <Typography variant='body2' color='text.secondary'>
@@ -255,7 +255,7 @@ export const CartPage = () => {
                 <Typography variant='body2' color='text.secondary'>
                   Subtotal
                 </Typography>
-                <Typography variant='body2' sx={{ fontWeight: 500 }}>
+                <Typography variant='body2' sx={{ fontWeight: 400 }}>
                   {formatPrice(subtotal())}
                 </Typography>
               </Box>
@@ -268,7 +268,7 @@ export const CartPage = () => {
                 <Typography variant='body2' color='text.secondary'>
                   Delivery Fee
                 </Typography>
-                <Typography variant='body2' sx={{ fontWeight: 500 }}>
+                <Typography variant='body2' sx={{ fontWeight: 400 }}>
                   {formatPrice(deliveryFee)}
                 </Typography>
               </Box>

--- a/apps/kaze-eats/src/pages/HomePage.tsx
+++ b/apps/kaze-eats/src/pages/HomePage.tsx
@@ -61,7 +61,7 @@ export const HomePage = () => {
           <Typography
             variant='h3'
             sx={{
-              fontWeight: 800,
+              fontWeight: 700,
               color: '#fff',
               mb: 1,
               fontSize: { xs: '1.75rem', md: '2.5rem' },
@@ -234,8 +234,8 @@ export const HomePage = () => {
                         px: 1.5,
                         py: 0.5,
                         borderRadius: 2,
-                        fontSize: '0.75rem',
-                        fontWeight: 600,
+                        fontSize: '0.86rem',
+                        fontWeight: 700,
                       }}>
                       Featured
                     </Box>
@@ -254,7 +254,7 @@ export const HomePage = () => {
                       />
                       <Typography
                         variant='body2'
-                        sx={{ color: '#fff', fontWeight: 600 }}>
+                        sx={{ color: '#fff', fontWeight: 700 }}>
                         {r.rating}
                       </Typography>
                       <Typography
@@ -390,7 +390,7 @@ export const HomePage = () => {
                       />
                       <Typography
                         variant='caption'
-                        sx={{ color: '#fff', fontWeight: 500 }}>
+                        sx={{ color: '#fff', fontWeight: 400 }}>
                         {r.deliveryTime}
                       </Typography>
                     </Box>
@@ -416,7 +416,7 @@ export const HomePage = () => {
                       />
                       <Typography
                         variant='body2'
-                        sx={{ fontWeight: 600, ml: 0.5 }}>
+                        sx={{ fontWeight: 700, ml: 0.5 }}>
                         {r.rating}
                       </Typography>
                       <Typography variant='body2' color='text.secondary'>
@@ -451,7 +451,7 @@ export const HomePage = () => {
                           label={tag}
                           size='small'
                           variant='outlined'
-                          sx={{ fontSize: '0.7rem' }}
+                          sx={{ fontSize: '0.86rem' }}
                         />
                       ))}
                     </Box>

--- a/apps/kaze-eats/src/pages/OrderHistoryPage.tsx
+++ b/apps/kaze-eats/src/pages/OrderHistoryPage.tsx
@@ -65,7 +65,7 @@ export const OrderHistoryPage = () => {
       headerName: 'Order #',
       width: 100,
       renderCell: (params) => (
-        <Typography variant='body2' sx={{ fontWeight: 600 }}>
+        <Typography variant='body2' sx={{ fontWeight: 700 }}>
           {params.value.toUpperCase()}
         </Typography>
       ),
@@ -97,7 +97,7 @@ export const OrderHistoryPage = () => {
       headerName: 'Total',
       width: 120,
       renderCell: (params) => (
-        <Typography variant='body2' sx={{ fontWeight: 600 }}>
+        <Typography variant='body2' sx={{ fontWeight: 700 }}>
           {formatPrice(params.value + params.row.deliveryFee)}
         </Typography>
       ),
@@ -164,7 +164,7 @@ export const OrderHistoryPage = () => {
           variant='h4'
           component='h1'
           sx={{
-            fontWeight: 800,
+            fontWeight: 700,
             mb: 0.5,
             letterSpacing: '-0.02em',
           }}>
@@ -197,7 +197,7 @@ export const OrderHistoryPage = () => {
               <Box>
                 <Typography
                   variant='h5'
-                  sx={{ fontWeight: 800, lineHeight: 1.2 }}>
+                  sx={{ fontWeight: 700, lineHeight: 1.2 }}>
                   {orders.length}
                 </Typography>
                 <Typography variant='caption' color='text.secondary'>
@@ -231,7 +231,7 @@ export const OrderHistoryPage = () => {
               <Box>
                 <Typography
                   variant='h5'
-                  sx={{ fontWeight: 800, lineHeight: 1.2 }}>
+                  sx={{ fontWeight: 700, lineHeight: 1.2 }}>
                   {formatPrice(totalSpent)}
                 </Typography>
                 <Typography variant='caption' color='text.secondary'>
@@ -261,7 +261,7 @@ export const OrderHistoryPage = () => {
               <Box>
                 <Typography
                   variant='h5'
-                  sx={{ fontWeight: 800, lineHeight: 1.2 }}>
+                  sx={{ fontWeight: 700, lineHeight: 1.2 }}>
                   {activeOrders}
                 </Typography>
                 <Typography variant='caption' color='text.secondary'>

--- a/apps/kaze-eats/src/pages/OrderTrackingPage.tsx
+++ b/apps/kaze-eats/src/pages/OrderTrackingPage.tsx
@@ -78,7 +78,7 @@ export const OrderTrackingPage = () => {
         <Box>
           <Typography
             variant='h4'
-            sx={{ fontWeight: 800, letterSpacing: '-0.02em' }}>
+            sx={{ fontWeight: 700, letterSpacing: '-0.02em' }}>
             Order #{order.id.toUpperCase()}
           </Typography>
           <Typography variant='body1' color='text.secondary' sx={{ mt: 0.5 }}>
@@ -118,7 +118,7 @@ export const OrderTrackingPage = () => {
             <Typography
               variant='body1'
               color='error.main'
-              sx={{ fontWeight: 600, textAlign: 'center' }}>
+              sx={{ fontWeight: 700, textAlign: 'center' }}>
               This order has been cancelled
             </Typography>
           </CardContent>
@@ -192,7 +192,7 @@ export const OrderTrackingPage = () => {
               <Typography variant='body2' color='text.secondary'>
                 Delivery Address
               </Typography>
-              <Typography variant='body2' sx={{ fontWeight: 500 }}>
+              <Typography variant='body2' sx={{ fontWeight: 400 }}>
                 {order.deliveryAddress}
               </Typography>
             </Box>
@@ -200,7 +200,7 @@ export const OrderTrackingPage = () => {
               <Typography variant='body2' color='text.secondary'>
                 Estimated Delivery
               </Typography>
-              <Typography variant='body2' sx={{ fontWeight: 500 }}>
+              <Typography variant='body2' sx={{ fontWeight: 400 }}>
                 {new Date(order.estimatedDelivery).toLocaleTimeString('ja-JP', {
                   hour: '2-digit',
                   minute: '2-digit',
@@ -211,7 +211,7 @@ export const OrderTrackingPage = () => {
               <Typography variant='body2' color='text.secondary'>
                 Order Time
               </Typography>
-              <Typography variant='body2' sx={{ fontWeight: 500 }}>
+              <Typography variant='body2' sx={{ fontWeight: 400 }}>
                 {new Date(order.orderDate).toLocaleString('ja-JP', {
                   month: 'short',
                   day: 'numeric',
@@ -240,7 +240,7 @@ export const OrderTrackingPage = () => {
                 <Typography variant='body1'>
                   {item.quantity}x {item.name}
                 </Typography>
-                <Typography variant='body1' sx={{ fontWeight: 600 }}>
+                <Typography variant='body1' sx={{ fontWeight: 700 }}>
                   {formatPrice(item.price * item.quantity)}
                 </Typography>
               </Box>
@@ -257,7 +257,7 @@ export const OrderTrackingPage = () => {
             <Typography variant='body2' color='text.secondary'>
               Subtotal
             </Typography>
-            <Typography variant='body2' sx={{ fontWeight: 500 }}>
+            <Typography variant='body2' sx={{ fontWeight: 400 }}>
               {formatPrice(order.total)}
             </Typography>
           </Box>
@@ -270,7 +270,7 @@ export const OrderTrackingPage = () => {
             <Typography variant='body2' color='text.secondary'>
               Delivery Fee
             </Typography>
-            <Typography variant='body2' sx={{ fontWeight: 500 }}>
+            <Typography variant='body2' sx={{ fontWeight: 400 }}>
               {formatPrice(order.deliveryFee)}
             </Typography>
           </Box>

--- a/apps/kaze-eats/src/pages/ProfilePage.tsx
+++ b/apps/kaze-eats/src/pages/ProfilePage.tsx
@@ -70,7 +70,7 @@ export const ProfilePage = () => {
         <Typography
           variant='h4'
           component='h1'
-          sx={{ fontWeight: 800, mb: 0.5, letterSpacing: '-0.02em' }}>
+          sx={{ fontWeight: 700, mb: 0.5, letterSpacing: '-0.02em' }}>
           Profile
         </Typography>
         <Typography variant='body1' color='text.secondary'>
@@ -139,7 +139,7 @@ export const ProfilePage = () => {
                   <Typography
                     variant='caption'
                     color='text.secondary'
-                    sx={{ fontWeight: 500 }}>
+                    sx={{ fontWeight: 400 }}>
                     {stat.label}
                   </Typography>
                 </Box>
@@ -276,7 +276,7 @@ export const ProfilePage = () => {
                   <Typography variant='body2' color='text.secondary'>
                     Member since
                   </Typography>
-                  <Typography variant='body2' sx={{ fontWeight: 500 }}>
+                  <Typography variant='body2' sx={{ fontWeight: 400 }}>
                     March 2025
                   </Typography>
                 </Box>
@@ -284,7 +284,7 @@ export const ProfilePage = () => {
                   <Typography variant='body2' color='text.secondary'>
                     Account type
                   </Typography>
-                  <Typography variant='body2' sx={{ fontWeight: 500 }}>
+                  <Typography variant='body2' sx={{ fontWeight: 400 }}>
                     Premium
                   </Typography>
                 </Box>
@@ -292,7 +292,7 @@ export const ProfilePage = () => {
                   <Typography variant='body2' color='text.secondary'>
                     Payment method
                   </Typography>
-                  <Typography variant='body2' sx={{ fontWeight: 500 }}>
+                  <Typography variant='body2' sx={{ fontWeight: 400 }}>
                     Visa •••• 4242
                   </Typography>
                 </Box>

--- a/apps/kaze-eats/src/pages/RestaurantPage.tsx
+++ b/apps/kaze-eats/src/pages/RestaurantPage.tsx
@@ -124,7 +124,7 @@ export const RestaurantPage = () => {
           <Typography
             variant='h4'
             sx={{
-              fontWeight: 800,
+              fontWeight: 700,
               color: '#fff',
               mb: 1,
               letterSpacing: '-0.02em',
@@ -155,7 +155,7 @@ export const RestaurantPage = () => {
               />
               <Typography
                 variant='body2'
-                sx={{ color: '#fff', fontWeight: 600 }}>
+                sx={{ color: '#fff', fontWeight: 700 }}>
                 {restaurant.rating}
               </Typography>
               <Typography
@@ -172,7 +172,7 @@ export const RestaurantPage = () => {
                 color: 'rgba(255,255,255,0.9)',
               }}>
               <AccessTimeIcon sx={{ fontSize: 18 }} aria-hidden='true' />
-              <Typography variant='body2' sx={{ fontWeight: 500 }}>
+              <Typography variant='body2' sx={{ fontWeight: 400 }}>
                 {restaurant.deliveryTime}
               </Typography>
             </Box>
@@ -184,7 +184,7 @@ export const RestaurantPage = () => {
                 color: 'rgba(255,255,255,0.9)',
               }}>
               <DeliveryDiningIcon sx={{ fontSize: 18 }} aria-hidden='true' />
-              <Typography variant='body2' sx={{ fontWeight: 500 }}>
+              <Typography variant='body2' sx={{ fontWeight: 400 }}>
                 {formatPrice(restaurant.deliveryFee)}
               </Typography>
             </Box>
@@ -203,10 +203,10 @@ export const RestaurantPage = () => {
           value={tabValue}
           onChange={(_e, v) => setTabValue(v)}
           sx={{ mb: 2, borderBottom: 1, borderColor: 'divider' }}>
-          <Tab label='Menu' sx={{ fontWeight: 600 }} />
+          <Tab label='Menu' sx={{ fontWeight: 700 }} />
           <Tab
             label={`Popular (${popularItems.length})`}
-            sx={{ fontWeight: 600 }}
+            sx={{ fontWeight: 700 }}
           />
         </Tabs>
 

--- a/apps/saas-dashboard/src/pages/ContactsPage.tsx
+++ b/apps/saas-dashboard/src/pages/ContactsPage.tsx
@@ -205,7 +205,7 @@ export const ContactsPage = () => {
                 <Box>
                   <Typography
                     variant='h5'
-                    sx={{ fontWeight: 800, lineHeight: 1.2 }}>
+                    sx={{ fontWeight: 700, lineHeight: 1.2 }}>
                     {stat.value}
                   </Typography>
                   <Typography variant='caption' color='text.secondary'>

--- a/apps/saas-dashboard/src/pages/DashboardPage.tsx
+++ b/apps/saas-dashboard/src/pages/DashboardPage.tsx
@@ -149,7 +149,7 @@ export const DashboardPage = () => {
                   variant='caption'
                   sx={{
                     color: 'primary.textContrast',
-                    fontWeight: 600,
+                    fontWeight: 700,
                     cursor: 'pointer',
                     textDecoration: 'none',
                     '&:hover': { textDecoration: 'underline' },
@@ -175,8 +175,8 @@ export const DashboardPage = () => {
                               textAlign: 'left',
                               padding: '10px 16px',
                               borderBottom: '1px solid var(--color-border)',
-                              fontSize: '0.7rem',
-                              fontWeight: 600,
+                              fontSize: '0.86rem',
+                              fontWeight: 700,
                               textTransform: 'uppercase',
                               letterSpacing: '0.05em',
                               color: 'var(--color-muted)',
@@ -208,7 +208,7 @@ export const DashboardPage = () => {
                             padding: '12px 16px',
                             borderBottom: '1px solid var(--color-border)',
                           }}>
-                          <Typography variant='body2' sx={{ fontWeight: 600 }}>
+                          <Typography variant='body2' sx={{ fontWeight: 700 }}>
                             {project.name}
                           </Typography>
                         </td>
@@ -259,7 +259,7 @@ export const DashboardPage = () => {
                             />
                             <Typography
                               variant='caption'
-                              sx={{ fontWeight: 500, minWidth: 28 }}>
+                              sx={{ fontWeight: 400, minWidth: 28 }}>
                               {project.progress}%
                             </Typography>
                           </Box>
@@ -366,7 +366,7 @@ export const DashboardPage = () => {
                           mb: 0.25,
                         }}>
                         <UserAvatar name={activity.user} size='small' />
-                        <Typography variant='body2' sx={{ fontWeight: 500 }}>
+                        <Typography variant='body2' sx={{ fontWeight: 400 }}>
                           {activity.user}
                         </Typography>
                         <CustomChip
@@ -382,7 +382,7 @@ export const DashboardPage = () => {
                               | 'default'
                           }
                           variant='outlined'
-                          sx={{ height: 18, fontSize: '0.6rem' }}
+                          sx={{ height: 18, fontSize: '0.86rem' }}
                         />
                       </Box>
                       <Typography
@@ -394,7 +394,7 @@ export const DashboardPage = () => {
                       <Typography
                         variant='caption'
                         color='text.secondary'
-                        sx={{ fontSize: '0.7rem' }}>
+                        sx={{ fontSize: '0.86rem' }}>
                         {dayjs(activity.timestamp).format('MMM D, HH:mm')}
                       </Typography>
                     </Box>
@@ -425,8 +425,8 @@ export const DashboardPage = () => {
                     px: 1,
                     py: 0.25,
                     borderRadius: 1,
-                    fontSize: '0.7rem',
-                    fontWeight: 600,
+                    fontSize: '0.86rem',
+                    fontWeight: 700,
                   }}>
                   {onlineTeam.length}
                 </Box>
@@ -452,7 +452,7 @@ export const DashboardPage = () => {
                       color='primary'
                     />
                     <Box sx={{ flex: 1 }}>
-                      <Typography variant='body2' sx={{ fontWeight: 500 }}>
+                      <Typography variant='body2' sx={{ fontWeight: 400 }}>
                         {member.name}
                       </Typography>
                       <Typography variant='caption' color='text.secondary'>

--- a/apps/saas-dashboard/src/pages/InvoicesPage.tsx
+++ b/apps/saas-dashboard/src/pages/InvoicesPage.tsx
@@ -193,7 +193,7 @@ export const InvoicesPage = () => {
       headerName: 'Invoice #',
       width: 150,
       renderCell: (params) => (
-        <Typography variant='body2' sx={{ fontWeight: 600 }}>
+        <Typography variant='body2' sx={{ fontWeight: 700 }}>
           {params.value}
         </Typography>
       ),
@@ -205,7 +205,7 @@ export const InvoicesPage = () => {
       headerName: 'Amount',
       width: 130,
       renderCell: (params) => (
-        <Typography variant='body2' sx={{ fontWeight: 600 }}>
+        <Typography variant='body2' sx={{ fontWeight: 700 }}>
           {formatCurrency(params.value)}
         </Typography>
       ),
@@ -313,7 +313,7 @@ export const InvoicesPage = () => {
                 <Typography
                   variant='caption'
                   color='text.secondary'
-                  sx={{ fontWeight: 500 }}>
+                  sx={{ fontWeight: 400 }}>
                   Total Invoices
                 </Typography>
               </Box>
@@ -351,7 +351,7 @@ export const InvoicesPage = () => {
                 <Typography
                   variant='caption'
                   color='text.secondary'
-                  sx={{ fontWeight: 500 }}>
+                  sx={{ fontWeight: 400 }}>
                   Paid
                 </Typography>
               </Box>
@@ -389,7 +389,7 @@ export const InvoicesPage = () => {
                 <Typography
                   variant='caption'
                   color='text.secondary'
-                  sx={{ fontWeight: 500 }}>
+                  sx={{ fontWeight: 400 }}>
                   Pending
                 </Typography>
               </Box>
@@ -427,7 +427,7 @@ export const InvoicesPage = () => {
                 <Typography
                   variant='caption'
                   color='text.secondary'
-                  sx={{ fontWeight: 500 }}>
+                  sx={{ fontWeight: 400 }}>
                   Overdue
                 </Typography>
               </Box>

--- a/apps/saas-dashboard/src/pages/MapPage.tsx
+++ b/apps/saas-dashboard/src/pages/MapPage.tsx
@@ -91,8 +91,8 @@ export const MapPage = () => {
                   px: 1,
                   py: 0.25,
                   borderRadius: 1,
-                  fontSize: '0.7rem',
-                  fontWeight: 600,
+                  fontSize: '0.86rem',
+                  fontWeight: 700,
                 }}>
                 <PeopleIcon sx={{ fontSize: 14 }} aria-hidden='true' />
                 {offices.reduce((sum, o) => sum + o.employees, 0)}
@@ -126,7 +126,7 @@ export const MapPage = () => {
                     <LocationOnIcon sx={{ fontSize: 20 }} aria-hidden='true' />
                   </Box>
                   <Box sx={{ flex: 1 }}>
-                    <Typography variant='body2' sx={{ fontWeight: 600 }}>
+                    <Typography variant='body2' sx={{ fontWeight: 700 }}>
                       {office.name}
                     </Typography>
                     <Typography variant='caption' color='text.secondary'>
@@ -135,7 +135,7 @@ export const MapPage = () => {
                   </Box>
                   <Typography
                     variant='caption'
-                    sx={{ fontWeight: 500, color: 'text.secondary' }}>
+                    sx={{ fontWeight: 400, color: 'text.secondary' }}>
                     {office.employees}
                   </Typography>
                 </Box>

--- a/apps/saas-dashboard/src/pages/ProjectDetailPage.tsx
+++ b/apps/saas-dashboard/src/pages/ProjectDetailPage.tsx
@@ -150,7 +150,7 @@ export const ProjectDetailPage = () => {
                     value={project.progress}
                     sx={{ flex: 1, height: 8, borderRadius: 4 }}
                   />
-                  <Typography variant='body2' sx={{ fontWeight: 600 }}>
+                  <Typography variant='body2' sx={{ fontWeight: 700 }}>
                     {project.progress}%
                   </Typography>
                 </Box>
@@ -200,7 +200,7 @@ export const ProjectDetailPage = () => {
                     size='small'
                     color='primary'
                   />
-                  <Typography variant='body2' sx={{ fontWeight: 500 }}>
+                  <Typography variant='body2' sx={{ fontWeight: 400 }}>
                     {project.owner}
                   </Typography>
                 </Box>
@@ -262,7 +262,7 @@ export const ProjectDetailPage = () => {
             />
             <Typography
               variant='body1'
-              sx={{ fontWeight: 600, mb: 0.5 }}
+              sx={{ fontWeight: 700, mb: 0.5 }}
               color='text.secondary'>
               No tasks yet
             </Typography>

--- a/apps/saas-dashboard/src/pages/ProjectsPage.tsx
+++ b/apps/saas-dashboard/src/pages/ProjectsPage.tsx
@@ -184,7 +184,7 @@ export const ProjectsPage = () => {
             value={params.value}
             sx={{ flex: 1, height: 6, borderRadius: 3 }}
           />
-          <span style={{ fontSize: '0.75rem', minWidth: 32 }}>
+          <span style={{ fontSize: '0.86rem', minWidth: 32 }}>
             {params.value}%
           </span>
         </Box>

--- a/apps/saas-dashboard/src/pages/ReportsPage.tsx
+++ b/apps/saas-dashboard/src/pages/ReportsPage.tsx
@@ -131,7 +131,7 @@ export const ReportsPage = () => {
                   <Typography variant='body2' color='text.secondary'>
                     Total Projects
                   </Typography>
-                  <Typography variant='body2' sx={{ fontWeight: 600 }}>
+                  <Typography variant='body2' sx={{ fontWeight: 700 }}>
                     {projects.length}
                   </Typography>
                 </Box>
@@ -139,7 +139,7 @@ export const ReportsPage = () => {
                   <Typography variant='body2' color='text.secondary'>
                     Total Budget
                   </Typography>
-                  <Typography variant='body2' sx={{ fontWeight: 600 }}>
+                  <Typography variant='body2' sx={{ fontWeight: 700 }}>
                     ¥{(totalBudget / 1000000).toFixed(1)}M
                   </Typography>
                 </Box>
@@ -147,7 +147,7 @@ export const ReportsPage = () => {
                   <Typography variant='body2' color='text.secondary'>
                     Total Spent
                   </Typography>
-                  <Typography variant='body2' sx={{ fontWeight: 600 }}>
+                  <Typography variant='body2' sx={{ fontWeight: 700 }}>
                     ¥{(totalSpent / 1000000).toFixed(1)}M
                   </Typography>
                 </Box>
@@ -161,7 +161,7 @@ export const ReportsPage = () => {
                     <Typography variant='body2' color='text.secondary'>
                       Budget Utilization
                     </Typography>
-                    <Typography variant='body2' sx={{ fontWeight: 600 }}>
+                    <Typography variant='body2' sx={{ fontWeight: 700 }}>
                       {budgetUtil.toFixed(1)}%
                     </Typography>
                   </Box>
@@ -195,7 +195,7 @@ export const ReportsPage = () => {
                   <Typography variant='body2' color='text.secondary'>
                     Total Invoices
                   </Typography>
-                  <Typography variant='body2' sx={{ fontWeight: 600 }}>
+                  <Typography variant='body2' sx={{ fontWeight: 700 }}>
                     {invoices.length}
                   </Typography>
                 </Box>
@@ -211,7 +211,7 @@ export const ReportsPage = () => {
                     </Typography>
                     <Typography
                       variant='body2'
-                      sx={{ fontWeight: 600, color: 'success.textContrast' }}>
+                      sx={{ fontWeight: 700, color: 'success.textContrast' }}>
                       ¥{(paidInvoices / 1000000).toFixed(1)}M
                     </Typography>
                   </Box>
@@ -234,7 +234,7 @@ export const ReportsPage = () => {
                     </Typography>
                     <Typography
                       variant='body2'
-                      sx={{ fontWeight: 600, color: 'warning.textContrast' }}>
+                      sx={{ fontWeight: 700, color: 'warning.textContrast' }}>
                       ¥{(pendingInvoices / 1000000).toFixed(1)}M
                     </Typography>
                   </Box>
@@ -257,7 +257,7 @@ export const ReportsPage = () => {
                     </Typography>
                     <Typography
                       variant='body2'
-                      sx={{ fontWeight: 600, color: 'error.textContrast' }}>
+                      sx={{ fontWeight: 700, color: 'error.textContrast' }}>
                       ¥{(overdueInvoices / 1000000).toFixed(1)}M
                     </Typography>
                   </Box>
@@ -292,7 +292,7 @@ export const ReportsPage = () => {
                   />
                   <Typography
                     variant='caption'
-                    sx={{ color: 'success.textContrast', fontWeight: 600 }}>
+                    sx={{ color: 'success.textContrast', fontWeight: 700 }}>
                     +12.5% vs last quarter
                   </Typography>
                 </Box>
@@ -319,7 +319,7 @@ export const ReportsPage = () => {
                     <Typography
                       variant='body2'
                       sx={{
-                        fontWeight: 500,
+                        fontWeight: 400,
                         minWidth: 32,
                         color: 'text.secondary',
                       }}>
@@ -341,7 +341,7 @@ export const ReportsPage = () => {
                     <Typography
                       variant='body2'
                       sx={{
-                        fontWeight: 600,
+                        fontWeight: 700,
                         minWidth: 56,
                         textAlign: 'right',
                       }}>

--- a/apps/saas-dashboard/src/pages/SettingsPage.tsx
+++ b/apps/saas-dashboard/src/pages/SettingsPage.tsx
@@ -77,7 +77,7 @@ export const SettingsPage = () => {
               }}>
               <UserAvatar name={name} size='medium' color='primary' />
               <Box>
-                <Typography variant='body2' sx={{ fontWeight: 600 }}>
+                <Typography variant='body2' sx={{ fontWeight: 700 }}>
                   {name}
                 </Typography>
                 <Typography variant='caption' color='text.secondary'>
@@ -236,7 +236,7 @@ export const SettingsPage = () => {
       <CardContent className='p-0'>
         <CustomAccordion
           summary={
-            <Typography variant='body2' sx={{ fontWeight: 500 }}>
+            <Typography variant='body2' sx={{ fontWeight: 400 }}>
               API Settings
             </Typography>
           }
@@ -259,7 +259,7 @@ export const SettingsPage = () => {
         />
         <CustomAccordion
           summary={
-            <Typography variant='body2' sx={{ fontWeight: 500 }}>
+            <Typography variant='body2' sx={{ fontWeight: 400 }}>
               Webhook Settings
             </Typography>
           }
@@ -276,7 +276,7 @@ export const SettingsPage = () => {
         />
         <CustomAccordion
           summary={
-            <Typography variant='body2' sx={{ fontWeight: 500 }}>
+            <Typography variant='body2' sx={{ fontWeight: 400 }}>
               Data Export
             </Typography>
           }
@@ -298,7 +298,7 @@ export const SettingsPage = () => {
           summary={
             <Typography
               variant='body2'
-              sx={{ fontWeight: 500, color: 'error.textContrast' }}>
+              sx={{ fontWeight: 400, color: 'error.textContrast' }}>
               Danger Zone
             </Typography>
           }

--- a/apps/saas-dashboard/src/pages/TeamPage.tsx
+++ b/apps/saas-dashboard/src/pages/TeamPage.tsx
@@ -145,7 +145,7 @@ export const TeamPage = () => {
                     }
                   />
                   <Box sx={{ flex: 1 }}>
-                    <Typography variant='subtitle1' sx={{ fontWeight: 600 }}>
+                    <Typography variant='subtitle1' sx={{ fontWeight: 700 }}>
                       {member.name}
                     </Typography>
                     <Typography variant='body2' color='text.secondary'>

--- a/apps/sky-kaze/src/components/CompleteView.tsx
+++ b/apps/sky-kaze/src/components/CompleteView.tsx
@@ -100,7 +100,7 @@ export const CompleteView = () => {
             <Typography
               variant='xl'
               display='block'
-              sx={{ fontWeight: 800, fontSize: '26px', mb: 0.5 }}>
+              sx={{ fontWeight: 700, fontSize: '26px', mb: 0.5 }}>
               配送結果
             </Typography>
             <Typography
@@ -267,7 +267,7 @@ export const CompleteView = () => {
                   <Box>
                     <Typography
                       variant='body2'
-                      sx={{ fontWeight: 600, fontSize: '15px' }}>
+                      sx={{ fontWeight: 700, fontSize: '15px' }}>
                       {d.name}
                     </Typography>
                     <Typography
@@ -299,7 +299,7 @@ export const CompleteView = () => {
                     <Typography
                       sx={{
                         fontFamily: "'JetBrains Mono', monospace",
-                        fontWeight: 600,
+                        fontWeight: 700,
                       }}>
                       {d.rating}
                     </Typography>
@@ -406,7 +406,7 @@ export const CompleteView = () => {
                             }}>
                             <Typography
                               variant='caption'
-                              sx={{ fontWeight: 600, fontSize: '13px' }}>
+                              sx={{ fontWeight: 700, fontSize: '13px' }}>
                               対応: {inc.resolution}
                             </Typography>
                           </Box>
@@ -510,7 +510,7 @@ export const CompleteView = () => {
                   <Box>
                     <Typography
                       variant='body2'
-                      sx={{ fontWeight: 500, fontSize: '15px' }}>
+                      sx={{ fontWeight: 400, fontSize: '15px' }}>
                       {s.contents}
                     </Typography>
                     <Typography
@@ -536,7 +536,7 @@ export const CompleteView = () => {
                   <Typography
                     sx={{
                       fontFamily: "'JetBrains Mono', monospace",
-                      fontWeight: 600,
+                      fontWeight: 700,
                       fontSize: '14px',
                     }}>
                     ¥{s.cost.toLocaleString()}

--- a/apps/sky-kaze/src/components/DriverPanel.tsx
+++ b/apps/sky-kaze/src/components/DriverPanel.tsx
@@ -157,7 +157,7 @@ export const DriverPanel = () => {
                   }}
                 />
                 <Box sx={{ flex: 1, minWidth: 0 }}>
-                  <Typography sx={{ fontSize: '15px', fontWeight: 600 }}>
+                  <Typography sx={{ fontSize: '15px', fontWeight: 700 }}>
                     {d?.name ?? dp.driverId}
                   </Typography>
                   <Typography
@@ -286,7 +286,7 @@ export const DriverPanel = () => {
                 sx={{
                   fontFamily: "'JetBrains Mono', monospace",
                   fontSize: '14px',
-                  fontWeight: 600,
+                  fontWeight: 700,
                 }}>
                 {Math.round(selected.speed)} km/h
               </Typography>
@@ -346,7 +346,7 @@ export const DriverPanel = () => {
               <Typography
                 sx={{
                   fontSize: '13px',
-                  fontWeight: 600,
+                  fontWeight: 700,
                   color: 'text.secondary',
                   textTransform: 'uppercase',
                   letterSpacing: '0.04em',
@@ -414,7 +414,7 @@ export const DriverPanel = () => {
               }}>
               {shipment.trackingNo}
             </Typography>
-            <Typography sx={{ fontSize: '14px', fontWeight: 500 }}>
+            <Typography sx={{ fontSize: '14px', fontWeight: 400 }}>
               {shipment.contents}
             </Typography>
             <Typography

--- a/apps/sky-kaze/src/components/EventLog.tsx
+++ b/apps/sky-kaze/src/components/EventLog.tsx
@@ -106,7 +106,7 @@ export const EventLog = () => {
                   bgcolor: alpha(color, 0.15),
                   color,
                   fontSize: '12px',
-                  fontWeight: 900,
+                  fontWeight: 700,
                   flexShrink: 0,
                   mt: 0.1,
                 }}>

--- a/apps/sky-kaze/src/components/HeaderBar.tsx
+++ b/apps/sky-kaze/src/components/HeaderBar.tsx
@@ -70,7 +70,7 @@ export const HeaderBar = () => {
         {!isMobile && (
           <Typography
             sx={{
-              fontWeight: 800,
+              fontWeight: 700,
               fontSize: '16px',
               letterSpacing: '-0.02em',
               color: 'text.primary',

--- a/apps/sky-kaze/src/components/IncidentPanel.tsx
+++ b/apps/sky-kaze/src/components/IncidentPanel.tsx
@@ -144,7 +144,7 @@ export const IncidentPanel = () => {
                       bgcolor: alpha(color, 0.05),
                     },
                   }}>
-                  <Typography sx={{ fontSize: '15px', fontWeight: 500 }}>
+                  <Typography sx={{ fontSize: '15px', fontWeight: 400 }}>
                     {r}
                   </Typography>
                 </Box>

--- a/apps/sky-kaze/src/components/LiveMap.tsx
+++ b/apps/sky-kaze/src/components/LiveMap.tsx
@@ -120,7 +120,7 @@ export const LiveMap = () => {
         width:22px;height:22px;border-radius:50%;
         background:rgba(15,23,42,0.75);border:2px solid ${color};
         display:flex;align-items:center;justify-content:center;
-        font-size:9px;font-weight:700;color:${color};
+        font-size:12px;font-weight:700;color:${color};
         font-family:'JetBrains Mono',monospace;cursor:pointer;
       `
       el.textContent = hub.code.split('-')[0]

--- a/apps/sky-kaze/src/components/PrepareView.tsx
+++ b/apps/sky-kaze/src/components/PrepareView.tsx
@@ -190,7 +190,7 @@ export const PrepareView = () => {
         <Typography
           variant='xl'
           display='block'
-          sx={{ fontWeight: 800, fontSize: '26px', mb: 0.5 }}>
+          sx={{ fontWeight: 700, fontSize: '26px', mb: 0.5 }}>
           出荷準備
         </Typography>
         <Typography
@@ -389,7 +389,7 @@ export const PrepareView = () => {
                     <Box>
                       <Typography
                         variant='body2'
-                        sx={{ fontWeight: 500, fontSize: '15px' }}>
+                        sx={{ fontWeight: 400, fontSize: '15px' }}>
                         {s.contents}
                       </Typography>
                       <Typography
@@ -425,7 +425,7 @@ export const PrepareView = () => {
                             STATUS_COLORS[s.status],
                             theme.palette.background.paper
                           ),
-                        fontWeight: 600,
+                        fontWeight: 700,
                         justifySelf: 'start',
                       }}
                     />

--- a/apps/sky-kaze/src/components/TimelineBar.tsx
+++ b/apps/sky-kaze/src/components/TimelineBar.tsx
@@ -215,7 +215,7 @@ export const TimelineBar = () => {
             sx={{
               fontSize: '14px',
               fontFamily: "'JetBrains Mono', monospace",
-              fontWeight: 600,
+              fontWeight: 700,
             }}>
             {movingCount} 走行
           </Typography>
@@ -237,7 +237,7 @@ export const TimelineBar = () => {
             sx={{
               fontSize: '14px',
               fontFamily: "'JetBrains Mono', monospace",
-              fontWeight: 600,
+              fontWeight: 700,
               color: (theme) =>
                 readableStatusColor(
                   DRIVER_STATUS_COLOR.delivering,
@@ -263,7 +263,7 @@ export const TimelineBar = () => {
               sx={{
                 fontSize: '14px',
                 fontFamily: "'JetBrains Mono', monospace",
-                fontWeight: 600,
+                fontWeight: 700,
                 color: (theme) =>
                   readableStatusColor(
                     DRIVER_STATUS_COLOR.incident,

--- a/apps/sky-kaze/src/components/WelcomeOverlay.tsx
+++ b/apps/sky-kaze/src/components/WelcomeOverlay.tsx
@@ -59,7 +59,7 @@ export const WelcomeOverlay = () => {
           sx={{
             color: '#fff',
             fontSize: '14px',
-            fontWeight: 600,
+            fontWeight: 700,
             letterSpacing: '0.01em',
           }}>
           再生ボタンを押すとシミュレーション開始

--- a/apps/sky-kaze/src/theme/skyTheme.ts
+++ b/apps/sky-kaze/src/theme/skyTheme.ts
@@ -155,14 +155,14 @@ export const skyTheme: Theme = createBrandTheme({
       styleOverrides: {
         label: {
           fontFamily: "'DM Sans', 'Noto Sans JP', sans-serif",
-          fontWeight: 600,
+          fontWeight: 700,
           fontSize: 15,
-          // MUI 自身が `.MuiStepLabel-label.Mui-active` で fontWeight: 500 を
+          // MUI 自身が `.MuiStepLabel-label.Mui-active` で fontWeight: 400 を
           // 当てており、素の `.MuiStepLabel-label` では詳細度で負ける。
           // index.css 側が !important を必要としていたのはこれが理由なので、
           // 状態セレクタを明示して打ち返す（実測で 600 になることを確認済み）
-          '&.Mui-active': { fontWeight: 600 },
-          '&.Mui-completed': { fontWeight: 600 },
+          '&.Mui-active': { fontWeight: 700 },
+          '&.Mui-completed': { fontWeight: 700 },
         },
       },
     },

--- a/src/components/Form/DateTimePicker/LazyDateTimePicker.tsx
+++ b/src/components/Form/DateTimePicker/LazyDateTimePicker.tsx
@@ -45,7 +45,7 @@ const LoadingPlaceholder = ({
         <Typography
           component='label'
           variant='body2'
-          sx={{ fontWeight: 500, color: 'text.primary' }}>
+          sx={{ fontWeight: 400, color: 'text.primary' }}>
           {label}
           {required && <RequiredMark>*</RequiredMark>}
         </Typography>

--- a/src/components/Form/DateTimePicker/index.tsx
+++ b/src/components/Form/DateTimePicker/index.tsx
@@ -102,7 +102,7 @@ export const DateTimePicker = ({
           <Typography
             component='label'
             variant='body2'
-            sx={{ fontWeight: 500, color: 'text.primary' }}>
+            sx={{ fontWeight: 400, color: 'text.primary' }}>
             {label}
             {required && <RequiredMark>*</RequiredMark>}
           </Typography>

--- a/src/components/Form/RegisterForm/index.tsx
+++ b/src/components/Form/RegisterForm/index.tsx
@@ -62,7 +62,7 @@ export const RegisterForm = ({
           mt: { xs: 8, sm: 12, md: 20 },
           mb: 4,
         }}>
-        <Typography component='h1' variant='h5' fontWeight={600}>
+        <Typography component='h1' variant='h5' fontWeight={700}>
           {title}
         </Typography>
       </Box>

--- a/src/components/Table/TableComponents/StyledComponents.tsx
+++ b/src/components/Table/TableComponents/StyledComponents.tsx
@@ -10,8 +10,8 @@ export const StyledTableCell = styled(TableCell)(({ theme }) => ({
         ? 'rgba(0, 0, 0, 0.02)'
         : 'rgba(255, 255, 255, 0.03)',
     color: theme.palette.text.secondary,
-    fontSize: '0.75rem',
-    fontWeight: 600,
+    fontSize: '0.86rem',
+    fontWeight: 700,
     textTransform: 'uppercase',
     letterSpacing: '0.5px',
     borderBottom: `1px solid ${theme.palette.divider}`,

--- a/src/components/Table/_index.tsx
+++ b/src/components/Table/_index.tsx
@@ -118,7 +118,7 @@ const StyledTableCell = styled(TableCell)(({ theme }) => ({
         ? theme.palette.grey[900]
         : theme.palette.secondary.dark,
     color: theme.palette.common.white,
-    fontSize: '0.75rem',
+    fontSize: '0.86rem',
     fontWeight: theme.typography.fontWeightMedium,
     textTransform: 'uppercase',
     letterSpacing: '0.05em',
@@ -191,8 +191,8 @@ const formatCellValue = (value: unknown): React.ReactNode => {
           px: 2,
           py: 0.5,
           borderRadius: 1,
-          fontSize: '0.75rem',
-          fontWeight: 'medium',
+          fontSize: '0.86rem',
+          fontWeight: 400,
           bgcolor: value ? 'success.lighter' : 'error.lighter',
           color: theme.palette.common.black,
         }}>

--- a/src/components/Table/utils/formatters.tsx
+++ b/src/components/Table/utils/formatters.tsx
@@ -17,7 +17,7 @@ export const formatCellValue = (value: unknown): React.ReactNode => {
           py: 0.5,
           borderRadius: 1,
           fontSize: '0.875rem',
-          fontWeight: 'medium',
+          fontWeight: 400,
           bgcolor: value ? 'success.lighter' : 'error.lighter',
           color: theme.palette.grey[700],
         }}>

--- a/src/components/examples/ShadcnExample.tsx
+++ b/src/components/examples/ShadcnExample.tsx
@@ -84,7 +84,7 @@ export const ShadcnExample = () => {
           <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4'>
             {[1, 2, 3, 4, 5, 6].map((item) => (
               <Card key={item} className='p-4'>
-                <h3 className='font-semibold mb-2'>Grid Item {item}</h3>
+                <h3 className='font-bold mb-2'>Grid Item {item}</h3>
                 <p className='text-sm text-muted-foreground'>
                   This is a grid item using Tailwind responsive classes.
                 </p>

--- a/src/components/ui/AppSwitcher.tsx
+++ b/src/components/ui/AppSwitcher.tsx
@@ -190,7 +190,7 @@ export const AppSwitcher = ({ currentApp }: AppSwitcherProps) => {
                         color='primary'
                         sx={{
                           height: 20,
-                          fontSize: '11px',
+                          fontSize: '12px',
                           fontWeight: 700,
                         }}
                       />

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -11,7 +11,7 @@ import { cn } from '@/utils/className'
 
 const buttonVariants = cva(
   // Base styles
-  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-normal cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -75,7 +75,7 @@ const CardTitle = React.forwardRef<HTMLParagraphElement, TypographyProps>(
         ref={ref}
         variant={variant}
         className={cn(
-          'text-2xl font-semibold leading-none tracking-tight',
+          'text-2xl font-bold leading-none tracking-tight',
           className
         )}
         style={kaze ? { ...kazeTitleStyle, ...style } : style}

--- a/src/components/ui/ChatSupport/components/ChatHeader.tsx
+++ b/src/components/ui/ChatSupport/components/ChatHeader.tsx
@@ -91,7 +91,7 @@ export const ChatHeader = ({
           <Box>
             <Typography
               variant='subtitle2'
-              sx={{ fontWeight: 600, lineHeight: 1.2 }}>
+              sx={{ fontWeight: 700, lineHeight: 1.2 }}>
               {showSettings
                 ? 'AI設定'
                 : currentStory

--- a/src/components/ui/ChatSupport/components/ChatMessageList.tsx
+++ b/src/components/ui/ChatSupport/components/ChatMessageList.tsx
@@ -124,7 +124,7 @@ export const ChatMessageList = ({
                         mt: 2,
                         mb: 1,
                         lineHeight: 1.5,
-                        fontWeight: 600,
+                        fontWeight: 700,
                       },
                       '& h1': { fontSize: 18 },
                       '& h2': { fontSize: 16 },
@@ -185,7 +185,7 @@ export const ChatMessageList = ({
                           fontSize: 12,
                         },
                         '& th': {
-                          fontWeight: 600,
+                          fontWeight: 700,
                           bgcolor:
                             theme.palette.mode === 'dark'
                               ? 'rgba(255,255,255,0.04)'

--- a/src/components/ui/ChatSupport/components/ChatPageContextChip.tsx
+++ b/src/components/ui/ChatSupport/components/ChatPageContextChip.tsx
@@ -45,7 +45,7 @@ export const ChatPageContextChip = ({
         onClick={onExplain}
         sx={{
           height: 28,
-          fontSize: '0.75rem',
+          fontSize: '0.86rem',
           cursor: 'pointer',
           borderColor:
             theme.palette.mode === 'dark'

--- a/src/components/ui/ChatSupport/components/ChatSettings.tsx
+++ b/src/components/ui/ChatSupport/components/ChatSettings.tsx
@@ -97,7 +97,7 @@ export const ChatSettings = ({
           }}>
           <Typography
             variant='caption'
-            sx={{ fontWeight: 600, display: 'block', mb: 0.5 }}>
+            sx={{ fontWeight: 700, display: 'block', mb: 0.5 }}>
             現在の設定
           </Typography>
           {isUsingDefaultKey ? (
@@ -184,7 +184,7 @@ export const ChatSettings = ({
         <Box>
           <Typography
             variant='caption'
-            sx={{ fontWeight: 600, display: 'block', mb: 0.5 }}>
+            sx={{ fontWeight: 700, display: 'block', mb: 0.5 }}>
             カスタムAPI設定（任意）
           </Typography>
           <Typography
@@ -219,8 +219,8 @@ export const ChatSettings = ({
                   }}
                   sx={{
                     cursor: 'pointer',
-                    fontWeight: 500,
-                    fontSize: '0.75rem',
+                    fontWeight: 400,
+                    fontSize: '0.86rem',
                   }}
                 />
               )
@@ -276,7 +276,7 @@ export const ChatSettings = ({
                       variant='text'
                       color='warning'
                       onClick={onResetApiKey}
-                      sx={{ minWidth: 0, p: 0.5, fontSize: 11 }}>
+                      sx={{ minWidth: 0, p: 0.5, fontSize: 12 }}>
                       リセット
                     </Button>
                   </Stack>
@@ -291,7 +291,7 @@ export const ChatSettings = ({
           <Typography
             variant='caption'
             color='text.secondary'
-            sx={{ display: 'block', mb: 0.8, fontWeight: 600 }}>
+            sx={{ display: 'block', mb: 0.8, fontWeight: 700 }}>
             AIモデル
           </Typography>
           <TextField
@@ -328,7 +328,7 @@ export const ChatSettings = ({
                         mb: 0.25,
                       }}>
                       {isLocked && <Lock size={12} />}
-                      <Typography variant='body2' sx={{ fontWeight: 600 }}>
+                      <Typography variant='body2' sx={{ fontWeight: 700 }}>
                         {opt.label}
                       </Typography>
                       <Chip
@@ -350,7 +350,7 @@ export const ChatSettings = ({
                         variant='outlined'
                         sx={{
                           height: 18,
-                          fontSize: '0.6rem',
+                          fontSize: '0.86rem',
                           '& .MuiChip-label': { px: 0.75 },
                         }}
                       />
@@ -367,7 +367,7 @@ export const ChatSettings = ({
                           key={uc}
                           variant='caption'
                           sx={{
-                            fontSize: '0.65rem',
+                            fontSize: '0.86rem',
                             color: 'text.disabled',
                             lineHeight: 1.2,
                             '&::before': { content: '"- "' },
@@ -435,7 +435,7 @@ export const ChatSettings = ({
           }}>
           <Typography
             variant='caption'
-            sx={{ fontWeight: 600, display: 'block', mb: 0.5 }}>
+            sx={{ fontWeight: 700, display: 'block', mb: 0.5 }}>
             APIキーの取得方法
           </Typography>
           <Typography
@@ -482,7 +482,7 @@ export const ChatSettings = ({
             sx={{ mb: 1 }}>
             <Stack direction='row' spacing={1} alignItems='center'>
               <Keyboard size={14} />
-              <Typography variant='caption' sx={{ fontWeight: 600 }}>
+              <Typography variant='caption' sx={{ fontWeight: 700 }}>
                 キーボードショートカット
               </Typography>
             </Stack>
@@ -501,7 +501,7 @@ export const ChatSettings = ({
             sx={{
               width: '100%',
               borderCollapse: 'collapse',
-              '& td': { py: 0.6, fontSize: 11, verticalAlign: 'middle' },
+              '& td': { py: 0.6, fontSize: 12, verticalAlign: 'middle' },
               '& td:first-of-type': { width: 160, pr: 1 },
             }}>
             <tbody>
@@ -518,7 +518,7 @@ export const ChatSettings = ({
                           'aria-label': `${s.desc} のショートカット`,
                           style: {
                             fontFamily: 'monospace',
-                            fontSize: 10,
+                            fontSize: 12,
                             textAlign: 'center',
                             paddingTop: 4,
                             paddingBottom: 4,

--- a/src/components/ui/CustomButton.tsx
+++ b/src/components/ui/CustomButton.tsx
@@ -5,7 +5,7 @@ import * as React from 'react'
 import { cn } from '@/utils/className'
 
 const customButtonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-normal transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {

--- a/src/components/ui/button-group/buttonGroup.tsx
+++ b/src/components/ui/button-group/buttonGroup.tsx
@@ -123,7 +123,7 @@ export const ButtonGroup = ({
       sx={{
         '& .MuiButton-root': {
           textTransform: 'none',
-          fontWeight: 500,
+          fontWeight: 400,
           // フォントサイズ: small=12px(0.86rem), medium=14px(1rem), large=16px(1.14rem)
           // 最小12px（A11yルール）
           fontSize:

--- a/src/components/ui/button/loadingButton.tsx
+++ b/src/components/ui/button/loadingButton.tsx
@@ -110,7 +110,7 @@ export const LoadingButton = forwardRef<HTMLButtonElement, LoadingButtonProps>(
         disabled={disabled || success}
         sx={{
           textTransform: 'none',
-          fontWeight: 500,
+          fontWeight: 400,
           borderRadius: BUTTON_BORDER_RADIUS,
           transition: BUTTON_TRANSITION,
           // フォントサイズ（1rem=14px基準）: small=約12px, medium=14px, large=約16px

--- a/src/components/ui/calendar/WeekStartSelector.tsx
+++ b/src/components/ui/calendar/WeekStartSelector.tsx
@@ -78,7 +78,7 @@ export const WeekStartSelector = ({
     <Box sx={sx}>
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
         <CalendarTodayIcon sx={{ fontSize: 20, color: 'text.secondary' }} />
-        <Typography variant='subtitle2' fontWeight={600}>
+        <Typography variant='subtitle2' fontWeight={700}>
           {label}
         </Typography>
       </Box>

--- a/src/components/ui/calendar/calendarControl.tsx
+++ b/src/components/ui/calendar/calendarControl.tsx
@@ -73,7 +73,7 @@ export const CalendarControl = ({
           <Typography
             variant='h5'
             sx={{
-              fontWeight: '600',
+              fontWeight: 700,
               color: 'text.primary',
               ml: 1,
             }}>

--- a/src/components/ui/calendar/dayView.tsx
+++ b/src/components/ui/calendar/dayView.tsx
@@ -167,7 +167,7 @@ export const DayView = ({
               }}>
               {getInitials(assignee)}
             </Avatar>
-            <Typography variant='body2' sx={{ fontWeight: 500 }}>
+            <Typography variant='body2' sx={{ fontWeight: 400 }}>
               {assignee}
             </Typography>
           </Box>
@@ -256,8 +256,8 @@ export const DayView = ({
                           <Typography
                             variant='caption'
                             sx={{
-                              fontWeight: 600,
-                              fontSize: '10px',
+                              fontWeight: 700,
+                              fontSize: '12px',
                               color: 'inherit',
                             }}>
                             {schedule.time}
@@ -265,7 +265,7 @@ export const DayView = ({
                           <Typography
                             variant='caption'
                             sx={{
-                              fontSize: '10px',
+                              fontSize: '12px',
                               color: 'rgba(255,255,255,0.8)',
                             }}>
                             ({schedule.duration})
@@ -275,7 +275,7 @@ export const DayView = ({
                           variant='body2'
                           sx={{
                             fontSize: '12px',
-                            fontWeight: 500,
+                            fontWeight: 400,
                             lineHeight: 1.3,
                             color: 'inherit',
                           }}>
@@ -286,7 +286,7 @@ export const DayView = ({
                             variant='caption'
                             sx={{
                               display: 'block',
-                              fontSize: '10px',
+                              fontSize: '12px',
                               color: 'rgba(255,255,255,0.8)',
                               mt: 0.5,
                             }}>

--- a/src/components/ui/calendar/miniCalendar.tsx
+++ b/src/components/ui/calendar/miniCalendar.tsx
@@ -130,7 +130,7 @@ export const MiniCalendar = ({
             <Typography
               variant='subtitle2'
               sx={{
-                fontWeight: 600,
+                fontWeight: 700,
                 overflow: 'hidden',
                 whiteSpace: 'nowrap',
                 textOverflow: 'ellipsis',

--- a/src/components/ui/calendar/monthView.tsx
+++ b/src/components/ui/calendar/monthView.tsx
@@ -114,7 +114,7 @@ export const MonthView = ({
             <Typography
               variant='body2'
               sx={{
-                fontWeight: 500,
+                fontWeight: 400,
                 color: isSunday(index)
                   ? 'error.main'
                   : isSaturday(index)
@@ -215,7 +215,7 @@ export const MonthView = ({
                           borderRadius: 0.5,
                           bgcolor: `${getTypeTone(schedule.type)}.main`,
                           color: `${getTypeTone(schedule.type)}.contrastText`,
-                          fontSize: '10px',
+                          fontSize: '12px',
                           lineHeight: 1.2,
                           overflow: 'hidden',
                           textOverflow: 'ellipsis',
@@ -233,7 +233,7 @@ export const MonthView = ({
                         variant='caption'
                         sx={{
                           color: 'text.secondary',
-                          fontSize: '10px',
+                          fontSize: '12px',
                           pl: 0.5,
                         }}>
                         +{daySchedules.length - 3}件

--- a/src/components/ui/calendar/weekView.tsx
+++ b/src/components/ui/calendar/weekView.tsx
@@ -209,7 +209,7 @@ export const WeekView = ({
                           color: `${getTypeTone(schedule.type)}.contrastText`,
                           borderRadius: 0.5,
                           p: 0.5,
-                          fontSize: '11px',
+                          fontSize: '12px',
                           overflow: 'hidden',
                           cursor: 'pointer',
                           zIndex: scheduleIndex + 1,
@@ -222,8 +222,8 @@ export const WeekView = ({
                           variant='caption'
                           sx={{
                             display: 'block',
-                            fontWeight: 600,
-                            fontSize: '10px',
+                            fontWeight: 700,
+                            fontSize: '12px',
                             color: 'inherit',
                           }}>
                           {schedule.time}
@@ -232,7 +232,7 @@ export const WeekView = ({
                           variant='caption'
                           sx={{
                             display: 'block',
-                            fontSize: '11px',
+                            fontSize: '12px',
                             lineHeight: 1.2,
                             color: 'inherit',
                             overflow: 'hidden',
@@ -246,7 +246,7 @@ export const WeekView = ({
                             variant='caption'
                             sx={{
                               display: 'block',
-                              fontSize: '10px',
+                              fontSize: '12px',
                               color: 'rgba(255,255,255,0.8)',
                               mt: 0.25,
                             }}>

--- a/src/components/ui/card/serviceCard.tsx
+++ b/src/components/ui/card/serviceCard.tsx
@@ -102,7 +102,7 @@ export const ServiceCard = ({
           </Box>
         )}
         <Box sx={{ flex: 1 }}>
-          <Typography variant='md' fontWeight={600} component='h3'>
+          <Typography variant='md' fontWeight={700} component='h3'>
             {title}
           </Typography>
           {description && (

--- a/src/components/ui/chip/connectionStatusChip.tsx
+++ b/src/components/ui/chip/connectionStatusChip.tsx
@@ -25,7 +25,7 @@ const StyledStatusChip = styled(Chip, {
   paddingRight: theme.spacing(1),
   border: `1px solid ${connected ? theme.palette.success.light : theme.palette.error.light}`,
   height: 28,
-  fontWeight: 500,
+  fontWeight: 400,
   '& .MuiChip-icon': {
     color: 'inherit',
     fontSize: 16,

--- a/src/components/ui/feedback/notFoundView.tsx
+++ b/src/components/ui/feedback/notFoundView.tsx
@@ -56,7 +56,7 @@ export const NotFoundView = ({ homePath = '/', sx }: NotFoundViewProps) => {
           sx={{
             mb: 2,
             color: 'text.primary',
-            fontWeight: 500,
+            fontWeight: 400,
           }}>
           ページが見つかりません
         </Typography>

--- a/src/components/ui/logo/kazeLogo.tsx
+++ b/src/components/ui/logo/kazeLogo.tsx
@@ -143,9 +143,12 @@ const Wordmark = ({
       aria-hidden={hidden || undefined}
       sx={{
         color,
-        // シンボルの主線と光学的に揃うよう、グリッドに対する比で決める
-        fontSize: `${size * 0.5}px`,
-        fontWeight: 600,
+        // シンボルの主線と光学的に揃うよう、グリッドに対する比で決める。
+        // ただし 12px を下限とする。size から計算しているので、小さい size を
+        // 渡されると比例して 12px を割る（size=20 で 10px になっていた）。
+        // 計算値は静的検査で捕まえられないため、ここでクランプする
+        fontSize: `${Math.max(12, size * 0.5)}px`,
+        fontWeight: 700,
         // 大きい文字ほど字間を詰める光学調整に合わせる
         letterSpacing: '-0.02em',
         lineHeight: 1,

--- a/src/components/ui/split-button/splitButton.tsx
+++ b/src/components/ui/split-button/splitButton.tsx
@@ -128,7 +128,7 @@ export const SplitButton = ({
         sx={{
           '& .MuiButton-root': {
             textTransform: 'none',
-            fontWeight: 500,
+            fontWeight: 400,
             // フォントサイズ: small=12px(0.86rem), medium=14px(1rem), large=16px(1.14rem)
             fontSize:
               size === 'small'

--- a/src/components/ui/stat-card/statCard.tsx
+++ b/src/components/ui/stat-card/statCard.tsx
@@ -173,7 +173,7 @@ export const StatCard = ({
                   variant='caption'
                   sx={{
                     color: `${trendColor}.textContrast`,
-                    fontWeight: 600,
+                    fontWeight: 700,
                     whiteSpace: 'nowrap',
                   }}>
                   {trend.value}
@@ -188,7 +188,7 @@ export const StatCard = ({
                 sx={{
                   display: 'block',
                   mt: trend ? 0.5 : 1,
-                  fontSize: trend ? '0.72rem' : '0.9rem',
+                  fontSize: trend ? '0.86rem' : '0.9rem',
                 }}>
                 {caption}
               </Typography>

--- a/src/components/ui/table/resourceTable.tsx
+++ b/src/components/ui/table/resourceTable.tsx
@@ -219,7 +219,7 @@ export const ResourceTable = <T extends { id: string | number }>({
             mb: 3,
           }}>
           {title && (
-            <Typography variant='h5' fontWeight={600}>
+            <Typography variant='h5' fontWeight={700}>
               {title}
             </Typography>
           )}

--- a/src/components/ui/tag/statusTag.tsx
+++ b/src/components/ui/tag/statusTag.tsx
@@ -87,7 +87,7 @@ export const StatusTag = ({
     ...style,
     borderRadius: kaze ? 'var(--kaze-r-sharp)' : '16px',
     borderWidth: '1px',
-    fontSize: '10px',
+    fontSize: '12px',
     fontWeight: 'bold',
     height: 'auto',
     '& .MuiChip-label': {

--- a/src/components/ui/toggle-button/toggleButton.tsx
+++ b/src/components/ui/toggle-button/toggleButton.tsx
@@ -72,13 +72,13 @@ export const ToggleButton = forwardRef<HTMLButtonElement, ToggleButtonProps>(
     ref
   ) => {
     const baseSx = kaze
-      ? { ...KAZE_STAMP, '&.Mui-selected': { fontWeight: 600 } }
+      ? { ...KAZE_STAMP, '&.Mui-selected': { fontWeight: 700 } }
       : {
           textTransform: 'none' as const,
           borderRadius: 1.5,
           transition: motionOf(['background-color', 'color', 'border-color']),
           '&.Mui-selected': {
-            fontWeight: 600,
+            fontWeight: 700,
           },
         }
 

--- a/src/layouts/sideNav/index.tsx
+++ b/src/layouts/sideNav/index.tsx
@@ -77,7 +77,7 @@ export const SideNav = ({ open, width }: SideNavProps) => {
                 transition: motionOf(['opacity'], 'long'),
                 marginLeft: '8px',
                 '& .MuiListItemText-primary': {
-                  fontSize: '0.8rem',
+                  fontSize: '0.86rem',
                   textAlign: 'left',
                   fontWeight: theme.typography.fontWeightBold,
                 },

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -661,7 +661,7 @@ const DevPortSettings = () => {
             bgcolor: saved ? 'success.main' : 'warning.main',
             color: saved ? 'success.contrastText' : 'warning.contrastText',
             fontSize: '0.9rem',
-            fontWeight: 600,
+            fontWeight: 700,
             cursor: 'pointer',
           }}>
           {saved ? '✓ Saved' : 'Save & Reload'}
@@ -681,8 +681,8 @@ const CONTAINER_SX = {
 // Kaze 骨格 — section eyebrow (小さい uppercase ラベル、Plex Mono)
 const EYEBROW_SX = {
   fontFamily: 'var(--kaze-font-mono)',
-  fontSize: '0.75rem',
-  fontWeight: 500,
+  fontSize: '0.86rem',
+  fontWeight: 400,
   letterSpacing: '0.24em',
   textTransform: 'uppercase',
   color: 'primary.textContrast',
@@ -693,7 +693,7 @@ const EYEBROW_SX = {
 const DISPLAY_SX = {
   fontFamily: 'var(--kaze-font-display)',
   fontSize: { xs: '2.5rem', md: '3.6rem' },
-  fontWeight: 380,
+  fontWeight: 400,
   letterSpacing: '-0.03em',
   lineHeight: 1.02,
   fontVariationSettings: "'opsz' 144, 'wght' 380, 'SOFT' 30, 'WONK' 0",
@@ -852,8 +852,8 @@ export const LandingPage = () => {
                   <Typography
                     sx={{
                       fontFamily: 'var(--kaze-font-mono)',
-                      fontSize: '0.75rem',
-                      fontWeight: 500,
+                      fontSize: '0.86rem',
+                      fontWeight: 400,
                       letterSpacing: '0.24em',
                       textTransform: 'uppercase',
                       color: 'primary.textContrast',
@@ -876,7 +876,7 @@ export const LandingPage = () => {
                   sx={{
                     fontFamily: 'var(--kaze-font-display)',
                     fontSize: { xs: '3rem', sm: '4.5rem', md: '5.5rem' },
-                    fontWeight: 380,
+                    fontWeight: 400,
                     lineHeight: 0.98,
                     letterSpacing: '-0.035em',
                     fontVariationSettings:
@@ -990,7 +990,7 @@ export const LandingPage = () => {
                           ? 'rgba(255,255,255,0.12)'
                           : 'rgba(0,0,0,0.12)',
                         color: 'text.primary',
-                        fontWeight: 600,
+                        fontWeight: 700,
                         fontSize: '0.9rem',
                         textDecoration: 'none',
                         transition: motionOf(
@@ -1246,7 +1246,7 @@ export const LandingPage = () => {
                         : {})}
                       sx={{
                         fontSize: '0.95rem',
-                        fontWeight: 600,
+                        fontWeight: 700,
                         color: 'primary.textContrast',
                         textDecoration: 'none',
                         '&:hover': { textDecoration: 'underline' },
@@ -1311,7 +1311,7 @@ export const LandingPage = () => {
                   borderRadius: 2,
                   bgcolor: 'primary.main',
                   color: 'primary.contrastText',
-                  fontWeight: 600,
+                  fontWeight: 700,
                   fontSize: '1rem',
                   textDecoration: 'none',
                   transition: motionOf(['transform', 'box-shadow']),
@@ -1359,7 +1359,7 @@ export const LandingPage = () => {
                     <Typography
                       sx={{
                         fontSize: '0.95rem',
-                        fontWeight: 600,
+                        fontWeight: 700,
                         color: 'primary.textContrast',
                         mb: 0.5,
                       }}>
@@ -1401,7 +1401,7 @@ export const LandingPage = () => {
           }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             <KazeLogo size={18} tone='outline' title='' />
-            <Typography sx={{ fontSize: '0.95rem', fontWeight: 600 }}>
+            <Typography sx={{ fontSize: '0.95rem', fontWeight: 700 }}>
               Kaze Design System
             </Typography>
           </Box>

--- a/src/stories/00-Guide/AIAndDesignSystem.stories.tsx
+++ b/src/stories/00-Guide/AIAndDesignSystem.stories.tsx
@@ -37,7 +37,7 @@ const SectionHeader = ({
   subtitle?: string
 }) => (
   <Box sx={{ mb: 4 }}>
-    <Typography variant='h4' sx={{ fontWeight: 800, letterSpacing: '-0.01em' }}>
+    <Typography variant='h4' sx={{ fontWeight: 700, letterSpacing: '-0.01em' }}>
       {title}
     </Typography>
     {subtitle && (
@@ -70,7 +70,7 @@ const AIDesignSystemContent = () => {
               ? 'linear-gradient(135deg, rgba(156,39,176,0.08) 0%, rgba(235,129,23,0.08) 100%)'
               : 'linear-gradient(135deg, rgba(156,39,176,0.04) 0%, rgba(235,129,23,0.04) 100%)',
         }}>
-        <Typography variant='h3' sx={{ fontWeight: 800, mb: 1 }}>
+        <Typography variant='h3' sx={{ fontWeight: 700, mb: 1 }}>
           AI とデザインシステム
         </Typography>
         <Typography variant='h6' color='text.secondary' sx={{ mb: 2 }}>
@@ -90,9 +90,9 @@ const AIDesignSystemContent = () => {
         <Table size='small'>
           <TableHead>
             <TableRow>
-              <TableCell sx={{ fontWeight: 600 }}>指示の質</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>プロンプト例</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>結果</TableCell>
+              <TableCell sx={{ fontWeight: 700 }}>指示の質</TableCell>
+              <TableCell sx={{ fontWeight: 700 }}>プロンプト例</TableCell>
+              <TableCell sx={{ fontWeight: 700 }}>結果</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -131,7 +131,7 @@ const AIDesignSystemContent = () => {
               ? 'rgba(70,171,74,0.06)'
               : 'rgba(70,171,74,0.03)',
         }}>
-        <Typography variant='body2' sx={{ fontWeight: 600, mb: 0.5 }}>
+        <Typography variant='body2' sx={{ fontWeight: 700, mb: 0.5 }}>
           核心
         </Typography>
         <Typography variant='body1' color='text.secondary'>
@@ -233,7 +233,7 @@ const AIDesignSystemContent = () => {
               </Typography>
             </Paper>
             <Box>
-              <Typography variant='body2' sx={{ fontWeight: 600 }}>
+              <Typography variant='body2' sx={{ fontWeight: 700 }}>
                 {item.title}
               </Typography>
               <Typography variant='body1' color='text.secondary'>
@@ -256,7 +256,7 @@ const AIDesignSystemContent = () => {
         <Grid size={{ xs: 12, sm: 6 }}>
           <Typography
             variant='body2'
-            sx={{ fontWeight: 600, mb: 1, color: 'error.main' }}>
+            sx={{ fontWeight: 700, mb: 1, color: 'error.main' }}>
             曖昧な指示
           </Typography>
           <CodeBlock language='markdown'>
@@ -268,7 +268,7 @@ const AIDesignSystemContent = () => {
         <Grid size={{ xs: 12, sm: 6 }}>
           <Typography
             variant='body2'
-            sx={{ fontWeight: 600, mb: 1, color: 'success.main' }}>
+            sx={{ fontWeight: 700, mb: 1, color: 'success.main' }}>
             Kaze UX語彙を使った指示
           </Typography>
           <CodeBlock language='markdown'>
@@ -290,9 +290,9 @@ const AIDesignSystemContent = () => {
         <Table size='small'>
           <TableHead>
             <TableRow>
-              <TableCell sx={{ fontWeight: 600 }}>活用方法</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>ツール</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>説明</TableCell>
+              <TableCell sx={{ fontWeight: 700 }}>活用方法</TableCell>
+              <TableCell sx={{ fontWeight: 700 }}>ツール</TableCell>
+              <TableCell sx={{ fontWeight: 700 }}>説明</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -320,7 +320,7 @@ const AIDesignSystemContent = () => {
             ].map((row) => (
               <TableRow key={row[0]}>
                 <TableCell>
-                  <Typography variant='body2' sx={{ fontWeight: 500 }}>
+                  <Typography variant='body2' sx={{ fontWeight: 400 }}>
                     {row[0]}
                   </Typography>
                 </TableCell>

--- a/src/stories/00-Guide/ApplicationGuide.stories.tsx
+++ b/src/stories/00-Guide/ApplicationGuide.stories.tsx
@@ -35,7 +35,7 @@ const SectionLabel = ({ children }: { children: string }) => (
   <Typography
     variant='overline'
     sx={{
-      fontSize: 11,
+      fontSize: 12,
       fontWeight: 700,
       letterSpacing: '0.1em',
       color: 'primary.main',
@@ -57,7 +57,7 @@ const SectionTitle = ({
     <Typography
       sx={{
         fontSize: { xs: 22, sm: 26 },
-        fontWeight: 800,
+        fontWeight: 700,
         letterSpacing: '-0.02em',
         lineHeight: 1.3,
       }}>
@@ -653,7 +653,7 @@ const ApplicationGuideContent = () => {
           variant='overline'
           sx={{
             fontSize: 12,
-            fontWeight: 600,
+            fontWeight: 700,
             letterSpacing: '0.12em',
             color: isDark ? 'primary.light' : 'primary.main',
             mb: 2,
@@ -663,7 +663,7 @@ const ApplicationGuideContent = () => {
         </Typography>
         <Typography
           sx={{
-            fontWeight: 800,
+            fontWeight: 700,
             fontSize: { xs: 28, sm: 40 },
             letterSpacing: '-0.03em',
             lineHeight: 1.15,
@@ -749,7 +749,7 @@ const ApplicationGuideContent = () => {
                   variant='outlined'
                   sx={{
                     fontFamily: 'monospace',
-                    fontSize: 11,
+                    fontSize: 12,
                   }}
                 />
               </Box>
@@ -759,20 +759,20 @@ const ApplicationGuideContent = () => {
 
         <InfoCallout title='共有の仕組み' color='info'>
           各プロダクトは{' '}
-          <Box component='code' sx={{ fontWeight: 600 }}>
+          <Box component='code' sx={{ fontWeight: 700 }}>
             @/
           </Box>{' '}
           パスエイリアスで Design System の{' '}
-          <Box component='code' sx={{ fontWeight: 600 }}>
+          <Box component='code' sx={{ fontWeight: 700 }}>
             src/
           </Box>{' '}
           ディレクトリからコンポーネントを直接 import
           しています。プロダクト固有のコードは{' '}
-          <Box component='code' sx={{ fontWeight: 600 }}>
+          <Box component='code' sx={{ fontWeight: 700 }}>
             ~/
           </Box>{' '}
           パスで各アプリの{' '}
-          <Box component='code' sx={{ fontWeight: 600 }}>
+          <Box component='code' sx={{ fontWeight: 700 }}>
             src/
           </Box>{' '}
           から読み込みます。
@@ -824,7 +824,7 @@ import { LOGI_ORANGE } from '~/theme/colors'`}
                     <TableCell>
                       <Typography
                         sx={{
-                          fontWeight: 600,
+                          fontWeight: 700,
                           fontSize: 13,
                           fontFamily: 'monospace',
                         }}>
@@ -1046,7 +1046,7 @@ import { darkTheme, lightTheme } from '@/themes/theme'
           {decisionCriteria.map((c) => (
             <TableRow key={c.condition}>
               <TableCell>
-                <Typography sx={{ fontWeight: 600, fontSize: 14 }}>
+                <Typography sx={{ fontWeight: 700, fontSize: 14 }}>
                   {c.condition}
                 </Typography>
               </TableCell>
@@ -1063,7 +1063,7 @@ import { darkTheme, lightTheme } from '@/themes/theme'
                           ? 'warning'
                           : 'default'
                   }
-                  sx={{ fontWeight: 600, fontSize: 12 }}
+                  sx={{ fontWeight: 700, fontSize: 12 }}
                 />
               </TableCell>
               <TableCell>

--- a/src/stories/00-Guide/ComponentDevelopment.stories.tsx
+++ b/src/stories/00-Guide/ComponentDevelopment.stories.tsx
@@ -40,7 +40,7 @@ const SectionHeader = ({
   subtitle?: string
 }) => (
   <Box sx={{ mb: 4 }}>
-    <Typography variant='h4' sx={{ fontWeight: 800, letterSpacing: '-0.01em' }}>
+    <Typography variant='h4' sx={{ fontWeight: 700, letterSpacing: '-0.01em' }}>
       {title}
     </Typography>
     {subtitle && (
@@ -119,7 +119,7 @@ const ComponentDevContent = () => {
               ? 'rgba(76,175,80,0.05)'
               : 'rgba(76,175,80,0.02)',
         }}>
-        <Typography variant='h4' sx={{ fontWeight: 800, mb: 1 }}>
+        <Typography variant='h4' sx={{ fontWeight: 700, mb: 1 }}>
           コンポーネント開発ガイド
         </Typography>
         <Typography variant='body1' color='text.secondary'>
@@ -267,7 +267,7 @@ export const Default: Story = {
             {argTypeExamples.map((a) => (
               <TableRow key={a.type}>
                 <TableCell>
-                  <Typography variant='body2' sx={{ fontWeight: 500 }}>
+                  <Typography variant='body2' sx={{ fontWeight: 400 }}>
                     {a.type}
                   </Typography>
                 </TableCell>
@@ -384,7 +384,7 @@ export const Default: Story = {
             {codingRules.map((r) => (
               <TableRow key={r.rule}>
                 <TableCell>
-                  <Typography variant='body2' sx={{ fontWeight: 600 }}>
+                  <Typography variant='body2' sx={{ fontWeight: 700 }}>
                     {r.rule}
                   </Typography>
                 </TableCell>

--- a/src/stories/00-Guide/CssReference.stories.tsx
+++ b/src/stories/00-Guide/CssReference.stories.tsx
@@ -34,7 +34,7 @@ const SectionHeader = ({
   subtitle?: string
 }) => (
   <Box sx={{ mb: 4 }}>
-    <Typography variant='h4' sx={{ fontWeight: 800, letterSpacing: '-0.01em' }}>
+    <Typography variant='h4' sx={{ fontWeight: 700, letterSpacing: '-0.01em' }}>
       {title}
     </Typography>
     {subtitle && (
@@ -68,14 +68,14 @@ const PropertyTable = ({
             <TableCell>
               <Typography
                 variant='body2'
-                sx={{ fontFamily: 'monospace', fontSize: 11, fontWeight: 600 }}>
+                sx={{ fontFamily: 'monospace', fontSize: 12, fontWeight: 700 }}>
                 {r.property}
               </Typography>
             </TableCell>
             <TableCell>
               <Typography
                 variant='body2'
-                sx={{ fontFamily: 'monospace', fontSize: 11 }}>
+                sx={{ fontFamily: 'monospace', fontSize: 12 }}>
                 {r.values}
               </Typography>
             </TableCell>
@@ -122,7 +122,7 @@ const BorderRadiusDemo = () => (
         />
         <Typography
           variant='caption'
-          sx={{ fontFamily: 'monospace', fontSize: 10 }}>
+          sx={{ fontFamily: 'monospace', fontSize: 12 }}>
           {b.label}
         </Typography>
       </Box>
@@ -162,7 +162,7 @@ const ShadowDemo = () => {
           />
           <Typography
             variant='caption'
-            sx={{ fontFamily: 'monospace', fontSize: 10 }}>
+            sx={{ fontFamily: 'monospace', fontSize: 12 }}>
             {s.label}
           </Typography>
         </Box>
@@ -200,7 +200,7 @@ const TransitionDemo = () => {
           />
           <Typography
             variant='caption'
-            sx={{ fontFamily: 'monospace', fontSize: 10 }}>
+            sx={{ fontFamily: 'monospace', fontSize: 12 }}>
             {t.label}
           </Typography>
         </Box>
@@ -226,7 +226,7 @@ const OpacityDemo = () => (
         />
         <Typography
           variant='caption'
-          sx={{ fontFamily: 'monospace', fontSize: 10 }}>
+          sx={{ fontFamily: 'monospace', fontSize: 12 }}>
           {o}
         </Typography>
       </Box>
@@ -256,7 +256,7 @@ const CssReferenceContent = () => {
               ? 'linear-gradient(135deg, rgba(103,58,183,0.08) 0%, rgba(0,150,136,0.08) 100%)'
               : 'linear-gradient(135deg, rgba(103,58,183,0.04) 0%, rgba(0,150,136,0.04) 100%)',
         }}>
-        <Typography variant='h4' sx={{ fontWeight: 800, mb: 1 }}>
+        <Typography variant='h4' sx={{ fontWeight: 700, mb: 1 }}>
           CSS プロパティ リファレンス
         </Typography>
         <Typography variant='body1' color='text.secondary'>
@@ -958,7 +958,7 @@ const CssReferenceContent = () => {
                     label={u.unit}
                     size='small'
                     variant='outlined'
-                    sx={{ fontFamily: 'monospace', fontSize: 11 }}
+                    sx={{ fontFamily: 'monospace', fontSize: 12 }}
                   />
                 </TableCell>
                 <TableCell>

--- a/src/stories/00-Guide/Ergonomics.stories.tsx
+++ b/src/stories/00-Guide/Ergonomics.stories.tsx
@@ -39,7 +39,7 @@ const SectionHeader = ({
   subtitle?: string
 }) => (
   <Box sx={{ mb: 4 }}>
-    <Typography variant='h4' sx={{ fontWeight: 800, letterSpacing: '-0.01em' }}>
+    <Typography variant='h4' sx={{ fontWeight: 700, letterSpacing: '-0.01em' }}>
       {title}
     </Typography>
     {subtitle && (
@@ -69,7 +69,7 @@ const FittsLawDemo = () => {
           <Button
             variant='outlined'
             size='small'
-            sx={{ minWidth: 40, minHeight: 24, fontSize: 10, px: 1 }}
+            sx={{ minWidth: 40, minHeight: 24, fontSize: 12, px: 1 }}
             onClick={() => setClicks((p) => ({ ...p, small: p.small + 1 }))}>
             小
           </Button>
@@ -129,7 +129,7 @@ const ContrastDemo = () => {
               color: s.fg,
               borderRadius: 0.5,
               fontSize: 13,
-              fontWeight: 600,
+              fontWeight: 700,
               border: '1px solid',
               borderColor:
                 theme.palette.mode === 'dark' ? 'grey.700' : 'grey.300',
@@ -178,7 +178,7 @@ const TouchTargetDemo = () => (
             border: '2px dashed',
             borderColor: t.status === 'OK' ? 'success.main' : 'error.main',
             borderRadius: 1,
-            fontSize: 10,
+            fontSize: 12,
           }}>
           <TouchAppIcon sx={{ fontSize: t.size * 0.5 }} />
         </IconButton>
@@ -189,7 +189,7 @@ const TouchTargetDemo = () => (
           label={t.status}
           size='small'
           color={t.status === 'OK' ? 'success' : 'error'}
-          sx={{ mt: 0.5, height: 20, fontSize: 11 }}
+          sx={{ mt: 0.5, height: 20, fontSize: 12 }}
         />
       </Box>
     ))}
@@ -207,7 +207,7 @@ const CognitiveLoadDemo = () => (
         sx={{ px: 3.5, py: 3, borderRadius: 2, borderColor: 'error.main' }}>
         <Typography
           variant='body2'
-          sx={{ fontWeight: 600, mb: 1.5, color: 'error.main' }}>
+          sx={{ fontWeight: 700, mb: 1.5, color: 'error.main' }}>
           NG: 認知負荷が高い
         </Typography>
         <Stack spacing={1}>
@@ -241,7 +241,7 @@ const CognitiveLoadDemo = () => (
         sx={{ px: 3.5, py: 3, borderRadius: 2, borderColor: 'success.main' }}>
         <Typography
           variant='body2'
-          sx={{ fontWeight: 600, mb: 1.5, color: 'success.main' }}>
+          sx={{ fontWeight: 700, mb: 1.5, color: 'success.main' }}>
           OK: 認知負荷が低い
         </Typography>
         <Stack spacing={1}>
@@ -378,7 +378,7 @@ const ErgonomicsContent = () => {
               ? 'linear-gradient(135deg, rgba(255,152,0,0.08) 0%, rgba(233,30,99,0.08) 100%)'
               : 'linear-gradient(135deg, rgba(255,152,0,0.04) 0%, rgba(233,30,99,0.04) 100%)',
         }}>
-        <Typography variant='h4' sx={{ fontWeight: 800, mb: 1 }}>
+        <Typography variant='h4' sx={{ fontWeight: 700, mb: 1 }}>
           UI と人間工学
         </Typography>
         <Typography variant='body1' color='text.secondary'>

--- a/src/stories/00-Guide/ForDesigners.stories.tsx
+++ b/src/stories/00-Guide/ForDesigners.stories.tsx
@@ -38,7 +38,7 @@ const SectionHeader = ({
   subtitle?: string
 }) => (
   <Box sx={{ mb: 4 }}>
-    <Typography variant='h4' sx={{ fontWeight: 800, letterSpacing: '-0.01em' }}>
+    <Typography variant='h4' sx={{ fontWeight: 700, letterSpacing: '-0.01em' }}>
       {title}
     </Typography>
     {subtitle && (
@@ -159,7 +159,7 @@ const ForDesignersContent = () => {
               ? 'rgba(156,39,176,0.05)'
               : 'rgba(156,39,176,0.02)',
         }}>
-        <Typography variant='h4' sx={{ fontWeight: 800, mb: 1 }}>
+        <Typography variant='h4' sx={{ fontWeight: 700, mb: 1 }}>
           デザイナー向けガイド
         </Typography>
         <Typography variant='body1' color='text.secondary'>
@@ -185,7 +185,7 @@ const ForDesignersContent = () => {
                 alignItems='center'
                 sx={{ mb: 0.5 }}>
                 <CheckCircleOutlineIcon color='success' sx={{ fontSize: 18 }} />
-                <Typography variant='body2' sx={{ fontWeight: 600 }}>
+                <Typography variant='body2' sx={{ fontWeight: 700 }}>
                   {s.section}
                 </Typography>
               </Stack>
@@ -299,7 +299,7 @@ const ForDesignersContent = () => {
                 <TableCell>
                   <Typography
                     variant='body2'
-                    sx={{ fontFamily: 'monospace', fontWeight: 600 }}>
+                    sx={{ fontFamily: 'monospace', fontWeight: 700 }}>
                     {s.value}
                   </Typography>
                 </TableCell>
@@ -420,7 +420,7 @@ const ForDesignersContent = () => {
             {dailyTasks.map((t) => (
               <TableRow key={t.task}>
                 <TableCell>
-                  <Typography variant='body2' sx={{ fontWeight: 500 }}>
+                  <Typography variant='body2' sx={{ fontWeight: 400 }}>
                     {t.task}
                   </Typography>
                 </TableCell>
@@ -483,7 +483,7 @@ const ForDesignersContent = () => {
             y='100'
             textAnchor='middle'
             fill={theme.palette.text.secondary}
-            style={{ fontSize: '11px', fontFamily: 'system-ui' }}>
+            style={{ fontSize: '12px', fontFamily: 'system-ui' }}>
             コンポーネント実装
           </text>
           <text
@@ -491,7 +491,7 @@ const ForDesignersContent = () => {
             y='118'
             textAnchor='middle'
             fill={theme.palette.text.secondary}
-            style={{ fontSize: '11px', fontFamily: 'system-ui' }}>
+            style={{ fontSize: '12px', fontFamily: 'system-ui' }}>
             デザイントークン定義
           </text>
 
@@ -538,7 +538,7 @@ const ForDesignersContent = () => {
             y='100'
             textAnchor='middle'
             fill={theme.palette.text.secondary}
-            style={{ fontSize: '11px', fontFamily: 'system-ui' }}>
+            style={{ fontSize: '12px', fontFamily: 'system-ui' }}>
             Storybook 参照で画面設計
           </text>
           <text
@@ -546,7 +546,7 @@ const ForDesignersContent = () => {
             y='118'
             textAnchor='middle'
             fill={theme.palette.text.secondary}
-            style={{ fontSize: '11px', fontFamily: 'system-ui' }}>
+            style={{ fontSize: '12px', fontFamily: 'system-ui' }}>
             既存コンポーネント再利用
           </text>
 
@@ -593,7 +593,7 @@ const ForDesignersContent = () => {
             y='100'
             textAnchor='middle'
             fill={theme.palette.text.secondary}
-            style={{ fontSize: '11px', fontFamily: 'system-ui' }}>
+            style={{ fontSize: '12px', fontFamily: 'system-ui' }}>
             Storybook コンポーネントで組む
           </text>
           <text
@@ -601,7 +601,7 @@ const ForDesignersContent = () => {
             y='118'
             textAnchor='middle'
             fill={theme.palette.text.secondary}
-            style={{ fontSize: '11px', fontFamily: 'system-ui' }}>
+            style={{ fontSize: '12px', fontFamily: 'system-ui' }}>
             デザインとの差分が最小化
           </text>
 
@@ -723,7 +723,7 @@ const ForDesignersContent = () => {
                   justifyContent: 'center',
                   flexShrink: 0,
                   fontWeight: 700,
-                  fontSize: '0.85rem',
+                  fontSize: '0.86rem',
                 }}>
                 {item.step}
               </Box>

--- a/src/stories/00-Guide/GettingStarted.stories.tsx
+++ b/src/stories/00-Guide/GettingStarted.stories.tsx
@@ -44,7 +44,7 @@ const SectionHeader = ({
   subtitle?: string
 }) => (
   <Box sx={{ mb: 3 }}>
-    <Typography variant='h4' sx={{ fontWeight: 800, letterSpacing: '-0.01em' }}>
+    <Typography variant='h4' sx={{ fontWeight: 700, letterSpacing: '-0.01em' }}>
       {title}
     </Typography>
     {subtitle && (
@@ -61,7 +61,7 @@ const WhereChip = ({ children }: { children: React.ReactNode }) => (
     label={children}
     size='small'
     variant='outlined'
-    sx={{ fontWeight: 600, fontSize: '0.75rem' }}
+    sx={{ fontWeight: 700, fontSize: '0.86rem' }}
   />
 )
 
@@ -92,7 +92,7 @@ const Step = ({
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
-            fontWeight: 800,
+            fontWeight: 700,
             fontSize: '0.875rem',
             flexShrink: 0,
           }}>
@@ -223,7 +223,7 @@ const GettingStartedContent = () => {
                 <TableCell>
                   <WhereChip>{row.area}</WhereChip>
                 </TableCell>
-                <TableCell sx={{ fontWeight: 600 }}>{row.what}</TableCell>
+                <TableCell sx={{ fontWeight: 700 }}>{row.what}</TableCell>
                 <TableCell color='text.secondary'>{row.detail}</TableCell>
               </TableRow>
             ))}
@@ -284,7 +284,7 @@ const GettingStartedContent = () => {
           <TableBody>
             {vocabulary.map((v) => (
               <TableRow key={v.word}>
-                <TableCell sx={{ fontWeight: 600 }}>{v.word}</TableCell>
+                <TableCell sx={{ fontWeight: 700 }}>{v.word}</TableCell>
                 <TableCell color='text.secondary'>{v.meaning}</TableCell>
               </TableRow>
             ))}
@@ -331,7 +331,7 @@ const GettingStartedContent = () => {
                 label={n.for}
                 size='small'
                 color='primary'
-                sx={{ mb: 1.5, fontWeight: 600, fontSize: '0.7rem' }}
+                sx={{ mb: 1.5, fontWeight: 700, fontSize: '0.86rem' }}
               />
               <Typography sx={{ fontWeight: 700, mb: 0.5 }}>
                 {n.title}

--- a/src/stories/00-Guide/Governance.stories.tsx
+++ b/src/stories/00-Guide/Governance.stories.tsx
@@ -48,7 +48,7 @@ const SectionHeader = ({
     <Typography
       variant='h5'
       component='h2'
-      sx={{ fontWeight: 800, letterSpacing: '-0.01em' }}>
+      sx={{ fontWeight: 700, letterSpacing: '-0.01em' }}>
       {title}
     </Typography>
     {subtitle && (
@@ -107,7 +107,7 @@ const Governance = () => {
       <Typography
         variant='h4'
         component='h1'
-        sx={{ fontWeight: 800, letterSpacing: '-0.02em', mb: 1 }}>
+        sx={{ fontWeight: 700, letterSpacing: '-0.02em', mb: 1 }}>
         プロダクトを追加しても、同じ部品と同じ定義しか使えない
       </Typography>
       <Typography color='text.secondary' sx={{ lineHeight: 1.8 }}>
@@ -131,7 +131,7 @@ const Governance = () => {
             全プロダクト合計
           </Typography>
           <Typography
-            sx={{ fontWeight: 800, fontSize: 40, lineHeight: 1.1, my: 0.5 }}
+            sx={{ fontWeight: 700, fontSize: 40, lineHeight: 1.1, my: 0.5 }}
             color='primary.main'>
             {totals.rate}%
           </Typography>
@@ -144,7 +144,7 @@ const Governance = () => {
             未準拠の箇所
           </Typography>
           <Typography
-            sx={{ fontWeight: 800, fontSize: 40, lineHeight: 1.1, my: 0.5 }}>
+            sx={{ fontWeight: 700, fontSize: 40, lineHeight: 1.1, my: 0.5 }}>
             {violations.length}
           </Typography>
           <Typography variant='body2' color='text.secondary'>

--- a/src/stories/00-Guide/HowToUse.stories.tsx
+++ b/src/stories/00-Guide/HowToUse.stories.tsx
@@ -39,7 +39,7 @@ const SectionHeader = ({
   subtitle?: string
 }) => (
   <Box sx={{ mb: 4 }}>
-    <Typography variant='h4' sx={{ fontWeight: 800, letterSpacing: '-0.01em' }}>
+    <Typography variant='h4' sx={{ fontWeight: 700, letterSpacing: '-0.01em' }}>
       {title}
     </Typography>
     {subtitle && (
@@ -141,7 +141,7 @@ const HowToUseContent = () => {
             <style>{`
               .sb-text { font-family: -apple-system, BlinkMacSystemFont, sans-serif; }
               .sb-label { font-size: 13px; fill: ${theme.palette.text.primary}; }
-              .sb-sublabel { font-size: 11px; fill: ${theme.palette.text.secondary}; }
+              .sb-sublabel { font-size: 12px; fill: ${theme.palette.text.secondary}; }
               .sb-bold { font-size: 13px; font-weight: 700; fill: ${theme.palette.text.primary}; }
             `}</style>
           </defs>
@@ -455,7 +455,7 @@ const HowToUseContent = () => {
             {controlTypes.map((c) => (
               <TableRow key={c.type}>
                 <TableCell>
-                  <Typography variant='body2' sx={{ fontWeight: 500 }}>
+                  <Typography variant='body2' sx={{ fontWeight: 400 }}>
                     {c.type}
                   </Typography>
                 </TableCell>
@@ -511,7 +511,7 @@ const HowToUseContent = () => {
             <style>{`
               .sm-text { font-family: -apple-system, BlinkMacSystemFont, sans-serif; }
               .sm-item { font-size: 13px; fill: ${theme.palette.text.primary}; }
-              .sm-key { font-size: 11px; fill: ${theme.palette.text.secondary}; font-family: ui-monospace, monospace; }
+              .sm-key { font-size: 12px; fill: ${theme.palette.text.secondary}; font-family: ui-monospace, monospace; }
               .sm-sep { stroke: ${theme.palette.divider}; stroke-width: 1; }
               .sm-check { font-size: 13px; fill: ${theme.palette.primary.main}; font-weight: 700; }
             `}</style>

--- a/src/stories/00-Guide/HtmlCssBasics.stories.tsx
+++ b/src/stories/00-Guide/HtmlCssBasics.stories.tsx
@@ -38,7 +38,7 @@ const SectionHeader = ({
   subtitle?: string
 }) => (
   <Box sx={{ mb: 4 }}>
-    <Typography variant='h4' sx={{ fontWeight: 800, letterSpacing: '-0.01em' }}>
+    <Typography variant='h4' sx={{ fontWeight: 700, letterSpacing: '-0.01em' }}>
       {title}
     </Typography>
     {subtitle && (
@@ -65,7 +65,7 @@ const BoxModelDemo = () => {
         }}>
         <Typography
           variant='caption'
-          sx={{ display: 'block', p: 0.5, fontWeight: 600 }}>
+          sx={{ display: 'block', p: 0.5, fontWeight: 700 }}>
           margin (外側余白)
         </Typography>
         <Box
@@ -76,7 +76,7 @@ const BoxModelDemo = () => {
           }}>
           <Typography
             variant='caption'
-            sx={{ display: 'block', p: 0.5, fontWeight: 600 }}>
+            sx={{ display: 'block', p: 0.5, fontWeight: 700 }}>
             border (境界線)
           </Typography>
           <Box
@@ -90,7 +90,7 @@ const BoxModelDemo = () => {
             }}>
             <Typography
               variant='caption'
-              sx={{ display: 'block', p: 0.5, fontWeight: 600 }}>
+              sx={{ display: 'block', p: 0.5, fontWeight: 700 }}>
               padding (内側余白)
             </Typography>
             <Box
@@ -126,7 +126,7 @@ const FlexboxDemo = () => {
     color: 'primary.contrastText',
     borderRadius: 0.5,
     fontSize: 12,
-    fontWeight: 600,
+    fontWeight: 700,
   }
 
   const demos: { label: string; sx: Record<string, unknown> }[] = [
@@ -167,7 +167,7 @@ const FlexboxDemo = () => {
           <Paper variant='outlined' sx={{ px: 2.5, py: 2, borderRadius: 2 }}>
             <Typography
               variant='caption'
-              sx={{ fontWeight: 600, mb: 1, display: 'block' }}>
+              sx={{ fontWeight: 700, mb: 1, display: 'block' }}>
               {d.label}
             </Typography>
             <Box sx={d.sx}>
@@ -196,7 +196,7 @@ const CssGridDemo = () => {
     color: 'primary.contrastText',
     borderRadius: 0.5,
     fontSize: 12,
-    fontWeight: 600,
+    fontWeight: 700,
     textAlign: 'center',
   }
 
@@ -206,7 +206,7 @@ const CssGridDemo = () => {
         <Paper variant='outlined' sx={{ px: 2.5, py: 2, borderRadius: 2 }}>
           <Typography
             variant='caption'
-            sx={{ fontWeight: 600, mb: 1, display: 'block' }}>
+            sx={{ fontWeight: 700, mb: 1, display: 'block' }}>
             grid-template-columns: repeat(3, 1fr)
           </Typography>
           <Box
@@ -227,7 +227,7 @@ const CssGridDemo = () => {
         <Paper variant='outlined' sx={{ px: 2.5, py: 2, borderRadius: 2 }}>
           <Typography
             variant='caption'
-            sx={{ fontWeight: 600, mb: 1, display: 'block' }}>
+            sx={{ fontWeight: 700, mb: 1, display: 'block' }}>
             grid-template-columns: 200px 1fr 1fr
           </Typography>
           <Box
@@ -385,7 +385,7 @@ const HtmlCssContent = () => {
               ? 'linear-gradient(135deg, rgba(0,150,136,0.08) 0%, rgba(33,150,243,0.08) 100%)'
               : 'linear-gradient(135deg, rgba(0,150,136,0.04) 0%, rgba(33,150,243,0.04) 100%)',
         }}>
-        <Typography variant='h4' sx={{ fontWeight: 800, mb: 1 }}>
+        <Typography variant='h4' sx={{ fontWeight: 700, mb: 1 }}>
           HTML / CSS 基礎と近年の動向
         </Typography>
         <Typography variant='body1' color='text.secondary'>
@@ -606,14 +606,14 @@ const HtmlCssContent = () => {
               spacing={1}
               alignItems='center'
               sx={{ mb: 0.5 }}>
-              <Typography variant='body2' sx={{ fontWeight: 600 }}>
+              <Typography variant='body2' sx={{ fontWeight: 700 }}>
                 {f.feature}
               </Typography>
               <Chip
                 label={f.year}
                 size='small'
                 variant='outlined'
-                sx={{ height: 20, fontSize: 11 }}
+                sx={{ height: 20, fontSize: 12 }}
               />
             </Stack>
             <Typography variant='body1' color='text.secondary' sx={{ mb: 1 }}>
@@ -763,7 +763,7 @@ const FlexboxPlaygroundContent = ({
   const itemSizes = [40, 60, 35, 50, 45, 55, 42, 48]
   return (
     <Box sx={{ maxWidth: 800, mx: 'auto' }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 1 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 1 }}>
         Flexbox Playground
       </Typography>
       <Typography variant='body1' color='text.secondary' sx={{ mb: 2 }}>
@@ -814,7 +814,7 @@ const FlexboxPlaygroundContent = ({
                 justifyContent: 'center',
                 bgcolor: 'primary.light',
                 color: 'primary.contrastText',
-                fontWeight: 600,
+                fontWeight: 700,
                 fontSize: 14,
                 borderRadius: 1.5,
                 flexShrink: 0,
@@ -896,7 +896,7 @@ const BoxModelPlayground = ({
   const theme = useTheme()
   return (
     <Box sx={{ maxWidth: 800, mx: 'auto' }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 1 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 1 }}>
         Box Model Playground
       </Typography>
       <Typography variant='body1' color='text.secondary' sx={{ mb: 2 }}>
@@ -931,7 +931,7 @@ const BoxModelPlayground = ({
               position: 'absolute',
               top: 4,
               left: 8,
-              fontWeight: 600,
+              fontWeight: 700,
               opacity: 0.7,
             }}>
             margin: {margin * 8}px
@@ -952,7 +952,7 @@ const BoxModelPlayground = ({
                 position: 'absolute',
                 top: 4,
                 left: 8,
-                fontWeight: 600,
+                fontWeight: 700,
                 opacity: 0.7,
               }}>
               padding: {padding * 8}px / border: {borderWidth}px

--- a/src/stories/00-Guide/Introduction.stories.tsx
+++ b/src/stories/00-Guide/Introduction.stories.tsx
@@ -42,7 +42,7 @@ const SectionLabel = ({ children }: { children: string }) => (
   <Typography
     variant='overline'
     sx={{
-      fontSize: 11,
+      fontSize: 12,
       fontWeight: 700,
       letterSpacing: '0.1em',
       color: 'primary.main',
@@ -64,7 +64,7 @@ const SectionTitle = ({
     <Typography
       sx={{
         fontSize: { xs: 22, sm: 26 },
-        fontWeight: 800,
+        fontWeight: 700,
         letterSpacing: '-0.02em',
         lineHeight: 1.3,
       }}>
@@ -291,7 +291,7 @@ const IntroductionContent = () => {
           variant='overline'
           sx={{
             fontSize: 12,
-            fontWeight: 600,
+            fontWeight: 700,
             letterSpacing: '0.12em',
             color: isDark ? 'primary.light' : 'primary.main',
             mb: 2,
@@ -301,7 +301,7 @@ const IntroductionContent = () => {
         </Typography>
         <Typography
           sx={{
-            fontWeight: 800,
+            fontWeight: 700,
             fontSize: { xs: 28, sm: 40 },
             letterSpacing: '-0.03em',
             lineHeight: 1.15,
@@ -394,7 +394,7 @@ const IntroductionContent = () => {
                 label={c.name}
                 color={c.color}
                 size='small'
-                sx={{ fontWeight: 600, minWidth: 130 }}
+                sx={{ fontWeight: 700, minWidth: 130 }}
               />
               <Typography
                 sx={{ fontSize: 14, lineHeight: 1.8, color: 'text.secondary' }}>
@@ -508,7 +508,7 @@ const IntroductionContent = () => {
                   variant='outlined'
                   sx={{
                     fontFamily: 'monospace',
-                    fontWeight: 600,
+                    fontWeight: 700,
                     fontSize: 12,
                   }}
                 />
@@ -519,7 +519,7 @@ const IntroductionContent = () => {
         <InfoCallout title='ショートカットのカスタマイズ'>
           <Box
             component='span'
-            sx={{ fontFamily: 'monospace', fontWeight: 600 }}>
+            sx={{ fontFamily: 'monospace', fontWeight: 700 }}>
             Cmd + Shift + ,
           </Box>{' '}
           （Windows: Ctrl + Shift + ,）で設定画面を開き、「Keyboard
@@ -582,7 +582,7 @@ const IntroductionContent = () => {
                   variant='outlined'
                   sx={{
                     fontFamily: 'monospace',
-                    fontWeight: 600,
+                    fontWeight: 700,
                     fontSize: 12,
                   }}
                 />
@@ -594,7 +594,7 @@ const IntroductionContent = () => {
                   variant='outlined'
                   sx={{
                     fontFamily: 'monospace',
-                    fontWeight: 600,
+                    fontWeight: 700,
                     fontSize: 12,
                   }}
                 />
@@ -638,7 +638,7 @@ const IntroductionContent = () => {
           {techStack.map((t) => (
             <TableRow key={t.name}>
               <TableCell>
-                <Typography sx={{ fontWeight: 600, fontSize: 14 }}>
+                <Typography sx={{ fontWeight: 700, fontSize: 14 }}>
                   {t.name}
                 </Typography>
               </TableCell>

--- a/src/stories/00-Guide/MaterialDesign.stories.tsx
+++ b/src/stories/00-Guide/MaterialDesign.stories.tsx
@@ -41,7 +41,7 @@ const SectionHeader = ({
   subtitle?: string
 }) => (
   <Box sx={{ mb: 4 }}>
-    <Typography variant='h4' sx={{ fontWeight: 800, letterSpacing: '-0.01em' }}>
+    <Typography variant='h4' sx={{ fontWeight: 700, letterSpacing: '-0.01em' }}>
       {title}
     </Typography>
     {subtitle && (
@@ -74,7 +74,7 @@ const MaterialDesignContent = () => {
               ? 'linear-gradient(135deg, rgba(33,150,243,0.08) 0%, rgba(70,171,74,0.08) 100%)'
               : 'linear-gradient(135deg, rgba(33,150,243,0.04) 0%, rgba(70,171,74,0.04) 100%)',
         }}>
-        <Typography variant='h3' sx={{ fontWeight: 800, mb: 1 }}>
+        <Typography variant='h3' sx={{ fontWeight: 700, mb: 1 }}>
           Material Design 概要
         </Typography>
         <Typography variant='h6' color='text.secondary' sx={{ mb: 2 }}>
@@ -116,7 +116,7 @@ const MaterialDesignContent = () => {
                 size='small'
                 sx={{ mb: 1.5 }}
               />
-              <Typography variant='body2' sx={{ fontWeight: 600, mb: 0.5 }}>
+              <Typography variant='body2' sx={{ fontWeight: 700, mb: 0.5 }}>
                 {item.title}
               </Typography>
               <Typography variant='body1' color='text.secondary'>
@@ -169,7 +169,7 @@ const MaterialDesignContent = () => {
               ? 'rgba(33,150,243,0.06)'
               : 'rgba(33,150,243,0.03)',
         }}>
-        <Typography variant='body2' sx={{ fontWeight: 600, mb: 0.5 }}>
+        <Typography variant='body2' sx={{ fontWeight: 700, mb: 0.5 }}>
           Kaze UX方針
         </Typography>
         <Typography variant='body1' color='text.secondary'>
@@ -207,10 +207,10 @@ const MaterialDesignContent = () => {
         <Table size='small'>
           <TableHead>
             <TableRow>
-              <TableCell sx={{ fontWeight: 600 }}>MUI トークン</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>値</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>用途</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>ビジュアル</TableCell>
+              <TableCell sx={{ fontWeight: 700 }}>MUI トークン</TableCell>
+              <TableCell sx={{ fontWeight: 700 }}>値</TableCell>
+              <TableCell sx={{ fontWeight: 700 }}>用途</TableCell>
+              <TableCell sx={{ fontWeight: 700 }}>ビジュアル</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -231,7 +231,7 @@ const MaterialDesignContent = () => {
                   />
                 </TableCell>
                 <TableCell>
-                  <Typography variant='body2' sx={{ fontWeight: 600 }}>
+                  <Typography variant='body2' sx={{ fontWeight: 700 }}>
                     {item.px}
                   </Typography>
                 </TableCell>
@@ -298,7 +298,7 @@ const MaterialDesignContent = () => {
               <Box sx={{ px: 2, py: 1.5 }}>
                 <Typography
                   variant='body2'
-                  sx={{ fontWeight: 600, fontSize: 12 }}>
+                  sx={{ fontWeight: 700, fontSize: 12 }}>
                   {item.name}
                 </Typography>
                 <Typography variant='caption' color='text.secondary'>
@@ -316,8 +316,8 @@ const MaterialDesignContent = () => {
         <Table size='small'>
           <TableHead>
             <TableRow>
-              <TableCell sx={{ fontWeight: 600 }}>機能</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>説明</TableCell>
+              <TableCell sx={{ fontWeight: 700 }}>機能</TableCell>
+              <TableCell sx={{ fontWeight: 700 }}>説明</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -336,7 +336,7 @@ const MaterialDesignContent = () => {
             ].map((row) => (
               <TableRow key={row[0]}>
                 <TableCell>
-                  <Typography variant='body2' sx={{ fontWeight: 500 }}>
+                  <Typography variant='body2' sx={{ fontWeight: 400 }}>
                     {row[0]}
                   </Typography>
                 </TableCell>
@@ -408,7 +408,7 @@ const ElevationPlayground = ({
   showOutline,
 }: ElevationArgs) => (
   <Box sx={{ maxWidth: 600, mx: 'auto' }}>
-    <Typography variant='h5' sx={{ fontWeight: 600, mb: 1 }}>
+    <Typography variant='h5' sx={{ fontWeight: 700, mb: 1 }}>
       Elevation Playground
     </Typography>
     <Typography variant='body1' color='text.secondary' sx={{ mb: 2 }}>
@@ -444,7 +444,7 @@ const ElevationPlayground = ({
           borderRadius,
           transition: motionOf(['border-radius', 'box-shadow'], 'macro'),
         }}>
-        <Typography variant='h4' sx={{ fontWeight: 800, mb: 0.5 }}>
+        <Typography variant='h4' sx={{ fontWeight: 700, mb: 0.5 }}>
           {elevation}
         </Typography>
         <Typography variant='body2' color='text.secondary'>
@@ -500,7 +500,7 @@ const SpacingDemoPlayground = ({ spacingValue }: SpacingPlaygroundArgs) => {
   const px = spacingValue * 8
   return (
     <Box sx={{ maxWidth: 600, mx: 'auto' }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 1 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 1 }}>
         8px Grid Spacing
       </Typography>
       <Typography variant='body1' color='text.secondary' sx={{ mb: 2 }}>
@@ -524,7 +524,7 @@ const SpacingDemoPlayground = ({ spacingValue }: SpacingPlaygroundArgs) => {
       </Paper>
       <Stack spacing={3}>
         <Box>
-          <Typography variant='body2' sx={{ fontWeight: 600, mb: 1 }}>
+          <Typography variant='body2' sx={{ fontWeight: 700, mb: 1 }}>
             Padding のプレビュー
           </Typography>
           <Paper
@@ -541,14 +541,14 @@ const SpacingDemoPlayground = ({ spacingValue }: SpacingPlaygroundArgs) => {
                 p: 2,
                 borderRadius: 1,
                 textAlign: 'center',
-                fontWeight: 600,
+                fontWeight: 700,
               }}>
               spacing({spacingValue}) = {px}px padding
             </Box>
           </Paper>
         </Box>
         <Box>
-          <Typography variant='body2' sx={{ fontWeight: 600, mb: 1 }}>
+          <Typography variant='body2' sx={{ fontWeight: 700, mb: 1 }}>
             Gap のプレビュー
           </Typography>
           <Stack
@@ -565,7 +565,7 @@ const SpacingDemoPlayground = ({ spacingValue }: SpacingPlaygroundArgs) => {
                   p: 1.5,
                   borderRadius: 1,
                   textAlign: 'center',
-                  fontWeight: 600,
+                  fontWeight: 700,
                 }}>
                 {n}
               </Box>
@@ -573,7 +573,7 @@ const SpacingDemoPlayground = ({ spacingValue }: SpacingPlaygroundArgs) => {
           </Stack>
         </Box>
         <Box>
-          <Typography variant='body2' sx={{ fontWeight: 600, mb: 1 }}>
+          <Typography variant='body2' sx={{ fontWeight: 700, mb: 1 }}>
             バーで比較
           </Typography>
           <Box

--- a/src/stories/00-Guide/MuiTailwind.stories.tsx
+++ b/src/stories/00-Guide/MuiTailwind.stories.tsx
@@ -42,7 +42,7 @@ const SectionHeader = ({
   subtitle?: string
 }) => (
   <Box sx={{ mb: 4 }}>
-    <Typography variant='h4' sx={{ fontWeight: 800, letterSpacing: '-0.01em' }}>
+    <Typography variant='h4' sx={{ fontWeight: 700, letterSpacing: '-0.01em' }}>
       {title}
     </Typography>
     {subtitle && (
@@ -73,7 +73,7 @@ const MuiTailwindContent = () => {
               ? 'linear-gradient(135deg, rgba(33,150,243,0.08) 0%, rgba(76,175,80,0.08) 100%)'
               : 'linear-gradient(135deg, rgba(33,150,243,0.04) 0%, rgba(76,175,80,0.04) 100%)',
         }}>
-        <Typography variant='h4' sx={{ fontWeight: 800, mb: 1 }}>
+        <Typography variant='h4' sx={{ fontWeight: 700, mb: 1 }}>
           MUI + Tailwind CSS 統合ガイド
         </Typography>
         <Typography variant='body1' color='text.secondary'>
@@ -96,9 +96,9 @@ const MuiTailwindContent = () => {
             <style>{`
               .at-text { font-family: -apple-system, BlinkMacSystemFont, sans-serif; }
               .at-title { font-size: 14px; font-weight: 700; fill: #fff; }
-              .at-file { font-size: 11px; fill: rgba(255,255,255,0.7); font-family: ui-monospace, monospace; }
+              .at-file { font-size: 12px; fill: rgba(255,255,255,0.7); font-family: ui-monospace, monospace; }
               .at-label { font-size: 12px; fill: ${theme.palette.text.primary}; }
-              .at-code { font-size: 11px; fill: ${theme.palette.text.secondary}; font-family: ui-monospace, monospace; }
+              .at-code { font-size: 12px; fill: ${theme.palette.text.secondary}; font-family: ui-monospace, monospace; }
               .at-arrow { stroke: ${theme.palette.primary.main}; stroke-width: 2.5; fill: none; marker-end: url(#arrowhead); }
             `}</style>
             <marker
@@ -385,7 +385,7 @@ const MuiTailwindContent = () => {
               alignItems='center'
               sx={{ mb: 1.5 }}>
               <Chip label='MUI sx prop' color='primary' size='small' />
-              <Typography variant='body1' sx={{ fontWeight: 600 }}>
+              <Typography variant='body1' sx={{ fontWeight: 700 }}>
                 推奨
               </Typography>
             </Stack>
@@ -419,7 +419,7 @@ const MuiTailwindContent = () => {
               alignItems='center'
               sx={{ mb: 1.5 }}>
               <Chip label='Tailwind className' color='success' size='small' />
-              <Typography variant='body1' sx={{ fontWeight: 600 }}>
+              <Typography variant='body1' sx={{ fontWeight: 700 }}>
                 補助的に使用
               </Typography>
             </Stack>
@@ -479,7 +479,7 @@ Tailwind の className は純HTML要素や、MUI を使わない箇所で使用�
 
 // テーマ値の参照
 <Paper sx={{ bgcolor: 'background.paper', color: 'text.primary' }}>
-  <Typography sx={{ color: 'primary.main', fontWeight: 600 }}>
+  <Typography sx={{ color: 'primary.main', fontWeight: 700 }}>
     テーマカラー参照
   </Typography>
 </Paper>
@@ -498,7 +498,7 @@ Tailwind の className は純HTML要素や、MUI を使わない箇所で使用�
       <CodeBlock>
         {`// 純HTML要素 → Tailwind className を使用
 <div className="flex gap-2 p-6">
-  <span className="text-primary font-semibold">
+  <span className="text-primary font-bold">
     Tailwindカラー
   </span>
 </div>
@@ -873,7 +873,7 @@ cn('p-4', 'p-6')
                     sx={{
                       fontFamily: 'monospace',
                       fontSize: 12,
-                      fontWeight: 500,
+                      fontWeight: 400,
                     }}>
                     {row.file}
                   </Typography>
@@ -957,7 +957,7 @@ const SxPlayground = ({
 }: SxPlaygroundArgs) => {
   return (
     <Box sx={{ maxWidth: 960, mx: 'auto', px: 3 }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 1 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 1 }}>
         MUI sx prop Playground
       </Typography>
       <Typography variant='body1' color='text.secondary' sx={{ mb: 2 }}>

--- a/src/stories/00-Guide/ReactBasics.stories.tsx
+++ b/src/stories/00-Guide/ReactBasics.stories.tsx
@@ -42,7 +42,7 @@ const SectionHeader = ({
   subtitle?: string
 }) => (
   <Box sx={{ mb: 4 }}>
-    <Typography variant='h4' sx={{ fontWeight: 800, letterSpacing: '-0.01em' }}>
+    <Typography variant='h4' sx={{ fontWeight: 700, letterSpacing: '-0.01em' }}>
       {title}
     </Typography>
     {subtitle && (
@@ -76,7 +76,7 @@ const ReactBasicsContent = () => {
               ? 'linear-gradient(135deg, rgba(97,218,251,0.08) 0%, rgba(33,150,243,0.08) 100%)'
               : 'linear-gradient(135deg, rgba(97,218,251,0.04) 0%, rgba(33,150,243,0.04) 100%)',
         }}>
-        <Typography variant='h3' sx={{ fontWeight: 800, mb: 1 }}>
+        <Typography variant='h3' sx={{ fontWeight: 700, mb: 1 }}>
           React 基礎
         </Typography>
         <Typography variant='h6' color='text.secondary' sx={{ mb: 2 }}>
@@ -210,7 +210,7 @@ const ServiceCard = ({
               </Typography>
             </Paper>
             <Box>
-              <Typography variant='body2' sx={{ fontWeight: 600 }}>
+              <Typography variant='body2' sx={{ fontWeight: 700 }}>
                 {item.title}
               </Typography>
               <Typography
@@ -223,7 +223,7 @@ const ServiceCard = ({
                 variant='caption'
                 sx={{
                   color: 'info.main',
-                  fontWeight: 500,
+                  fontWeight: 400,
                 }}>
                 Figma対応: {item.figma}
               </Typography>
@@ -240,9 +240,9 @@ const ServiceCard = ({
         <Table size='small'>
           <TableHead>
             <TableRow>
-              <TableCell sx={{ fontWeight: 600 }}>Figma</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>React</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>説明</TableCell>
+              <TableCell sx={{ fontWeight: 700 }}>Figma</TableCell>
+              <TableCell sx={{ fontWeight: 700 }}>React</TableCell>
+              <TableCell sx={{ fontWeight: 700 }}>説明</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -262,7 +262,7 @@ const ServiceCard = ({
             ].map((row) => (
               <TableRow key={row[0]}>
                 <TableCell>
-                  <Typography variant='body2' sx={{ fontWeight: 500 }}>
+                  <Typography variant='body2' sx={{ fontWeight: 400 }}>
                     {row[0]}
                   </Typography>
                 </TableCell>

--- a/src/stories/01-DesignPhilosophy/ComponentDesignGuide.stories.tsx
+++ b/src/stories/01-DesignPhilosophy/ComponentDesignGuide.stories.tsx
@@ -86,7 +86,7 @@ const SectionHeader = ({
       <Typography
         variant='h3'
         sx={{
-          fontWeight: 800,
+          fontWeight: 700,
           letterSpacing: '-0.02em',
           fontSize: { xs: 24, sm: 28 },
           color: theme.palette.mode === 'dark' ? 'grey.100' : 'grey.900',
@@ -285,7 +285,7 @@ const SectionHero = ({
       <Typography
         variant='h2'
         sx={{
-          fontWeight: 800,
+          fontWeight: 700,
           letterSpacing: '-0.03em',
           fontSize: { xs: 26, sm: 32 },
           mb: 1.5,
@@ -401,13 +401,13 @@ const PrinciplesContent = () => {
                     label={p.name}
                     color={p.color}
                     size='small'
-                    sx={{ fontWeight: 600 }}
+                    sx={{ fontWeight: 700 }}
                   />
                   <Typography variant='caption' color='text.secondary'>
                     {p.en}
                   </Typography>
                 </Stack>
-                <Typography variant='body2' sx={{ fontWeight: 600 }}>
+                <Typography variant='body2' sx={{ fontWeight: 700 }}>
                   {p.summary}
                 </Typography>
                 <Typography
@@ -427,7 +427,7 @@ const PrinciplesContent = () => {
                     borderRadius: 1,
                   }}>
                   <Typography variant='caption' color='text.secondary'>
-                    <Box component='span' sx={{ fontWeight: 600 }}>
+                    <Box component='span' sx={{ fontWeight: 700 }}>
                       例:{' '}
                     </Box>
                     {p.example}
@@ -486,7 +486,7 @@ const PathDependencyContent = () => {
       />
       <Stack spacing={3} sx={{ mb: 6 }}>
         <Paper variant='outlined' sx={{ px: 3.5, py: 3, borderRadius: 2 }}>
-          <Typography variant='body2' sx={{ fontWeight: 600, mb: 1.5 }}>
+          <Typography variant='body2' sx={{ fontWeight: 700, mb: 1.5 }}>
             QWERTY配列の例
           </Typography>
           <Typography
@@ -704,7 +704,7 @@ const StrategyContent = () => {
                 </Typography>
               </Paper>
               <Box>
-                <Typography variant='body2' sx={{ fontWeight: 600, mb: 0.5 }}>
+                <Typography variant='body2' sx={{ fontWeight: 700, mb: 0.5 }}>
                   {item.title}
                 </Typography>
                 <Typography
@@ -879,7 +879,7 @@ const DemoPanel = ({
       }}>
       <Typography
         sx={{
-          fontSize: 11,
+          fontSize: 12,
           fontWeight: 700,
           letterSpacing: '0.1em',
           color: 'primary.main',
@@ -954,7 +954,7 @@ const VariablesContent = () => {
                 direction='row'
                 justifyContent='space-between'
                 alignItems='center'>
-                <Typography sx={{ fontSize: 14, fontWeight: 600 }}>
+                <Typography sx={{ fontSize: 14, fontWeight: 700 }}>
                   アイコンを表示
                 </Typography>
                 <Switch
@@ -967,7 +967,7 @@ const VariablesContent = () => {
                 direction='row'
                 justifyContent='space-between'
                 alignItems='center'>
-                <Typography sx={{ fontSize: 14, fontWeight: 600 }}>
+                <Typography sx={{ fontSize: 14, fontWeight: 700 }}>
                   バッジを表示
                 </Typography>
                 <Switch
@@ -980,7 +980,7 @@ const VariablesContent = () => {
                 direction='row'
                 justifyContent='space-between'
                 alignItems='center'>
-                <Typography sx={{ fontSize: 14, fontWeight: 600 }}>
+                <Typography sx={{ fontSize: 14, fontWeight: 700 }}>
                   無効化（操作不可）
                 </Typography>
                 <Switch
@@ -1047,7 +1047,7 @@ const VariablesContent = () => {
           <Grid size={{ xs: 12, md: 5 }}>
             <Stack spacing={4}>
               <Box>
-                <Typography sx={{ fontSize: 13, fontWeight: 600, mb: 1.5 }}>
+                <Typography sx={{ fontSize: 13, fontWeight: 700, mb: 1.5 }}>
                   サイズ
                 </Typography>
                 <ToggleButtonGroup
@@ -1062,7 +1062,7 @@ const VariablesContent = () => {
                 </ToggleButtonGroup>
               </Box>
               <Box>
-                <Typography sx={{ fontSize: 13, fontWeight: 600, mb: 1.5 }}>
+                <Typography sx={{ fontSize: 13, fontWeight: 700, mb: 1.5 }}>
                   スタイル
                 </Typography>
                 <ToggleButtonGroup
@@ -1120,7 +1120,7 @@ const VariablesContent = () => {
           <Grid size={{ xs: 12, md: 5 }}>
             <Stack spacing={4}>
               <Box>
-                <Typography sx={{ fontSize: 13, fontWeight: 600, mb: 1.5 }}>
+                <Typography sx={{ fontSize: 13, fontWeight: 700, mb: 1.5 }}>
                   ボタンのラベル（テキスト入力してみてください）
                 </Typography>
                 <TextField
@@ -1132,7 +1132,7 @@ const VariablesContent = () => {
                 />
               </Box>
               <Box>
-                <Typography sx={{ fontSize: 13, fontWeight: 600, mb: 1.5 }}>
+                <Typography sx={{ fontSize: 13, fontWeight: 700, mb: 1.5 }}>
                   バッジの件数: {badgeCount}
                 </Typography>
                 <Slider
@@ -1205,7 +1205,7 @@ const VariablesContent = () => {
           <Grid size={{ xs: 12, md: 5 }}>
             <Stack spacing={4}>
               <Box>
-                <Typography sx={{ fontSize: 13, fontWeight: 600, mb: 1.5 }}>
+                <Typography sx={{ fontSize: 13, fontWeight: 700, mb: 1.5 }}>
                   サイズ（大きさだけが変わる）
                 </Typography>
                 <ToggleButtonGroup
@@ -1220,7 +1220,7 @@ const VariablesContent = () => {
                 </ToggleButtonGroup>
               </Box>
               <Box>
-                <Typography sx={{ fontSize: 13, fontWeight: 600, mb: 1.5 }}>
+                <Typography sx={{ fontSize: 13, fontWeight: 700, mb: 1.5 }}>
                   色（色だけが変わる）
                 </Typography>
                 <ToggleButtonGroup
@@ -1309,7 +1309,7 @@ const VariablesContent = () => {
       <DemoPanel label='操作してみよう - アイコンを差し替え'>
         <Grid container spacing={4}>
           <Grid size={{ xs: 12, md: 5 }}>
-            <Typography sx={{ fontSize: 13, fontWeight: 600, mb: 2 }}>
+            <Typography sx={{ fontSize: 13, fontWeight: 700, mb: 2 }}>
               左アイコンを選ぶ
             </Typography>
             <Grid container spacing={1.5}>
@@ -1418,7 +1418,7 @@ const VariablesContent = () => {
               <Stack spacing={1.5} alignItems='center'>
                 <Typography
                   sx={{
-                    fontSize: 11,
+                    fontSize: 12,
                     fontWeight: 700,
                     letterSpacing: '0.08em',
                     color: `${semantic}.main`,
@@ -1512,7 +1512,7 @@ const StatesLayoutContent = () => {
               ? 'linear-gradient(135deg, rgba(29,175,194,0.08) 0%, rgba(70,171,74,0.08) 100%)'
               : 'linear-gradient(135deg, rgba(29,175,194,0.04) 0%, rgba(70,171,74,0.04) 100%)',
         }}>
-        <Typography variant='h3' sx={{ fontWeight: 800, mb: 1 }}>
+        <Typography variant='h3' sx={{ fontWeight: 700, mb: 1 }}>
           状態・レイアウト・アセット
         </Typography>
         <Typography variant='body1' color='text.secondary'>
@@ -1536,9 +1536,9 @@ const StatesLayoutContent = () => {
                   label={s.state}
                   color={s.color}
                   size='small'
-                  sx={{ alignSelf: 'flex-start', fontWeight: 600 }}
+                  sx={{ alignSelf: 'flex-start', fontWeight: 700 }}
                 />
-                <Typography variant='body2' sx={{ fontWeight: 600 }}>
+                <Typography variant='body2' sx={{ fontWeight: 700 }}>
                   {s.label}
                 </Typography>
                 <Typography
@@ -1792,7 +1792,7 @@ const DeviceRow = ({
       {/* 名前 */}
       <Typography
         variant='body1'
-        sx={{ fontWeight: 500, flex: 1, opacity: failed ? 0.5 : 1 }}>
+        sx={{ fontWeight: 400, flex: 1, opacity: failed ? 0.5 : 1 }}>
         {name}
       </Typography>
 
@@ -1826,7 +1826,7 @@ const DeviceRow = ({
             </Box>
             <Typography
               variant='caption'
-              sx={{ fontWeight: 600, color: batteryColor, minWidth: 28 }}>
+              sx={{ fontWeight: 700, color: batteryColor, minWidth: 28 }}>
               {battery}%
             </Typography>
           </Stack>
@@ -1948,14 +1948,14 @@ const UIStatePlayground = ({ state, sizing, showInteraction }: UIStateArgs) => {
               label={cfg.desc}
               size='small'
               color={cfg.color}
-              sx={{ fontWeight: 500, fontSize: 12 }}
+              sx={{ fontWeight: 400, fontSize: 12 }}
             />
           </Stack>
           <Chip
             label={`sizing: ${sizing}`}
             size='small'
             variant='outlined'
-            sx={{ fontSize: 11, fontFamily: 'monospace' }}
+            sx={{ fontSize: 12, fontFamily: 'monospace' }}
           />
         </Stack>
 
@@ -2023,7 +2023,7 @@ const UIStatePlayground = ({ state, sizing, showInteraction }: UIStateArgs) => {
                 <Inbox size={28} />
               </Box>
               <Stack alignItems='center' spacing={0.5}>
-                <Typography variant='body1' sx={{ fontWeight: 600 }}>
+                <Typography variant='body1' sx={{ fontWeight: 700 }}>
                   デバイスが登録されていません
                 </Typography>
                 <Typography variant='body1' color='text.secondary'>
@@ -2034,7 +2034,7 @@ const UIStatePlayground = ({ state, sizing, showInteraction }: UIStateArgs) => {
                 icon={<Plus size={14} />}
                 label='デバイスを追加'
                 color='primary'
-                sx={{ cursor: 'pointer', fontWeight: 600, mt: 1 }}
+                sx={{ cursor: 'pointer', fontWeight: 700, mt: 1 }}
               />
             </Stack>
           )}
@@ -2078,7 +2078,7 @@ const UIStatePlayground = ({ state, sizing, showInteraction }: UIStateArgs) => {
                 <XCircle size={28} />
               </Box>
               <Stack alignItems='center' spacing={0.5}>
-                <Typography variant='body1' sx={{ fontWeight: 600 }}>
+                <Typography variant='body1' sx={{ fontWeight: 700 }}>
                   通信エラーが発生しました
                 </Typography>
                 <Typography variant='body1' color='text.secondary'>
@@ -2090,7 +2090,7 @@ const UIStatePlayground = ({ state, sizing, showInteraction }: UIStateArgs) => {
                 label='再接続'
                 color='error'
                 variant='outlined'
-                sx={{ cursor: 'pointer', fontWeight: 600, mt: 1 }}
+                sx={{ cursor: 'pointer', fontWeight: 700, mt: 1 }}
               />
             </Stack>
           )}

--- a/src/stories/01-DesignPhilosophy/KazeSkeleton.stories.tsx
+++ b/src/stories/01-DesignPhilosophy/KazeSkeleton.stories.tsx
@@ -128,7 +128,7 @@ const Section = ({
       <div
         className='mono'
         style={{
-          fontSize: 11,
+          fontSize: 12,
           letterSpacing: '0.24em',
           textTransform: 'uppercase',
           color: tokens.washiMute,
@@ -140,7 +140,7 @@ const Section = ({
         className='display'
         style={{
           fontSize: 'clamp(32px, 5vw, 56px)',
-          fontWeight: 380,
+          fontWeight: 400,
           letterSpacing: '-0.02em',
           lineHeight: 1.05,
           margin: 0,
@@ -210,7 +210,7 @@ const Hero = () => (
       <div
         className='mono'
         style={{
-          fontSize: 11,
+          fontSize: 12,
           letterSpacing: '0.24em',
           textTransform: 'uppercase',
           color: tokens.washiMute,
@@ -224,7 +224,7 @@ const Hero = () => (
           className='display'
           style={{
             fontSize: 'clamp(64px, 11vw, 180px)',
-            fontWeight: 380,
+            fontWeight: 400,
             letterSpacing: '-0.035em',
             lineHeight: 0.95,
             margin: '0 0 32px',
@@ -264,7 +264,7 @@ const Hero = () => (
                 key={label}
                 className='mono'
                 style={{
-                  fontSize: 11,
+                  fontSize: 12,
                   letterSpacing: '0.18em',
                   textTransform: 'uppercase',
                   padding: '8px 14px',
@@ -296,7 +296,7 @@ const TypographySection = () => (
         <div
           className='mono'
           style={{
-            fontSize: 10,
+            fontSize: 12,
             letterSpacing: '0.24em',
             textTransform: 'uppercase',
             color: tokens.washiMute,
@@ -332,7 +332,7 @@ const TypographySection = () => (
         <div
           className='mono'
           style={{
-            fontSize: 11,
+            fontSize: 12,
             color: tokens.washiMute,
             marginTop: 16,
             lineHeight: 1.8,
@@ -345,7 +345,7 @@ const TypographySection = () => (
         <div
           className='mono'
           style={{
-            fontSize: 10,
+            fontSize: 12,
             letterSpacing: '0.24em',
             textTransform: 'uppercase',
             color: tokens.washiMute,
@@ -356,7 +356,7 @@ const TypographySection = () => (
         <p
           style={{
             fontSize: 40,
-            fontWeight: 500,
+            fontWeight: 400,
             lineHeight: 1.2,
             margin: 0,
             letterSpacing: '-0.01em',
@@ -396,17 +396,17 @@ const TypographySection = () => (
         gap: 32,
       }}>
       {[
-        { label: 'Caption', size: 11, weight: 500 },
+        { label: 'Caption', size: 12, weight: 400 },
         { label: 'Body-S', size: 13, weight: 400 },
         { label: 'Body', size: 15, weight: 400 },
         { label: 'Lead', size: 20, weight: 400 },
-        { label: 'H3', size: 28, weight: 500 },
+        { label: 'H3', size: 28, weight: 400 },
       ].map((row) => (
         <div key={row.label}>
           <div
             className='mono'
             style={{
-              fontSize: 10,
+              fontSize: 12,
               letterSpacing: '0.2em',
               textTransform: 'uppercase',
               color: tokens.washiMute,
@@ -513,18 +513,18 @@ const ColorSection = () => {
               {s.jp}
             </div>
             <div>
-              <div style={{ fontSize: 14, fontWeight: 500, marginBottom: 4 }}>
+              <div style={{ fontSize: 14, fontWeight: 400, marginBottom: 4 }}>
                 {s.name}
               </div>
               <div
                 className='mono'
-                style={{ fontSize: 11, opacity: 0.75, marginBottom: 8 }}>
+                style={{ fontSize: 12, opacity: 0.75, marginBottom: 8 }}>
                 {s.hex.toUpperCase()}
               </div>
               <div
                 className='mono'
                 style={{
-                  fontSize: 10,
+                  fontSize: 12,
                   letterSpacing: '0.16em',
                   textTransform: 'uppercase',
                   opacity: 0.7,
@@ -567,7 +567,7 @@ const RadiusSection = () => {
             borderRadius: 2,
             padding: '12px 20px',
             fontSize: 13,
-            fontWeight: 500,
+            fontWeight: 400,
             cursor: 'pointer',
             letterSpacing: '0.02em',
           }}>
@@ -590,8 +590,8 @@ const RadiusSection = () => {
             lineHeight: 1.6,
             width: 160,
           }}>
-          <div style={{ fontWeight: 500, marginBottom: 4 }}>Card</div>
-          <div style={{ color: tokens.washiMute, fontSize: 11 }}>
+          <div style={{ fontWeight: 400, marginBottom: 4 }}>Card</div>
+          <div style={{ color: tokens.washiMute, fontSize: 12 }}>
             Soft corner, soft voice.
           </div>
         </div>
@@ -614,7 +614,7 @@ const RadiusSection = () => {
           <div className='display' style={{ fontSize: 22, marginBottom: 4 }}>
             Welcome
           </div>
-          <div style={{ opacity: 0.85, fontSize: 11 }}>Hero-scale block.</div>
+          <div style={{ opacity: 0.85, fontSize: 12 }}>Hero-scale block.</div>
         </div>
       ),
     },
@@ -642,7 +642,7 @@ const RadiusSection = () => {
           <span
             className='mono'
             style={{
-              fontSize: 10,
+              fontSize: 12,
               letterSpacing: '0.2em',
               textTransform: 'uppercase',
               padding: '6px 12px',
@@ -681,7 +681,7 @@ const RadiusSection = () => {
               <div
                 className='mono'
                 style={{
-                  fontSize: 10,
+                  fontSize: 12,
                   letterSpacing: '0.22em',
                   textTransform: 'uppercase',
                   color: tokens.washiMute,
@@ -752,7 +752,7 @@ const MotionSection = () => (
           <div
             className='mono'
             style={{
-              fontSize: 10,
+              fontSize: 12,
               letterSpacing: '0.22em',
               textTransform: 'uppercase',
               color: tokens.washiMute,
@@ -791,7 +791,7 @@ const MotionSection = () => (
       <div
         className='mono'
         style={{
-          fontSize: 10,
+          fontSize: 12,
           letterSpacing: '0.24em',
           textTransform: 'uppercase',
           opacity: 0.55,
@@ -837,10 +837,10 @@ const MotionSection = () => (
             onMouseLeave={(ev) => {
               ev.currentTarget.style.transform = 'translateX(0)'
             }}>
-            <div style={{ fontWeight: 500, marginBottom: 6 }}>
+            <div style={{ fontWeight: 400, marginBottom: 6 }}>
               {e.label} {e.good ? '✓' : '✕'}
             </div>
-            <div className='mono' style={{ fontSize: 10, opacity: 0.7 }}>
+            <div className='mono' style={{ fontSize: 12, opacity: 0.7 }}>
               {e.ease}
             </div>
           </button>
@@ -923,7 +923,7 @@ const CommitmentSection = () => {
               <div
                 className='mono'
                 style={{
-                  fontSize: 10,
+                  fontSize: 12,
                   letterSpacing: '0.24em',
                   textTransform: 'uppercase',
                   color: tokens.kazeBlue,
@@ -937,7 +937,7 @@ const CommitmentSection = () => {
               <div
                 className='mono'
                 style={{
-                  fontSize: 10,
+                  fontSize: 12,
                   letterSpacing: '0.24em',
                   textTransform: 'uppercase',
                   color: tokens.beni,
@@ -980,7 +980,7 @@ const Footer = () => (
       <div
         className='mono'
         style={{
-          fontSize: 11,
+          fontSize: 12,
           letterSpacing: '0.24em',
           textTransform: 'uppercase',
           color: tokens.washiMute,

--- a/src/stories/01-DesignPhilosophy/Overview.stories.tsx
+++ b/src/stories/01-DesignPhilosophy/Overview.stories.tsx
@@ -119,7 +119,7 @@ const DesignPhilosophyOverview = () => {
           variant='overline'
           sx={{
             fontSize: 12,
-            fontWeight: 600,
+            fontWeight: 700,
             letterSpacing: '0.12em',
             color: isDark ? 'primary.light' : 'primary.main',
             mb: 2,
@@ -130,7 +130,7 @@ const DesignPhilosophyOverview = () => {
         <Typography
           variant='h1'
           sx={{
-            fontWeight: 800,
+            fontWeight: 700,
             fontSize: { xs: 32, sm: 44 },
             letterSpacing: '-0.03em',
             lineHeight: 1.15,
@@ -142,7 +142,7 @@ const DesignPhilosophyOverview = () => {
         <Typography
           sx={{
             fontSize: { xs: 18, sm: 22 },
-            fontWeight: 300,
+            fontWeight: 400,
             letterSpacing: '0.08em',
             color: isDark ? 'grey.400' : 'grey.600',
           }}>
@@ -155,7 +155,7 @@ const DesignPhilosophyOverview = () => {
         <Typography
           variant='overline'
           sx={{
-            fontSize: 11,
+            fontSize: 12,
             fontWeight: 700,
             letterSpacing: '0.1em',
             color: 'primary.main',
@@ -182,7 +182,7 @@ const DesignPhilosophyOverview = () => {
         <Typography
           variant='overline'
           sx={{
-            fontSize: 11,
+            fontSize: 12,
             fontWeight: 700,
             letterSpacing: '0.1em',
             color: 'primary.main',
@@ -208,7 +208,7 @@ const DesignPhilosophyOverview = () => {
               <Typography
                 sx={{
                   fontSize: { xs: 28, sm: 36 },
-                  fontWeight: 200,
+                  fontWeight: 400,
                   color: isDark ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.1)',
                   lineHeight: 1,
                   fontVariantNumeric: 'tabular-nums',
@@ -235,7 +235,7 @@ const DesignPhilosophyOverview = () => {
         <Typography
           variant='overline'
           sx={{
-            fontSize: 11,
+            fontSize: 12,
             fontWeight: 700,
             letterSpacing: '0.1em',
             color: 'primary.main',
@@ -329,7 +329,7 @@ const DesignPhilosophyOverview = () => {
         <Typography
           variant='overline'
           sx={{
-            fontSize: 11,
+            fontSize: 12,
             fontWeight: 700,
             letterSpacing: '0.1em',
             color: 'primary.main',
@@ -372,7 +372,7 @@ const DesignPhilosophyOverview = () => {
                 <Typography
                   sx={{
                     fontSize: 32,
-                    fontWeight: 200,
+                    fontWeight: 400,
                     color: isDark
                       ? 'rgba(255,255,255,0.1)'
                       : 'rgba(0,0,0,0.07)',
@@ -394,7 +394,7 @@ const DesignPhilosophyOverview = () => {
                 <Typography
                   sx={{
                     fontSize: 14,
-                    fontWeight: 500,
+                    fontWeight: 400,
                     mb: 1.5,
                     color: isDark ? 'grey.300' : 'grey.700',
                     lineHeight: 1.7,

--- a/src/stories/01-DesignPhilosophy/TechnicalStack.stories.tsx
+++ b/src/stories/01-DesignPhilosophy/TechnicalStack.stories.tsx
@@ -154,7 +154,7 @@ const TechnicalStackOverview = () => {
                 border: `1px solid ${theme.palette.divider}`,
               }}>
               <Box sx={{ mb: 2 }}>
-                <Typography variant='h5' sx={{ fontWeight: 600, mb: 0.5 }}>
+                <Typography variant='h5' sx={{ fontWeight: 700, mb: 0.5 }}>
                   {tech.name}
                 </Typography>
                 <Typography
@@ -176,7 +176,7 @@ const TechnicalStackOverview = () => {
               <Typography
                 variant='body2'
                 color='text.secondary'
-                sx={{ mb: 1, fontWeight: 600 }}>
+                sx={{ mb: 1, fontWeight: 700 }}>
                 主な機能
               </Typography>
               <Box
@@ -212,7 +212,7 @@ const TechnicalStackOverview = () => {
           variant='h3'
           sx={{
             mb: 4,
-            fontWeight: 600,
+            fontWeight: 700,
             fontSize: { xs: '1.5rem', md: '1.75rem' },
           }}>
           技術選定の理由
@@ -229,7 +229,7 @@ const TechnicalStackOverview = () => {
                   bgcolor: 'action.hover',
                   border: `1px solid ${theme.palette.divider}`,
                 }}>
-                <Typography variant='h6' sx={{ mb: 2, fontWeight: 600 }}>
+                <Typography variant='h6' sx={{ mb: 2, fontWeight: 700 }}>
                   {reason.title}
                 </Typography>
                 <Typography

--- a/src/stories/02-DesignTokens/Accessibility.stories.tsx
+++ b/src/stories/02-DesignTokens/Accessibility.stories.tsx
@@ -158,20 +158,20 @@ function ContrastRatiosShowcase() {
             borderBottom: '1px solid',
             borderColor: 'divider',
           }}>
-          <Typography variant='caption' sx={{ fontWeight: 600, minWidth: 60 }}>
+          <Typography variant='caption' sx={{ fontWeight: 700, minWidth: 60 }}>
             判定
           </Typography>
-          <Typography variant='caption' sx={{ fontWeight: 600, minWidth: 200 }}>
+          <Typography variant='caption' sx={{ fontWeight: 700, minWidth: 200 }}>
             前景色 / 背景色
           </Typography>
           <Typography
             variant='caption'
-            sx={{ fontWeight: 600, flex: 1, minWidth: 240 }}>
+            sx={{ fontWeight: 700, flex: 1, minWidth: 240 }}>
             表示サンプル
           </Typography>
           <Typography
             variant='caption'
-            sx={{ fontWeight: 600, minWidth: 280, textAlign: 'right' }}>
+            sx={{ fontWeight: 700, minWidth: 280, textAlign: 'right' }}>
             備考
           </Typography>
         </Box>
@@ -205,7 +205,7 @@ function ContrastRatiosShowcase() {
               <Typography
                 variant='caption'
                 sx={{
-                  fontWeight: 600,
+                  fontWeight: 700,
                   color: pair.passesAA ? 'success.main' : 'warning.main',
                 }}>
                 {pair.passesAA ? 'AA' : '参考'}
@@ -218,7 +218,7 @@ function ContrastRatiosShowcase() {
                 variant='body2'
                 sx={{
                   fontFamily: 'monospace',
-                  fontWeight: 600,
+                  fontWeight: 700,
                   color: 'primary.main',
                 }}>
                 {pair.foregroundLabel}
@@ -240,10 +240,10 @@ function ContrastRatiosShowcase() {
                   border: '1px solid',
                   borderColor: 'divider',
                 }}>
-                <Typography sx={{ fontSize: '1rem', fontWeight: 600 }}>
+                <Typography sx={{ fontSize: '1rem', fontWeight: 700 }}>
                   サンプルテキスト Aa
                 </Typography>
-                <Typography sx={{ fontSize: '0.857rem' }}>
+                <Typography sx={{ fontSize: '0.86rem' }}>
                   補足テキスト 12px sample text
                 </Typography>
               </Box>
@@ -269,7 +269,7 @@ function ContrastRatiosShowcase() {
           borderRadius: 2,
           bgcolor: 'action.hover',
         }}>
-        <Typography variant='body2' sx={{ fontWeight: 600, mb: 1 }}>
+        <Typography variant='body2' sx={{ fontWeight: 700, mb: 1 }}>
           WCAG AA コントラスト比の基準
         </Typography>
         <Stack spacing={1}>
@@ -378,7 +378,7 @@ function TouchTargetsShowcase() {
                   variant='caption'
                   sx={{
                     fontFamily: 'monospace',
-                    fontWeight: 600,
+                    fontWeight: 700,
                     color: `${spec.color}.main`,
                     bgcolor: `${spec.color}.lighter`,
                     px: 1.5,
@@ -487,7 +487,7 @@ function TouchTargetsShowcase() {
 
       {/* サイズ比較図 */}
       <Paper variant='outlined' sx={{ mt: 4, p: 4, borderRadius: 2 }}>
-        <Typography variant='body2' sx={{ fontWeight: 600, mb: 3 }}>
+        <Typography variant='body2' sx={{ fontWeight: 700, mb: 3 }}>
           サイズ比較
         </Typography>
         <Stack direction='row' spacing={4} sx={{ alignItems: 'flex-end' }}>
@@ -509,8 +509,8 @@ function TouchTargetsShowcase() {
                 <Typography
                   sx={{
                     fontFamily: 'monospace',
-                    fontSize: '0.75rem',
-                    fontWeight: 600,
+                    fontSize: '0.86rem',
+                    fontWeight: 700,
                     color: `${spec.color}.main`,
                   }}>
                   {spec.size}
@@ -533,7 +533,7 @@ function TouchTargetsShowcase() {
           borderRadius: 2,
           bgcolor: 'action.hover',
         }}>
-        <Typography variant='body2' sx={{ fontWeight: 600, mb: 1 }}>
+        <Typography variant='body2' sx={{ fontWeight: 700, mb: 1 }}>
           業務運用における注意事項
         </Typography>
         <Stack spacing={1}>
@@ -640,12 +640,6 @@ function FontSizesShowcase() {
       usage: 'body2/caption相当、補助テキスト、テーブルセル、チップ',
       highlight: 'minimum',
     },
-    {
-      variant: 'xs',
-      px: 10,
-      rem: `${(10 / baseFontSize).toFixed(2)}rem`,
-      usage: '特殊用途のみ（バッジ、極小ラベル）- 通常は使用しない',
-    },
   ]
 
   return (
@@ -674,21 +668,21 @@ function FontSizesShowcase() {
             borderBottom: '1px solid',
             borderColor: 'divider',
           }}>
-          <Typography variant='caption' sx={{ fontWeight: 600, minWidth: 130 }}>
+          <Typography variant='caption' sx={{ fontWeight: 700, minWidth: 130 }}>
             バリアント
           </Typography>
-          <Typography variant='caption' sx={{ fontWeight: 600, minWidth: 70 }}>
+          <Typography variant='caption' sx={{ fontWeight: 700, minWidth: 70 }}>
             サイズ
           </Typography>
-          <Typography variant='caption' sx={{ fontWeight: 600, minWidth: 80 }}>
+          <Typography variant='caption' sx={{ fontWeight: 700, minWidth: 80 }}>
             rem値
           </Typography>
-          <Typography variant='caption' sx={{ fontWeight: 600, flex: 1 }}>
+          <Typography variant='caption' sx={{ fontWeight: 700, flex: 1 }}>
             サンプル
           </Typography>
           <Typography
             variant='caption'
-            sx={{ fontWeight: 600, minWidth: 240, textAlign: 'right' }}>
+            sx={{ fontWeight: 700, minWidth: 240, textAlign: 'right' }}>
             用途
           </Typography>
         </Box>
@@ -721,7 +715,7 @@ function FontSizesShowcase() {
                   variant='body2'
                   sx={{
                     fontFamily: 'monospace',
-                    fontWeight: 600,
+                    fontWeight: 700,
                     color: 'primary.main',
                   }}>
                   {entry.variant}
@@ -736,7 +730,7 @@ function FontSizesShowcase() {
                       px: 1,
                       py: 0.25,
                       borderRadius: 0.5,
-                      fontSize: '0.65rem',
+                      fontSize: '0.86rem',
                     }}>
                     BASE
                   </Typography>
@@ -751,7 +745,7 @@ function FontSizesShowcase() {
                       px: 1,
                       py: 0.25,
                       borderRadius: 0.5,
-                      fontSize: '0.65rem',
+                      fontSize: '0.86rem',
                     }}>
                     MIN
                   </Typography>
@@ -809,14 +803,14 @@ function FontSizesShowcase() {
 
       {/* MUI標準バリアントとの対応表 */}
       <Paper variant='outlined' sx={{ mt: 4, p: 4, borderRadius: 2 }}>
-        <Typography variant='body2' sx={{ fontWeight: 600, mb: 3 }}>
+        <Typography variant='body2' sx={{ fontWeight: 700, mb: 3 }}>
           MUI標準バリアントとの対応
         </Typography>
         <Grid container spacing={3}>
           <Grid size={{ xs: 12, md: 6 }}>
             <Typography
               variant='caption'
-              sx={{ fontWeight: 600, mb: 2, display: 'block' }}>
+              sx={{ fontWeight: 700, mb: 2, display: 'block' }}>
               見出し系
             </Typography>
             <Stack spacing={1}>
@@ -851,7 +845,7 @@ function FontSizesShowcase() {
                     variant='caption'
                     sx={{
                       fontFamily: 'monospace',
-                      fontWeight: 600,
+                      fontWeight: 700,
                       color: 'primary.main',
                     }}>
                     {mapping.custom} ({mapping.px}px)
@@ -863,7 +857,7 @@ function FontSizesShowcase() {
           <Grid size={{ xs: 12, md: 6 }}>
             <Typography
               variant='caption'
-              sx={{ fontWeight: 600, mb: 2, display: 'block' }}>
+              sx={{ fontWeight: 700, mb: 2, display: 'block' }}>
               本文系
             </Typography>
             <Stack spacing={1}>
@@ -897,7 +891,7 @@ function FontSizesShowcase() {
                     variant='caption'
                     sx={{
                       fontFamily: 'monospace',
-                      fontWeight: 600,
+                      fontWeight: 700,
                       color: 'primary.main',
                     }}>
                     {mapping.custom} ({mapping.px}px)
@@ -918,7 +912,7 @@ function FontSizesShowcase() {
           borderRadius: 2,
           bgcolor: 'action.hover',
         }}>
-        <Typography variant='body2' sx={{ fontWeight: 600, mb: 1 }}>
+        <Typography variant='body2' sx={{ fontWeight: 700, mb: 1 }}>
           フォントサイズの原則
         </Typography>
         <Stack spacing={1}>

--- a/src/stories/02-DesignTokens/Breakpoints.stories.tsx
+++ b/src/stories/02-DesignTokens/Breakpoints.stories.tsx
@@ -145,12 +145,12 @@ const BreakpointScaleDemo = () => {
           label={currentBp}
           color='primary'
           size='small'
-          sx={{ fontWeight: 600, ml: 0.5 }}
+          sx={{ fontWeight: 700, ml: 0.5 }}
         />
       </Alert>
 
       {/* ----- カスタムブレークポイント一覧 ----- */}
-      <Typography variant='h5' gutterBottom sx={{ fontWeight: 600, mb: 3 }}>
+      <Typography variant='h5' gutterBottom sx={{ fontWeight: 700, mb: 3 }}>
         カスタムブレークポイント
       </Typography>
 
@@ -193,14 +193,14 @@ const BreakpointScaleDemo = () => {
                       label='ACTIVE'
                       color='primary'
                       size='small'
-                      sx={{ fontWeight: 600, fontSize: '0.7rem' }}
+                      sx={{ fontWeight: 700, fontSize: '0.86rem' }}
                     />
                   )}
                 </Box>
                 <Box sx={{ textAlign: 'right' }}>
                   <Typography
                     variant='body2'
-                    sx={{ fontFamily: 'monospace', fontWeight: 600 }}>
+                    sx={{ fontFamily: 'monospace', fontWeight: 700 }}>
                     {value}px{upper ? ` - ${upper}` : '+'}
                   </Typography>
                 </Box>
@@ -246,7 +246,7 @@ const BreakpointScaleDemo = () => {
       <Divider sx={{ mb: 5 }} />
 
       {/* ----- MUI ブレークポイントマッピング ----- */}
-      <Typography variant='h5' gutterBottom sx={{ fontWeight: 600, mb: 3 }}>
+      <Typography variant='h5' gutterBottom sx={{ fontWeight: 700, mb: 3 }}>
         MUI ブレークポイントマッピング
       </Typography>
 
@@ -274,7 +274,7 @@ const BreakpointScaleDemo = () => {
                   }}>
                   <Typography
                     variant='body2'
-                    sx={{ fontWeight: 600, fontFamily: 'monospace' }}>
+                    sx={{ fontWeight: 700, fontFamily: 'monospace' }}>
                     {key}
                   </Typography>
                   <Typography
@@ -290,7 +290,7 @@ const BreakpointScaleDemo = () => {
       </Paper>
 
       {/* ----- 全体スケールバー（セグメント表示） ----- */}
-      <Typography variant='h5' gutterBottom sx={{ fontWeight: 600, mb: 3 }}>
+      <Typography variant='h5' gutterBottom sx={{ fontWeight: 700, mb: 3 }}>
         ブレークポイントスケール
       </Typography>
 
@@ -345,7 +345,7 @@ const BreakpointScaleDemo = () => {
                   sx={{
                     fontWeight: 700,
                     color: isActive ? 'white' : 'text.secondary',
-                    fontSize: '0.7rem',
+                    fontSize: '0.86rem',
                     textTransform: 'uppercase',
                   }}>
                   {label}
@@ -394,7 +394,7 @@ const BreakpointScaleDemo = () => {
                   position: 'absolute',
                   left: `${pos}%`,
                   fontFamily: 'monospace',
-                  fontSize: '0.65rem',
+                  fontSize: '0.86rem',
                   color: 'text.secondary',
                   transform: 'translateX(-50%)',
                 }}>
@@ -498,12 +498,12 @@ const ContainerWidthsDemo = () => {
                     label={key}
                     size='small'
                     variant='outlined'
-                    sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }}
+                    sx={{ fontFamily: 'monospace', fontSize: '0.86rem' }}
                   />
                 </Box>
                 <Typography
                   variant='body2'
-                  sx={{ fontFamily: 'monospace', fontWeight: 600 }}>
+                  sx={{ fontFamily: 'monospace', fontWeight: 700 }}>
                   {typeof value === 'number' ? `${value}px` : value}
                 </Typography>
               </Box>
@@ -540,8 +540,8 @@ const ContainerWidthsDemo = () => {
                     variant='caption'
                     sx={{
                       color: 'white',
-                      fontWeight: 600,
-                      fontSize: '0.65rem',
+                      fontWeight: 700,
+                      fontSize: '0.86rem',
                     }}>
                     {typeof value === 'number' ? `${value}px` : '100%'}
                   </Typography>
@@ -554,7 +554,7 @@ const ContainerWidthsDemo = () => {
 
       {/* サイズ比較 */}
       <Box sx={{ mt: 6 }}>
-        <Typography variant='h5' gutterBottom sx={{ fontWeight: 600, mb: 3 }}>
+        <Typography variant='h5' gutterBottom sx={{ fontWeight: 700, mb: 3 }}>
           サイズ比較
         </Typography>
         <Paper elevation={0} sx={{ p: 3, bgcolor: 'action.hover' }}>
@@ -683,7 +683,7 @@ const TouchTargetsDemo = () => {
                 variant='body2'
                 sx={{
                   fontFamily: 'monospace',
-                  fontWeight: 600,
+                  fontWeight: 700,
                   mb: 1,
                 }}>
                 {value}px
@@ -725,7 +725,7 @@ const TouchTargetsDemo = () => {
                     sx={{
                       color: 'white',
                       fontWeight: 700,
-                      fontSize: '0.6rem',
+                      fontSize: '0.86rem',
                     }}>
                     {value}
                   </Typography>
@@ -749,7 +749,7 @@ const TouchTargetsDemo = () => {
                     sx={{
                       color: 'white',
                       fontWeight: 700,
-                      fontSize: '0.6rem',
+                      fontSize: '0.86rem',
                     }}>
                     {value}
                   </Typography>
@@ -762,7 +762,7 @@ const TouchTargetsDemo = () => {
 
       {/* 横並び比較 */}
       <Box sx={{ mt: 6 }}>
-        <Typography variant='h5' gutterBottom sx={{ fontWeight: 600, mb: 3 }}>
+        <Typography variant='h5' gutterBottom sx={{ fontWeight: 700, mb: 3 }}>
           サイズ比較
         </Typography>
         <Paper
@@ -795,12 +795,12 @@ const TouchTargetsDemo = () => {
                   sx={{
                     color: 'white',
                     fontWeight: 700,
-                    fontSize: '0.6rem',
+                    fontSize: '0.86rem',
                   }}>
                   {value}
                 </Typography>
               </Box>
-              <Typography variant='caption' sx={{ fontWeight: 600 }}>
+              <Typography variant='caption' sx={{ fontWeight: 700 }}>
                 {label}
               </Typography>
               <Typography
@@ -885,12 +885,12 @@ const ResponsiveDemoView = () => {
           label={currentBp}
           color='primary'
           size='small'
-          sx={{ fontWeight: 600, ml: 0.5 }}
+          sx={{ fontWeight: 700, ml: 0.5 }}
         />
       </Alert>
 
       {/* ----- パターン 1: xs=12, md=6, lg=4 ----- */}
-      <Typography variant='h5' gutterBottom sx={{ fontWeight: 600, mb: 1 }}>
+      <Typography variant='h5' gutterBottom sx={{ fontWeight: 700, mb: 1 }}>
         パターン 1
       </Typography>
       <Typography
@@ -913,7 +913,7 @@ const ResponsiveDemoView = () => {
       <Divider sx={{ mb: 5 }} />
 
       {/* ----- パターン 2: xs=12, sm=6, md=4, lg=3 ----- */}
-      <Typography variant='h5' gutterBottom sx={{ fontWeight: 600, mb: 1 }}>
+      <Typography variant='h5' gutterBottom sx={{ fontWeight: 700, mb: 1 }}>
         パターン 2
       </Typography>
       <Typography
@@ -936,7 +936,7 @@ const ResponsiveDemoView = () => {
       <Divider sx={{ mb: 5 }} />
 
       {/* ----- パターン 3: サイドバーレイアウト ----- */}
-      <Typography variant='h5' gutterBottom sx={{ fontWeight: 600, mb: 1 }}>
+      <Typography variant='h5' gutterBottom sx={{ fontWeight: 700, mb: 1 }}>
         パターン 3 (サイドバーレイアウト)
       </Typography>
       <Typography
@@ -988,7 +988,7 @@ const ResponsiveDemoView = () => {
       </Grid>
 
       {/* ----- ブレークポイント別カラム数リファレンス ----- */}
-      <Typography variant='h5' gutterBottom sx={{ fontWeight: 600, mb: 3 }}>
+      <Typography variant='h5' gutterBottom sx={{ fontWeight: 700, mb: 3 }}>
         ブレークポイント別カラム数リファレンス
       </Typography>
       <Paper elevation={0} sx={{ p: 3, bgcolor: 'action.hover' }}>

--- a/src/stories/02-DesignTokens/Color/index.stories.tsx
+++ b/src/stories/02-DesignTokens/Color/index.stories.tsx
@@ -163,8 +163,8 @@ const ColorChip = ({
         <Typography
           sx={{
             fontFamily: 'monospace',
-            fontSize: '0.75rem',
-            fontWeight: 600,
+            fontSize: '0.86rem',
+            fontWeight: 700,
             color: textColor,
             opacity: 0.9,
           }}>
@@ -176,8 +176,8 @@ const ColorChip = ({
         <Typography
           sx={{
             fontFamily: 'monospace',
-            fontSize: '0.8rem',
-            fontWeight: 600,
+            fontSize: '0.86rem',
+            fontWeight: 700,
             color: theme.palette.text.primary,
             mb: 1,
           }}>
@@ -199,7 +199,7 @@ const ColorChip = ({
               <Typography
                 sx={{
                   fontFamily: 'monospace',
-                  fontSize: '0.7rem',
+                  fontSize: '0.86rem',
                   color: theme.palette.text.secondary,
                 }}>
                 {contrastWhite.toFixed(1)}:1
@@ -207,7 +207,7 @@ const ColorChip = ({
               <Typography
                 sx={{
                   fontFamily: 'monospace',
-                  fontSize: '0.65rem',
+                  fontSize: '0.86rem',
                   fontWeight: 700,
                   color: getWcagColor(wcagWhite),
                 }}>
@@ -227,7 +227,7 @@ const ColorChip = ({
               <Typography
                 sx={{
                   fontFamily: 'monospace',
-                  fontSize: '0.7rem',
+                  fontSize: '0.86rem',
                   color: theme.palette.text.secondary,
                 }}>
                 {contrastBlack.toFixed(1)}:1
@@ -235,7 +235,7 @@ const ColorChip = ({
               <Typography
                 sx={{
                   fontFamily: 'monospace',
-                  fontSize: '0.65rem',
+                  fontSize: '0.86rem',
                   fontWeight: 700,
                   color: getWcagColor(wcagBlack),
                 }}>
@@ -248,7 +248,7 @@ const ColorChip = ({
           <Typography
             sx={{
               fontFamily: 'monospace',
-              fontSize: '0.65rem',
+              fontSize: '0.86rem',
               color: theme.palette.text.disabled,
             }}>
             rgba (コントラスト比算出不可)
@@ -282,7 +282,7 @@ const SectionHeader = ({
       {description && (
         <Typography
           sx={{
-            fontSize: '0.85rem',
+            fontSize: '0.86rem',
             color: theme.palette.text.secondary,
           }}>
           {description}
@@ -490,7 +490,7 @@ const FullColorPalette = () => {
         <Typography
           sx={{
             fontFamily: 'monospace',
-            fontSize: '0.75rem',
+            fontSize: '0.86rem',
             color: theme.palette.text.disabled,
           }}>
           データソース: colorToken.ts + useTheme()
@@ -849,8 +849,8 @@ const LightDarkComparisonView = () => {
               <Box key={name} sx={{ mb: 3 }}>
                 <Typography
                   sx={{
-                    fontSize: '0.8rem',
-                    fontWeight: 600,
+                    fontSize: '0.86rem',
+                    fontWeight: 700,
                     textTransform: 'capitalize',
                     color: (t) => t.palette.text.primary,
                     mb: 1,
@@ -889,8 +889,8 @@ const LightDarkComparisonView = () => {
           {/* テキスト / 背景 */}
           <Typography
             sx={{
-              fontSize: '0.8rem',
-              fontWeight: 600,
+              fontSize: '0.86rem',
+              fontWeight: 700,
               color: (t) => t.palette.text.primary,
               mt: 4,
               mb: 1,
@@ -930,8 +930,8 @@ const LightDarkComparisonView = () => {
                     <Typography
                       sx={{
                         fontFamily: 'monospace',
-                        fontSize: '0.7rem',
-                        fontWeight: 600,
+                        fontSize: '0.86rem',
+                        fontWeight: 700,
                         color: (t) => t.palette.text.primary,
                       }}>
                       {key}
@@ -939,7 +939,7 @@ const LightDarkComparisonView = () => {
                     <Typography
                       sx={{
                         fontFamily: 'monospace',
-                        fontSize: '0.65rem',
+                        fontSize: '0.86rem',
                         color: (t) => t.palette.text.secondary,
                       }}>
                       {resolveColor(value)}
@@ -953,8 +953,8 @@ const LightDarkComparisonView = () => {
           {/* サーフェス / アイコン */}
           <Typography
             sx={{
-              fontSize: '0.8rem',
-              fontWeight: 600,
+              fontSize: '0.86rem',
+              fontWeight: 700,
               color: (t) => t.palette.text.primary,
               mt: 3,
               mb: 1,
@@ -994,8 +994,8 @@ const LightDarkComparisonView = () => {
                     <Typography
                       sx={{
                         fontFamily: 'monospace',
-                        fontSize: '0.7rem',
-                        fontWeight: 600,
+                        fontSize: '0.86rem',
+                        fontWeight: 700,
                         color: (t) => t.palette.text.primary,
                       }}>
                       {key}
@@ -1003,7 +1003,7 @@ const LightDarkComparisonView = () => {
                     <Typography
                       sx={{
                         fontFamily: 'monospace',
-                        fontSize: '0.65rem',
+                        fontSize: '0.86rem',
                         color: (t) => t.palette.text.secondary,
                       }}>
                       {resolveColor(value)}

--- a/src/stories/02-DesignTokens/Color/index.tsx
+++ b/src/stories/02-DesignTokens/Color/index.tsx
@@ -9,7 +9,7 @@ import type { Theme } from '@mui/material/styles'
 // styled-components
 const TextStyled = styled(Typography)(() => ({
   fontSize: 14,
-  fontWeight: 500,
+  fontWeight: 400,
 }))
 
 const BoxStyled = styled('div')(() => ({

--- a/src/stories/02-DesignTokens/DarkMode.stories.tsx
+++ b/src/stories/02-DesignTokens/DarkMode.stories.tsx
@@ -181,8 +181,8 @@ function TokenPanel({
                 <Typography
                   sx={{
                     fontFamily: 'monospace',
-                    fontSize: '0.75rem',
-                    fontWeight: 600,
+                    fontSize: '0.86rem',
+                    fontWeight: 700,
                     lineHeight: 1.3,
                   }}>
                   {token.label}
@@ -190,7 +190,7 @@ function TokenPanel({
                 <Typography
                   sx={{
                     fontFamily: 'monospace',
-                    fontSize: '0.7rem',
+                    fontSize: '0.86rem',
                     color: 'text.secondary',
                     lineHeight: 1.3,
                   }}>
@@ -279,7 +279,7 @@ function ComponentShowcase() {
     <Stack spacing={3}>
       {/* ボタン */}
       <Box>
-        <Typography sx={{ fontSize: '0.8rem', fontWeight: 600, mb: 1.5 }}>
+        <Typography sx={{ fontSize: '0.86rem', fontWeight: 700, mb: 1.5 }}>
           Button
         </Typography>
         <Stack direction='row' spacing={2} sx={{ flexWrap: 'wrap', gap: 1 }}>
@@ -290,7 +290,7 @@ function ComponentShowcase() {
 
       {/* チップ */}
       <Box>
-        <Typography sx={{ fontSize: '0.8rem', fontWeight: 600, mb: 1.5 }}>
+        <Typography sx={{ fontSize: '0.86rem', fontWeight: 700, mb: 1.5 }}>
           Chip
         </Typography>
         <Stack direction='row' spacing={1} sx={{ flexWrap: 'wrap', gap: 1 }}>
@@ -301,7 +301,7 @@ function ComponentShowcase() {
 
       {/* アラート */}
       <Box>
-        <Typography sx={{ fontSize: '0.8rem', fontWeight: 600, mb: 1.5 }}>
+        <Typography sx={{ fontSize: '0.86rem', fontWeight: 700, mb: 1.5 }}>
           Alert
         </Typography>
         <Stack spacing={1}>
@@ -314,7 +314,7 @@ function ComponentShowcase() {
 
       {/* テキストフィールド */}
       <Box>
-        <Typography sx={{ fontSize: '0.8rem', fontWeight: 600, mb: 1.5 }}>
+        <Typography sx={{ fontSize: '0.86rem', fontWeight: 700, mb: 1.5 }}>
           TextField
         </Typography>
         <TextField
@@ -327,7 +327,7 @@ function ComponentShowcase() {
 
       {/* カード */}
       <Box>
-        <Typography sx={{ fontSize: '0.8rem', fontWeight: 600, mb: 1.5 }}>
+        <Typography sx={{ fontSize: '0.86rem', fontWeight: 700, mb: 1.5 }}>
           Card
         </Typography>
         <Card>
@@ -341,7 +341,7 @@ function ComponentShowcase() {
 
       {/* スイッチ */}
       <Box>
-        <Typography sx={{ fontSize: '0.8rem', fontWeight: 600, mb: 1.5 }}>
+        <Typography sx={{ fontSize: '0.86rem', fontWeight: 700, mb: 1.5 }}>
           Switch
         </Typography>
         <Stack direction='row' spacing={2} sx={{ alignItems: 'center' }}>
@@ -352,7 +352,7 @@ function ComponentShowcase() {
 
       {/* プログレスバー */}
       <Box>
-        <Typography sx={{ fontSize: '0.8rem', fontWeight: 600, mb: 1.5 }}>
+        <Typography sx={{ fontSize: '0.86rem', fontWeight: 700, mb: 1.5 }}>
           LinearProgress
         </Typography>
         <LinearProgress variant='determinate' value={65} />
@@ -447,13 +447,13 @@ function SurfacePanel({ label }: { label: string }) {
               alignItems: 'center',
               justifyContent: 'space-between',
             }}>
-            <Typography sx={{ fontSize: '0.85rem', fontWeight: 600 }}>
+            <Typography sx={{ fontSize: '0.86rem', fontWeight: 700 }}>
               elevation={level}
             </Typography>
             <Typography
               sx={{
                 fontFamily: 'monospace',
-                fontSize: '0.7rem',
+                fontSize: '0.86rem',
                 color: 'text.secondary',
               }}>
               Paper

--- a/src/stories/02-DesignTokens/Logo.stories.tsx
+++ b/src/stories/02-DesignTokens/Logo.stories.tsx
@@ -67,7 +67,7 @@ const Swatch = ({
       }}>
       {children}
     </Box>
-    <Typography variant='body2' sx={{ fontWeight: 600 }}>
+    <Typography variant='body2' sx={{ fontWeight: 700 }}>
       {label}
     </Typography>
     {note && (
@@ -325,7 +325,7 @@ const ProhibitionsContent = () => (
     </Grid>
 
     <Box sx={{ mt: 6 }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
         やってはいけない例
       </Typography>
       <Grid container spacing={4}>
@@ -360,7 +360,7 @@ const ProhibitionsContent = () => (
             </Box>
             <Typography
               variant='caption'
-              sx={{ color: 'error.textContrast', fontWeight: 600 }}>
+              sx={{ color: 'error.textContrast', fontWeight: 700 }}>
               × {label}
             </Typography>
           </Grid>

--- a/src/stories/02-DesignTokens/Motion.stories.tsx
+++ b/src/stories/02-DesignTokens/Motion.stories.tsx
@@ -117,7 +117,7 @@ const EasingCurveCard = ({
       <Stack spacing={2}>
         {/* ヘッダー */}
         <Box>
-          <Typography variant='h6' sx={{ fontWeight: 600 }}>
+          <Typography variant='h6' sx={{ fontWeight: 700 }}>
             {name}
           </Typography>
           <Typography variant='body2' color='text.secondary'>
@@ -128,7 +128,7 @@ const EasingCurveCard = ({
             sx={{
               fontFamily: 'monospace',
               color: 'primary.main',
-              fontWeight: 600,
+              fontWeight: 700,
               display: 'block',
               mt: 0.5,
             }}>
@@ -203,7 +203,7 @@ const EasingCurveCard = ({
               x={svgWidth / 2}
               y={svgHeight - 2}
               textAnchor='middle'
-              fontSize='10'
+              fontSize='12'
               fill={theme.palette.text.secondary}>
               時間
             </text>
@@ -211,7 +211,7 @@ const EasingCurveCard = ({
               x={4}
               y={svgHeight / 2}
               textAnchor='middle'
-              fontSize='10'
+              fontSize='12'
               fill={theme.palette.text.secondary}
               transform={`rotate(-90, 8, ${svgHeight / 2})`}>
               進捗
@@ -363,7 +363,7 @@ const EasingCurves = () => {
           borderColor: 'divider',
           borderRadius: 3,
         }}>
-        <Typography variant='h6' sx={{ fontWeight: 600, mb: 0.5 }}>
+        <Typography variant='h6' sx={{ fontWeight: 700, mb: 0.5 }}>
           イージング値一覧 (CSS)
         </Typography>
         <Typography variant='body2' color='text.secondary' sx={{ mb: 2 }}>
@@ -389,7 +389,7 @@ const EasingCurves = () => {
             <Box key={group}>
               <Typography
                 variant='subtitle2'
-                sx={{ fontWeight: 600, mb: 0.25 }}>
+                sx={{ fontWeight: 700, mb: 0.25 }}>
                 {group}
               </Typography>
               <Typography
@@ -419,7 +419,7 @@ const EasingCurves = () => {
                     />
                     <Typography
                       variant='body2'
-                      sx={{ fontFamily: 'monospace', fontWeight: 500 }}>
+                      sx={{ fontFamily: 'monospace', fontWeight: 400 }}>
                       {easings[key]}
                     </Typography>
                   </Box>
@@ -472,7 +472,7 @@ const DurationBar = ({
         sx={{ minWidth: 120, display: 'flex', alignItems: 'center', gap: 1 }}>
         <Typography
           variant='body2'
-          sx={{ fontWeight: 600, fontFamily: 'monospace' }}>
+          sx={{ fontWeight: 700, fontFamily: 'monospace' }}>
           {durationMs}ms
         </Typography>
         {isFromTheme && (
@@ -527,9 +527,9 @@ const DurationBar = ({
             top: '50%',
             transform: 'translateY(-50%)',
             fontFamily: 'monospace',
-            fontWeight: 600,
+            fontWeight: 700,
             color: 'text.secondary',
-            fontSize: '0.7rem',
+            fontSize: '0.86rem',
             zIndex: 1,
             mixBlendMode: 'difference',
           }}>
@@ -610,7 +610,7 @@ const DurationScale = () => {
           borderColor: 'divider',
           borderRadius: 3,
         }}>
-        <Typography variant='h6' sx={{ fontWeight: 600, mb: 2 }}>
+        <Typography variant='h6' sx={{ fontWeight: 700, mb: 2 }}>
           テーマ定義値
         </Typography>
         <Grid container spacing={2}>
@@ -634,7 +634,7 @@ const DurationScale = () => {
                 />
                 <Typography
                   variant='body2'
-                  sx={{ fontFamily: 'monospace', fontWeight: 600 }}>
+                  sx={{ fontFamily: 'monospace', fontWeight: 700 }}>
                   {value}ms
                 </Typography>
               </Box>
@@ -734,7 +734,7 @@ const InteractiveDemo = () => {
               borderColor: 'divider',
               borderRadius: 3,
             }}>
-            <Typography variant='h6' sx={{ fontWeight: 600, mb: 3 }}>
+            <Typography variant='h6' sx={{ fontWeight: 700, mb: 3 }}>
               設定
             </Typography>
 
@@ -749,13 +749,13 @@ const InteractiveDemo = () => {
                   {Object.entries(easingOptions).map(([key, value]) => (
                     <MenuItem key={key} value={key}>
                       <Box>
-                        <Typography variant='body2' sx={{ fontWeight: 600 }}>
+                        <Typography variant='body2' sx={{ fontWeight: 700 }}>
                           {key}
                         </Typography>
                         <Typography
                           variant='caption'
                           color='text.secondary'
-                          sx={{ fontFamily: 'monospace', fontSize: '0.65rem' }}>
+                          sx={{ fontFamily: 'monospace', fontSize: '0.86rem' }}>
                           {value}
                         </Typography>
                       </Box>
@@ -799,7 +799,7 @@ const InteractiveDemo = () => {
                   variant='body2'
                   sx={{
                     fontFamily: 'monospace',
-                    fontWeight: 600,
+                    fontWeight: 700,
                     color: 'primary.main',
                     wordBreak: 'break-all',
                   }}>
@@ -841,7 +841,7 @@ const InteractiveDemo = () => {
                 borderColor: 'divider',
                 borderRadius: 3,
               }}>
-              <Typography variant='h6' sx={{ fontWeight: 600, mb: 2 }}>
+              <Typography variant='h6' sx={{ fontWeight: 700, mb: 2 }}>
                 横移動
               </Typography>
               <Box
@@ -900,7 +900,7 @@ const InteractiveDemo = () => {
                 borderColor: 'divider',
                 borderRadius: 3,
               }}>
-              <Typography variant='h6' sx={{ fontWeight: 600, mb: 2 }}>
+              <Typography variant='h6' sx={{ fontWeight: 700, mb: 2 }}>
                 スケール変化
               </Typography>
               <Box
@@ -940,7 +940,7 @@ const InteractiveDemo = () => {
                 borderColor: 'divider',
                 borderRadius: 3,
               }}>
-              <Typography variant='h6' sx={{ fontWeight: 600, mb: 2 }}>
+              <Typography variant='h6' sx={{ fontWeight: 700, mb: 2 }}>
                 フェード
               </Typography>
               <Box
@@ -971,7 +971,7 @@ const InteractiveDemo = () => {
                   }}>
                   <Typography
                     variant='caption'
-                    sx={{ color: 'white', fontWeight: 600 }}>
+                    sx={{ color: 'white', fontWeight: 700 }}>
                     Fade In
                   </Typography>
                 </Box>
@@ -988,7 +988,7 @@ const InteractiveDemo = () => {
                 borderColor: 'divider',
                 borderRadius: 3,
               }}>
-              <Typography variant='h6' sx={{ fontWeight: 600, mb: 2 }}>
+              <Typography variant='h6' sx={{ fontWeight: 700, mb: 2 }}>
                 イージング比較 (同一デュレーション: {selectedDuration}ms)
               </Typography>
               <Stack spacing={2}>
@@ -997,7 +997,7 @@ const InteractiveDemo = () => {
                     <Typography
                       variant='caption'
                       color='text.secondary'
-                      sx={{ fontWeight: 600, mb: 0.5, display: 'block' }}>
+                      sx={{ fontWeight: 700, mb: 0.5, display: 'block' }}>
                       {key}
                     </Typography>
                     <Box

--- a/src/stories/02-DesignTokens/Shadows.stories.tsx
+++ b/src/stories/02-DesignTokens/Shadows.stories.tsx
@@ -93,7 +93,7 @@ const ShadowValue = ({ level }: { level: number }) => {
         variant='caption'
         sx={{
           fontFamily: 'monospace',
-          fontSize: '0.7rem',
+          fontSize: '0.86rem',
           lineHeight: 1.6,
           wordBreak: 'break-all',
           color: 'text.secondary',
@@ -257,7 +257,7 @@ const AssignmentPanel = ({
         border: '1px solid',
         borderColor: 'divider',
       }}>
-      <Typography variant='body2' sx={{ fontWeight: 600, mb: 1 }}>
+      <Typography variant='body2' sx={{ fontWeight: 700, mb: 1 }}>
         {assignment.description}
       </Typography>
       <Typography
@@ -302,7 +302,7 @@ const ComponentElevationContent = () => {
       <Stack spacing={6}>
         {/* Card */}
         <Box>
-          <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+          <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
             Card
           </Typography>
           <Grid container spacing={4}>
@@ -325,7 +325,7 @@ const ComponentElevationContent = () => {
 
         {/* Dialog */}
         <Box>
-          <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+          <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
             Dialog
           </Typography>
           <Grid container spacing={4}>
@@ -348,7 +348,7 @@ const ComponentElevationContent = () => {
                     borderBottom: '1px solid',
                     borderColor: 'divider',
                   }}>
-                  <Typography variant='h6' sx={{ fontWeight: 600 }}>
+                  <Typography variant='h6' sx={{ fontWeight: 700 }}>
                     ダイアログタイトル
                   </Typography>
                 </Box>
@@ -385,7 +385,7 @@ const ComponentElevationContent = () => {
 
         {/* Menu */}
         <Box>
-          <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+          <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
             Menu
           </Typography>
           <Grid container spacing={4}>
@@ -427,7 +427,7 @@ const ComponentElevationContent = () => {
 
         {/* Paper */}
         <Box>
-          <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+          <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
             Paper
           </Typography>
           <Grid container spacing={4}>
@@ -450,7 +450,7 @@ const ComponentElevationContent = () => {
 
         {/* Tooltip */}
         <Box>
-          <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+          <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
             Tooltip
           </Typography>
           <Grid container spacing={4}>
@@ -549,7 +549,7 @@ const BorderRadiusContent = () => {
               <Box sx={{ textAlign: 'center' }}>
                 <Typography
                   variant='body2'
-                  sx={{ fontWeight: 600, fontFamily: 'monospace', mb: 0.5 }}>
+                  sx={{ fontWeight: 700, fontFamily: 'monospace', mb: 0.5 }}>
                   borderRadius: {item.value}
                 </Typography>
                 <Typography variant='caption' color='text.secondary'>
@@ -563,7 +563,7 @@ const BorderRadiusContent = () => {
 
       {/* 比較バー */}
       <Box sx={{ mt: 8 }}>
-        <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+        <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
           横並び比較
         </Typography>
         <Stack
@@ -595,7 +595,7 @@ const BorderRadiusContent = () => {
               />
               <Typography
                 variant='caption'
-                sx={{ fontFamily: 'monospace', fontWeight: 600 }}>
+                sx={{ fontFamily: 'monospace', fontWeight: 700 }}>
                 {item.label}
               </Typography>
             </Box>
@@ -641,7 +641,7 @@ const ElevationRows = () => {
             <Typography
               variant='body2'
               color='text.primary'
-              sx={{ fontWeight: 600 }}>
+              sx={{ fontWeight: 700 }}>
               {label}
             </Typography>
             <Typography
@@ -695,7 +695,7 @@ const ShadowComparisonContent = () => (
     <Grid container spacing={4}>
       {/* Lightモード */}
       <Grid size={{ xs: 12, md: 6 }}>
-        <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+        <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
           Light Mode
         </Typography>
         <ThemeProvider theme={lightTheme}>
@@ -714,7 +714,7 @@ const ShadowComparisonContent = () => (
 
       {/* Darkモード */}
       <Grid size={{ xs: 12, md: 6 }}>
-        <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+        <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
           Dark Mode
         </Typography>
         <ThemeProvider theme={darkTheme}>
@@ -734,7 +734,7 @@ const ShadowComparisonContent = () => (
 
     {/* コンポーネント比較 */}
     <Box sx={{ mt: 8 }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
         コンポーネントの見え方比較
       </Typography>
       <Grid container spacing={4}>
@@ -751,7 +751,7 @@ const ShadowComparisonContent = () => (
               <Typography
                 variant='subtitle2'
                 color='text.secondary'
-                sx={{ fontWeight: 600, mb: 2 }}>
+                sx={{ fontWeight: 700, mb: 2 }}>
                 Light
               </Typography>
               <SampleCard />
@@ -772,7 +772,7 @@ const ShadowComparisonContent = () => (
               <Typography
                 variant='subtitle2'
                 color='text.secondary'
-                sx={{ fontWeight: 600, mb: 2 }}>
+                sx={{ fontWeight: 700, mb: 2 }}>
                 Dark
               </Typography>
               <SampleCard />
@@ -784,7 +784,7 @@ const ShadowComparisonContent = () => (
 
     {/* 設計指針 */}
     <Box sx={{ mt: 8 }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
         設計指針
       </Typography>
       <Grid container spacing={3}>
@@ -825,7 +825,7 @@ const ShadowComparisonContent = () => (
               elevation={0}
               variant='outlined'
               sx={{ p: 3, borderRadius: 2, height: '100%' }}>
-              <Typography variant='subtitle2' sx={{ fontWeight: 600, mb: 1 }}>
+              <Typography variant='subtitle2' sx={{ fontWeight: 700, mb: 1 }}>
                 {item.title}
               </Typography>
               <Typography variant='body2' color='text.secondary'>

--- a/src/stories/02-DesignTokens/Spacing.stories.tsx
+++ b/src/stories/02-DesignTokens/Spacing.stories.tsx
@@ -71,18 +71,18 @@ const SpacingScaleShowcase = () => {
             borderBottom: '1px solid',
             borderColor: 'divider',
           }}>
-          <Typography variant='caption' sx={{ fontWeight: 600, minWidth: 100 }}>
+          <Typography variant='caption' sx={{ fontWeight: 700, minWidth: 100 }}>
             トークン
           </Typography>
-          <Typography variant='caption' sx={{ fontWeight: 600, minWidth: 80 }}>
+          <Typography variant='caption' sx={{ fontWeight: 700, minWidth: 80 }}>
             ピクセル値
           </Typography>
-          <Typography variant='caption' sx={{ fontWeight: 600, flex: 1 }}>
+          <Typography variant='caption' sx={{ fontWeight: 700, flex: 1 }}>
             ビジュアル
           </Typography>
           <Typography
             variant='caption'
-            sx={{ fontWeight: 600, minWidth: 180, textAlign: 'right' }}>
+            sx={{ fontWeight: 700, minWidth: 180, textAlign: 'right' }}>
             使用場面
           </Typography>
         </Box>
@@ -106,7 +106,7 @@ const SpacingScaleShowcase = () => {
                 variant='body2'
                 sx={{
                   fontFamily: 'monospace',
-                  fontWeight: 600,
+                  fontWeight: 700,
                   minWidth: 100,
                   color: 'primary.main',
                 }}>
@@ -167,8 +167,8 @@ const SpacingUsageShowcase = () => {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    fontSize: '0.75rem',
-    fontWeight: 600,
+    fontSize: '0.86rem',
+    fontWeight: 700,
     minHeight: 32,
   }
 
@@ -184,7 +184,7 @@ const SpacingUsageShowcase = () => {
       <Grid container spacing={4}>
         {/* パディング比較 */}
         <Grid size={{ xs: 12, md: 6 }}>
-          <Typography variant='h5' sx={{ fontWeight: 600, mb: 2 }}>
+          <Typography variant='h5' sx={{ fontWeight: 700, mb: 2 }}>
             Padding
           </Typography>
           <Stack spacing={2}>
@@ -211,7 +211,7 @@ const SpacingUsageShowcase = () => {
 
         {/* ギャップ比較 */}
         <Grid size={{ xs: 12, md: 6 }}>
-          <Typography variant='h5' sx={{ fontWeight: 600, mb: 2 }}>
+          <Typography variant='h5' sx={{ fontWeight: 700, mb: 2 }}>
             Gap (Stack spacing)
           </Typography>
           <Stack spacing={3}>
@@ -275,7 +275,7 @@ const LayoutPatternsShowcase = () => {
         alignItems: 'center',
         justifyContent: 'center',
       }}>
-      <Typography variant='caption' sx={{ fontWeight: 500 }}>
+      <Typography variant='caption' sx={{ fontWeight: 400 }}>
         {label}
       </Typography>
     </Box>
@@ -293,7 +293,7 @@ const LayoutPatternsShowcase = () => {
       <Grid container spacing={4}>
         {/* カードレイアウト */}
         <Grid size={{ xs: 12, md: 6 }}>
-          <Typography variant='h5' sx={{ fontWeight: 600, mb: 2 }}>
+          <Typography variant='h5' sx={{ fontWeight: 700, mb: 2 }}>
             カード内レイアウト
           </Typography>
           <Paper
@@ -312,7 +312,7 @@ const LayoutPatternsShowcase = () => {
                 justifyContent='space-between'
                 alignItems='center'>
                 <Box>
-                  <Typography variant='body2' sx={{ fontWeight: 600 }}>
+                  <Typography variant='body2' sx={{ fontWeight: 700 }}>
                     カードヘッダー
                   </Typography>
                   <Typography variant='caption' color='text.secondary'>
@@ -355,13 +355,13 @@ const LayoutPatternsShowcase = () => {
 
         {/* フォームレイアウト */}
         <Grid size={{ xs: 12, md: 6 }}>
-          <Typography variant='h5' sx={{ fontWeight: 600, mb: 2 }}>
+          <Typography variant='h5' sx={{ fontWeight: 700, mb: 2 }}>
             フォームレイアウト
           </Typography>
           <Paper variant='outlined' sx={{ p: 5, borderRadius: 2 }}>
             <Stack spacing={4}>
               <Box>
-                <Typography variant='body2' sx={{ fontWeight: 500, mb: 1 }}>
+                <Typography variant='body2' sx={{ fontWeight: 400, mb: 1 }}>
                   ラベル
                 </Typography>
                 <Placeholder label='入力フィールド' height={40} />
@@ -373,13 +373,13 @@ const LayoutPatternsShowcase = () => {
                 </Typography>
               </Box>
               <Box>
-                <Typography variant='body2' sx={{ fontWeight: 500, mb: 1 }}>
+                <Typography variant='body2' sx={{ fontWeight: 400, mb: 1 }}>
                   ラベル
                 </Typography>
                 <Placeholder label='入力フィールド' height={40} />
               </Box>
               <Box>
-                <Typography variant='body2' sx={{ fontWeight: 500, mb: 1 }}>
+                <Typography variant='body2' sx={{ fontWeight: 400, mb: 1 }}>
                   ラベル
                 </Typography>
                 <Placeholder label='テキストエリア' height={80} />
@@ -396,7 +396,7 @@ const LayoutPatternsShowcase = () => {
 
         {/* セクション間隔 */}
         <Grid size={{ xs: 12 }}>
-          <Typography variant='h5' sx={{ fontWeight: 600, mb: 2 }}>
+          <Typography variant='h5' sx={{ fontWeight: 700, mb: 2 }}>
             セクション間隔の推奨値
           </Typography>
           <Paper variant='outlined' sx={{ p: 4, borderRadius: 2 }}>
@@ -453,7 +453,7 @@ const LayoutPatternsShowcase = () => {
                   />
                   <Typography
                     variant='body2'
-                    sx={{ fontWeight: 600, minWidth: 180 }}>
+                    sx={{ fontWeight: 700, minWidth: 180 }}>
                     {label}
                   </Typography>
                   <Typography variant='body2' color='text.secondary'>

--- a/src/stories/02-DesignTokens/TokenList.stories.tsx
+++ b/src/stories/02-DesignTokens/TokenList.stories.tsx
@@ -65,12 +65,12 @@ const TokenOverview = () => {
           <Paper
             variant='outlined'
             sx={{ p: 4, borderRadius: 2, height: '100%' }}>
-            <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+            <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
               カラーパレット
             </Typography>
 
             {/* セマンティックカラー */}
-            <Typography variant='body2' sx={{ fontWeight: 600, mb: 1.5 }}>
+            <Typography variant='body2' sx={{ fontWeight: 700, mb: 1.5 }}>
               セマンティックカラー
             </Typography>
             <Stack direction='row' spacing={1} sx={{ mb: 3 }} flexWrap='wrap'>
@@ -87,7 +87,7 @@ const TokenOverview = () => {
                   />
                   <Typography
                     variant='caption'
-                    sx={{ fontSize: '0.625rem', color: 'text.secondary' }}>
+                    sx={{ fontSize: '0.86rem', color: 'text.secondary' }}>
                     {c.name}
                   </Typography>
                 </Box>
@@ -95,7 +95,7 @@ const TokenOverview = () => {
             </Stack>
 
             {/* グレースケール */}
-            <Typography variant='body2' sx={{ fontWeight: 600, mb: 1.5 }}>
+            <Typography variant='body2' sx={{ fontWeight: 700, mb: 1.5 }}>
               グレースケール
             </Typography>
             <Stack direction='row' spacing={0.5} sx={{ mb: 3 }}>
@@ -113,7 +113,7 @@ const TokenOverview = () => {
             </Stack>
 
             {/* テキスト・背景 */}
-            <Typography variant='body2' sx={{ fontWeight: 600, mb: 1.5 }}>
+            <Typography variant='body2' sx={{ fontWeight: 700, mb: 1.5 }}>
               テキスト & 背景
             </Typography>
             <Stack direction='row' spacing={1}>
@@ -142,7 +142,7 @@ const TokenOverview = () => {
                   />
                   <Typography
                     variant='caption'
-                    sx={{ fontSize: '0.5625rem', color: 'text.secondary' }}>
+                    sx={{ fontSize: '0.86rem', color: 'text.secondary' }}>
                     {t.label}
                   </Typography>
                 </Box>
@@ -156,7 +156,7 @@ const TokenOverview = () => {
           <Paper
             variant='outlined'
             sx={{ p: 4, borderRadius: 2, height: '100%' }}>
-            <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+            <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
               タイポグラフィ
             </Typography>
 
@@ -165,7 +165,7 @@ const TokenOverview = () => {
                 <Typography variant='body2' color='text.secondary'>
                   フォントファミリー
                 </Typography>
-                <Typography variant='body2' sx={{ fontWeight: 500 }}>
+                <Typography variant='body2' sx={{ fontWeight: 400 }}>
                   Inter, Noto Sans JP
                 </Typography>
               </Box>
@@ -175,7 +175,7 @@ const TokenOverview = () => {
                 </Typography>
                 <Typography
                   variant='body2'
-                  sx={{ fontWeight: 500, fontFamily: 'monospace' }}>
+                  sx={{ fontWeight: 400, fontFamily: 'monospace' }}>
                   {typographyOptions.fontSize}px
                 </Typography>
               </Box>
@@ -185,7 +185,7 @@ const TokenOverview = () => {
                 </Typography>
                 <Typography
                   variant='body2'
-                  sx={{ fontWeight: 500, fontFamily: 'monospace' }}>
+                  sx={{ fontWeight: 400, fontFamily: 'monospace' }}>
                   12px
                 </Typography>
               </Box>
@@ -193,7 +193,7 @@ const TokenOverview = () => {
 
             <Divider sx={{ my: 2 }} />
 
-            <Typography variant='body2' sx={{ fontWeight: 600, mb: 1.5 }}>
+            <Typography variant='body2' sx={{ fontWeight: 700, mb: 1.5 }}>
               サイズスケール
             </Typography>
             <Stack spacing={0.5}>
@@ -245,7 +245,7 @@ const TokenOverview = () => {
           <Paper
             variant='outlined'
             sx={{ p: 4, borderRadius: 2, height: '100%' }}>
-            <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+            <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
               スペーシング
             </Typography>
 
@@ -288,7 +288,7 @@ const TokenOverview = () => {
           <Paper
             variant='outlined'
             sx={{ p: 4, borderRadius: 2, height: '100%' }}>
-            <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+            <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
               エレベーション
             </Typography>
 
@@ -324,7 +324,7 @@ const TokenOverview = () => {
 
             <Divider sx={{ my: 3 }} />
 
-            <Typography variant='body2' sx={{ fontWeight: 600, mb: 1.5 }}>
+            <Typography variant='body2' sx={{ fontWeight: 700, mb: 1.5 }}>
               角丸
             </Typography>
             <Stack direction='row' spacing={1.5}>
@@ -340,7 +340,7 @@ const TokenOverview = () => {
                   />
                   <Typography
                     variant='caption'
-                    sx={{ fontFamily: 'monospace', fontSize: '0.625rem' }}>
+                    sx={{ fontFamily: 'monospace', fontSize: '0.86rem' }}>
                     {r}px
                   </Typography>
                 </Box>
@@ -354,7 +354,7 @@ const TokenOverview = () => {
           <Paper
             variant='outlined'
             sx={{ p: 4, borderRadius: 2, height: '100%' }}>
-            <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+            <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
               ブレークポイント
             </Typography>
 
@@ -363,7 +363,7 @@ const TokenOverview = () => {
                 <Box
                   key={name}
                   sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                  <Typography variant='body2' sx={{ fontWeight: 500 }}>
+                  <Typography variant='body2' sx={{ fontWeight: 400 }}>
                     {name}
                   </Typography>
                   <Typography
@@ -377,7 +377,7 @@ const TokenOverview = () => {
 
             <Divider sx={{ my: 2 }} />
 
-            <Typography variant='body2' sx={{ fontWeight: 600, mb: 1.5 }}>
+            <Typography variant='body2' sx={{ fontWeight: 700, mb: 1.5 }}>
               コンテナ幅
             </Typography>
             <Stack spacing={0.5}>
@@ -397,7 +397,7 @@ const TokenOverview = () => {
 
             <Divider sx={{ my: 2 }} />
 
-            <Typography variant='body2' sx={{ fontWeight: 600, mb: 1.5 }}>
+            <Typography variant='body2' sx={{ fontWeight: 700, mb: 1.5 }}>
               タッチターゲット
             </Typography>
             <Stack direction='row' spacing={1.5}>
@@ -417,13 +417,13 @@ const TokenOverview = () => {
                     }}>
                     <Typography
                       variant='caption'
-                      sx={{ fontFamily: 'monospace', fontSize: '0.5625rem' }}>
+                      sx={{ fontFamily: 'monospace', fontSize: '0.86rem' }}>
                       {size}
                     </Typography>
                   </Box>
                   <Typography
                     variant='caption'
-                    sx={{ fontSize: '0.5625rem', color: 'text.secondary' }}>
+                    sx={{ fontSize: '0.86rem', color: 'text.secondary' }}>
                     {name}
                   </Typography>
                 </Box>

--- a/src/stories/02-DesignTokens/Typography/index.stories.tsx
+++ b/src/stories/02-DesignTokens/Typography/index.stories.tsx
@@ -96,7 +96,6 @@ const TypeScaleShowcase = () => {
     { variant: 'ml', label: 'ML', usage: '中表示 16px' },
     { variant: 'md', label: 'MD', usage: '標準 14px（基準）' },
     { variant: 'sm', label: 'SM', usage: '小 12px（最小本文）' },
-    { variant: 'xs', label: 'XS', usage: '最小 10px（特殊用途）' },
   ]
 
   const TypeRow = ({ variant, label, usage }: TypeRowProps) => {
@@ -129,7 +128,7 @@ const TypeScaleShowcase = () => {
         <Box sx={{ minWidth: 180, flexShrink: 0 }}>
           <Typography
             variant='body2'
-            sx={{ fontWeight: 600, color: 'text.primary', mb: 0.5 }}>
+            sx={{ fontWeight: 700, color: 'text.primary', mb: 0.5 }}>
             {label}
           </Typography>
           <Stack direction='row' spacing={1} flexWrap='wrap'>
@@ -184,7 +183,7 @@ const TypeScaleShowcase = () => {
       </Typography>
 
       {/* 見出しスケール */}
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 2 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 2 }}>
         見出し (Headings)
       </Typography>
       <Paper
@@ -196,7 +195,7 @@ const TypeScaleShowcase = () => {
       </Paper>
 
       {/* 本文・ユーティリティ */}
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 2 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 2 }}>
         本文・ユーティリティ (Body & Utility)
       </Typography>
       <Paper
@@ -208,7 +207,7 @@ const TypeScaleShowcase = () => {
       </Paper>
 
       {/* カスタムサイズ */}
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 2 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 2 }}>
         カスタムサイズバリアント
       </Typography>
       <Typography variant='body2' color='text.secondary' sx={{ mb: 2 }}>
@@ -233,27 +232,24 @@ export const Default: StoryObj = {
 // --- ストーリー2: フォントウェイト ---
 
 const FontWeightShowcase = () => {
+  // ウェイトは 2 値のみ。中間値（300 / 500 / 600 / 800）は廃止した。
+  //
+  // 以前は 5 段あったが、実装では 200/300/380/400/420/500/600/700/800/900 の
+  // 10 種類が 528 箇所に混在していた。段が多いほど「少し強調」に対する答えが
+  // 人によって変わり、レビューで判断できなくなる。
   const weights = [
-    {
-      value: 300,
-      label: 'Light',
-      token: 'fontWeightLight',
-      usage: '装飾テキスト',
-    },
     {
       value: 400,
       label: 'Regular',
       token: 'fontWeightRegular',
-      usage: '本文テキスト',
+      usage: '本文・ラベル・補助テキスト',
     },
     {
-      value: 500,
-      label: 'Medium',
-      token: 'fontWeightMedium',
-      usage: 'ラベル・強調',
+      value: 700,
+      label: 'Bold',
+      token: 'fontWeightBold',
+      usage: '見出し・強調',
     },
-    { value: 600, label: 'SemiBold', token: '-', usage: '見出し・重要ラベル' },
-    { value: 700, label: 'Bold', token: 'fontWeightBold', usage: '見出し' },
   ]
 
   const sampleText = '空を舞台に人とテクノロジーの調和で The quick brown fox'
@@ -282,7 +278,7 @@ const FontWeightShowcase = () => {
               '&:last-child': { borderBottom: 'none' },
             }}>
             <Box sx={{ minWidth: 140, flexShrink: 0 }}>
-              <Typography variant='body2' sx={{ fontWeight: 600 }}>
+              <Typography variant='body2' sx={{ fontWeight: 700 }}>
                 {w.label}
               </Typography>
               <Typography
@@ -349,7 +345,7 @@ const LineHeightShowcase = () => {
                 justifyContent='space-between'
                 alignItems='center'
                 sx={{ mb: 2 }}>
-                <Typography variant='body2' sx={{ fontWeight: 600 }}>
+                <Typography variant='body2' sx={{ fontWeight: 700 }}>
                   {lh.label}
                 </Typography>
                 <Chip label={lh.usage} size='small' variant='outlined' />
@@ -402,13 +398,13 @@ const SizeTokenTable = () => {
             borderBottom: '1px solid',
             borderColor: 'divider',
           }}>
-          <Typography variant='caption' sx={{ fontWeight: 600, minWidth: 120 }}>
+          <Typography variant='caption' sx={{ fontWeight: 700, minWidth: 120 }}>
             トークン名
           </Typography>
-          <Typography variant='caption' sx={{ fontWeight: 600, minWidth: 140 }}>
+          <Typography variant='caption' sx={{ fontWeight: 700, minWidth: 140 }}>
             rem値 (px換算)
           </Typography>
-          <Typography variant='caption' sx={{ fontWeight: 600, flex: 1 }}>
+          <Typography variant='caption' sx={{ fontWeight: 700, flex: 1 }}>
             プレビュー
           </Typography>
         </Box>
@@ -433,7 +429,7 @@ const SizeTokenTable = () => {
                 variant='body2'
                 sx={{
                   fontFamily: 'monospace',
-                  fontWeight: 600,
+                  fontWeight: 700,
                   minWidth: 120,
                   color: 'primary.main',
                 }}>
@@ -528,7 +524,7 @@ const FontFamilyShowcase = () => {
               justifyContent='space-between'
               alignItems='center'
               sx={{ mb: 2 }}>
-              <Typography variant='h5' sx={{ fontWeight: 600 }}>
+              <Typography variant='h5' sx={{ fontWeight: 700 }}>
                 {f.name}
               </Typography>
               <Chip

--- a/src/stories/02-DesignTokens/Typography/index.tsx
+++ b/src/stories/02-DesignTokens/Typography/index.tsx
@@ -146,7 +146,6 @@ const Typographies = () => {
       note: 'body2相当',
     },
     {
-      variant: 'xs',
       note: '最小サイズ（10px）。特殊用途のみ推奨',
     },
   ]

--- a/src/stories/03-Layout/Grid.stories.tsx
+++ b/src/stories/03-Layout/Grid.stories.tsx
@@ -40,8 +40,8 @@ const DemoItem = ({
       textAlign: 'center',
       bgcolor: 'primary.light',
       color: 'primary.contrastText',
-      fontWeight: 600,
-      fontSize: '0.857rem',
+      fontWeight: 700,
+      fontSize: '0.86rem',
       borderRadius: 1.5,
     }}>
     {children}
@@ -64,7 +64,7 @@ const BasicGridPlayground = ({
   const count = Math.ceil(12 / Math.max(1, columnSize))
   return (
     <Box sx={{ maxWidth: 1400, mx: 'auto' }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 1 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 1 }}>
         12カラムグリッドシステム
       </Typography>
       <Typography variant='body2' color='text.secondary' sx={{ mb: 1 }}>
@@ -131,7 +131,7 @@ const ResponsiveContent = () => {
 
   return (
     <Box sx={{ maxWidth: 1400, mx: 'auto' }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
         レスポンシブグリッド
       </Typography>
 
@@ -145,7 +145,7 @@ const ResponsiveContent = () => {
       <Stack spacing={5}>
         {/* パターン1: 1→2→4列 */}
         <Box>
-          <Typography variant='body2' sx={{ fontWeight: 600, mb: 1 }}>
+          <Typography variant='body2' sx={{ fontWeight: 700, mb: 1 }}>
             mobile: 1列 / tablet: 2列 / laptop: 4列
           </Typography>
           <Typography
@@ -169,7 +169,7 @@ const ResponsiveContent = () => {
 
         {/* パターン2: 1→2→3列 */}
         <Box>
-          <Typography variant='body2' sx={{ fontWeight: 600, mb: 1 }}>
+          <Typography variant='body2' sx={{ fontWeight: 700, mb: 1 }}>
             mobile: 1列 / tablet: 2列 / laptop: 3列
           </Typography>
           <Typography
@@ -193,7 +193,7 @@ const ResponsiveContent = () => {
 
         {/* パターン3: サイドバーレイアウト */}
         <Box>
-          <Typography variant='body2' sx={{ fontWeight: 600, mb: 1 }}>
+          <Typography variant='body2' sx={{ fontWeight: 700, mb: 1 }}>
             サイドバーレイアウト（mobile: スタック / tablet以上:
             サイドバー+メイン）
           </Typography>
@@ -248,7 +248,7 @@ const ResponsiveContent = () => {
 
       {/* ブレークポイント参照 */}
       <Box sx={{ mt: 6 }}>
-        <Typography variant='body2' sx={{ fontWeight: 600, mb: 2 }}>
+        <Typography variant='body2' sx={{ fontWeight: 700, mb: 2 }}>
           カスタムブレークポイント
         </Typography>
         <Paper variant='outlined' sx={{ p: 3, borderRadius: 2 }}>
@@ -257,7 +257,7 @@ const ResponsiveContent = () => {
               <Box
                 key={name}
                 sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                <Typography variant='body2' sx={{ fontWeight: 500 }}>
+                <Typography variant='body2' sx={{ fontWeight: 400 }}>
                   {name}
                 </Typography>
                 <Typography
@@ -292,7 +292,7 @@ const SpacingPlayground = ({ spacing, itemCount, columns }: SpacingArgs) => {
     1 | 2 | 3 | 4 | 6 | 12
   return (
     <Box sx={{ maxWidth: 1200, mx: 'auto' }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 1 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 1 }}>
         グリッドスペーシング
       </Typography>
       <Typography variant='body2' color='text.secondary' sx={{ mb: 1 }}>
@@ -358,7 +358,7 @@ export const Spacing: StoryObj<SpacingArgs> = {
 
 const NestedContent = () => (
   <Box sx={{ maxWidth: 1200, mx: 'auto' }}>
-    <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+    <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
       ネストされたグリッド
     </Typography>
 
@@ -367,7 +367,7 @@ const NestedContent = () => (
         <Paper
           variant='outlined'
           sx={{ p: 3, borderRadius: 2, height: '100%' }}>
-          <Typography variant='body2' sx={{ fontWeight: 600, mb: 2 }}>
+          <Typography variant='body2' sx={{ fontWeight: 700, mb: 2 }}>
             メインエリア（8カラム）
           </Typography>
           <Grid container spacing={2}>
@@ -383,7 +383,7 @@ const NestedContent = () => (
         <Paper
           variant='outlined'
           sx={{ p: 3, borderRadius: 2, height: '100%' }}>
-          <Typography variant='body2' sx={{ fontWeight: 600, mb: 2 }}>
+          <Typography variant='body2' sx={{ fontWeight: 700, mb: 2 }}>
             サイドエリア（4カラム）
           </Typography>
           <Grid container spacing={2}>

--- a/src/stories/04-Components/UI/Accordion/Accordion.stories.tsx
+++ b/src/stories/04-Components/UI/Accordion/Accordion.stories.tsx
@@ -37,7 +37,7 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   args: {
-    summary: <Typography fontWeight={500}>クリックして展開</Typography>,
+    summary: <Typography fontWeight={400}>クリックして展開</Typography>,
     details: (
       <Typography color='text.secondary'>
         アコーディオンの詳細コンテンツです。展開アイコンをクリックすることで表示されます。

--- a/src/stories/04-Components/UI/Card/Card.stories.tsx
+++ b/src/stories/04-Components/UI/Card/Card.stories.tsx
@@ -61,7 +61,7 @@ export default meta
 
 const BasicContent = () => (
   <Box sx={{ maxWidth: 1200, mx: 'auto' }}>
-    <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+    <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
       基本カード
     </Typography>
     <Typography variant='body2' color='text.secondary' sx={{ mb: 4 }}>
@@ -74,7 +74,7 @@ const BasicContent = () => (
       <Grid size={{ xs: 12, md: 4 }}>
         <Card>
           <CardContent>
-            <Typography variant='body2' sx={{ fontWeight: 600, mb: 1 }}>
+            <Typography variant='body2' sx={{ fontWeight: 700, mb: 1 }}>
               シンプルカード
             </Typography>
             <Typography variant='body2' color='text.secondary'>
@@ -166,7 +166,7 @@ const DeviceStatusContent = () => {
 
   return (
     <Box sx={{ maxWidth: 1200, mx: 'auto' }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
         配送ユニットステータスカード
       </Typography>
 
@@ -208,7 +208,7 @@ const DeviceStatusContent = () => {
                       </Stack>
                       <Typography
                         variant='caption'
-                        sx={{ fontFamily: 'monospace', fontWeight: 600 }}>
+                        sx={{ fontFamily: 'monospace', fontWeight: 700 }}>
                         {device.battery}%
                       </Typography>
                     </Stack>
@@ -239,7 +239,7 @@ const DeviceStatusContent = () => {
                           variant='caption'
                           sx={{
                             fontFamily: 'monospace',
-                            fontWeight: 600,
+                            fontWeight: 700,
                             display: 'block',
                           }}>
                           {device.remaining}km
@@ -247,7 +247,7 @@ const DeviceStatusContent = () => {
                         <Typography
                           variant='caption'
                           color='text.secondary'
-                          sx={{ fontSize: '0.625rem' }}>
+                          sx={{ fontSize: '0.86rem' }}>
                           残り距離
                         </Typography>
                       </Box>
@@ -269,7 +269,7 @@ const DeviceStatusContent = () => {
                           variant='caption'
                           sx={{
                             fontFamily: 'monospace',
-                            fontWeight: 600,
+                            fontWeight: 700,
                             display: 'block',
                           }}>
                           {device.speed}km/h
@@ -277,7 +277,7 @@ const DeviceStatusContent = () => {
                         <Typography
                           variant='caption'
                           color='text.secondary'
-                          sx={{ fontSize: '0.625rem' }}>
+                          sx={{ fontSize: '0.86rem' }}>
                           速度
                         </Typography>
                       </Box>
@@ -310,14 +310,14 @@ export const DeviceStatus: StoryObj = {
 
 const LayoutPatternsContent = () => (
   <Box sx={{ maxWidth: 1200, mx: 'auto' }}>
-    <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+    <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
       レイアウトパターン
     </Typography>
 
     <Stack spacing={4}>
       {/* ダッシュボードグリッド */}
       <Box>
-        <Typography variant='body2' sx={{ fontWeight: 600, mb: 2 }}>
+        <Typography variant='body2' sx={{ fontWeight: 700, mb: 2 }}>
           ダッシュボードグリッド
         </Typography>
         <Grid container spacing={3}>
@@ -342,7 +342,7 @@ const LayoutPatternsContent = () => (
                       color: stat.change.startsWith('+')
                         ? 'success.main'
                         : 'text.secondary',
-                      fontWeight: 500,
+                      fontWeight: 400,
                     }}>
                     {stat.change}
                   </Typography>
@@ -355,7 +355,7 @@ const LayoutPatternsContent = () => (
 
       {/* 横並びカード */}
       <Box>
-        <Typography variant='body2' sx={{ fontWeight: 600, mb: 2 }}>
+        <Typography variant='body2' sx={{ fontWeight: 700, mb: 2 }}>
           横レイアウトカード
         </Typography>
         <Card>
@@ -373,7 +373,7 @@ const LayoutPatternsContent = () => (
             </Box>
             <Box sx={{ flex: 1 }}>
               <CardContent>
-                <Typography variant='body2' sx={{ fontWeight: 600 }}>
+                <Typography variant='body2' sx={{ fontWeight: 700 }}>
                   タスクプラン TSK-2024-0042
                 </Typography>
                 <Typography

--- a/src/stories/04-Components/UI/Dialog/MuiDialog.stories.tsx
+++ b/src/stories/04-Components/UI/Dialog/MuiDialog.stories.tsx
@@ -56,7 +56,7 @@ const BasicContent = () => {
 
   return (
     <Box sx={{ maxWidth: 1200, mx: 'auto' }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
         基本ダイアログ
       </Typography>
       <Typography variant='body2' color='text.secondary' sx={{ mb: 4 }}>
@@ -129,7 +129,7 @@ const SizesContent = () => {
 
   return (
     <Box sx={{ maxWidth: 1200, mx: 'auto' }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
         サイズバリエーション
       </Typography>
       <Typography variant='body2' color='text.secondary' sx={{ mb: 4 }}>
@@ -191,7 +191,7 @@ const PracticalPatternsContent = () => {
 
   return (
     <Box sx={{ maxWidth: 1200, mx: 'auto' }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
         実践パターン
       </Typography>
       <Typography variant='body2' color='text.secondary' sx={{ mb: 4 }}>
@@ -209,7 +209,7 @@ const PracticalPatternsContent = () => {
               borderRadius: 2,
               textAlign: 'center',
             }}>
-            <Typography variant='body2' sx={{ fontWeight: 600, mb: 2 }}>
+            <Typography variant='body2' sx={{ fontWeight: 700, mb: 2 }}>
               削除確認
             </Typography>
             <Button
@@ -231,7 +231,7 @@ const PracticalPatternsContent = () => {
               borderRadius: 2,
               textAlign: 'center',
             }}>
-            <Typography variant='body2' sx={{ fontWeight: 600, mb: 2 }}>
+            <Typography variant='body2' sx={{ fontWeight: 700, mb: 2 }}>
               フォーム入力
             </Typography>
             <Button variant='contained' onClick={() => setFormOpen(true)}>
@@ -250,7 +250,7 @@ const PracticalPatternsContent = () => {
               borderRadius: 2,
               textAlign: 'center',
             }}>
-            <Typography variant='body2' sx={{ fontWeight: 600, mb: 2 }}>
+            <Typography variant='body2' sx={{ fontWeight: 700, mb: 2 }}>
               情報表示
             </Typography>
             <Button variant='outlined' onClick={() => setInfoOpen(true)}>
@@ -378,7 +378,7 @@ const PracticalPatternsContent = () => {
                 <Typography variant='body2' color='text.secondary'>
                   {item.label}
                 </Typography>
-                <Typography variant='body2' sx={{ fontWeight: 600 }}>
+                <Typography variant='body2' sx={{ fontWeight: 700 }}>
                   {item.value}
                 </Typography>
               </Stack>

--- a/src/stories/04-Components/UI/Drawer/Drawer.stories.tsx
+++ b/src/stories/04-Components/UI/Drawer/Drawer.stories.tsx
@@ -102,7 +102,7 @@ const AnchorsContent = () => {
           justifyContent: 'space-between',
           p: 2,
         }}>
-        <Typography variant='subtitle1' sx={{ fontWeight: 600 }}>
+        <Typography variant='subtitle1' sx={{ fontWeight: 700 }}>
           ナビゲーション
         </Typography>
         <IconButton
@@ -128,7 +128,7 @@ const AnchorsContent = () => {
 
   return (
     <Box sx={{ maxWidth: 800, mx: 'auto' }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
         表示位置
       </Typography>
       <Typography variant='body2' color='text.secondary' sx={{ mb: 3 }}>
@@ -173,7 +173,7 @@ const NavigationDrawerContent = () => {
 
   return (
     <Box sx={{ maxWidth: 900, mx: 'auto' }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
         ナビゲーションドロワー
       </Typography>
       <Typography variant='body2' color='text.secondary' sx={{ mb: 3 }}>
@@ -221,7 +221,7 @@ const NavigationDrawerContent = () => {
 
           {/* メインコンテンツ部分 */}
           <Box sx={{ flex: 1, p: 3, bgcolor: 'action.hover' }}>
-            <Typography variant='h6' sx={{ fontWeight: 600, mb: 1 }}>
+            <Typography variant='h6' sx={{ fontWeight: 700, mb: 1 }}>
               {navItems[selectedIndex].label}
             </Typography>
             <Typography variant='body2' color='text.secondary'>
@@ -248,7 +248,7 @@ const PracticalPatternsContent = () => {
 
   return (
     <Box sx={{ maxWidth: 900, mx: 'auto' }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
         実用パターン
       </Typography>
       <Typography variant='body2' color='text.secondary' sx={{ mb: 3 }}>
@@ -259,7 +259,7 @@ const PracticalPatternsContent = () => {
         {/* フィルタードロワー */}
         <Grid size={{ xs: 12, md: 6 }}>
           <Paper variant='outlined' sx={{ p: 3, borderRadius: 2 }}>
-            <Typography variant='body2' sx={{ fontWeight: 600, mb: 2 }}>
+            <Typography variant='body2' sx={{ fontWeight: 700, mb: 2 }}>
               フィルターパネル
             </Typography>
             <Typography
@@ -277,7 +277,7 @@ const PracticalPatternsContent = () => {
         {/* 詳細パネルドロワー */}
         <Grid size={{ xs: 12, md: 6 }}>
           <Paper variant='outlined' sx={{ p: 3, borderRadius: 2 }}>
-            <Typography variant='body2' sx={{ fontWeight: 600, mb: 2 }}>
+            <Typography variant='body2' sx={{ fontWeight: 700, mb: 2 }}>
               詳細情報パネル
             </Typography>
             <Typography
@@ -315,7 +315,7 @@ const PracticalPatternsContent = () => {
               borderBottom: 1,
               borderColor: 'divider',
             }}>
-            <Typography variant='subtitle1' sx={{ fontWeight: 600 }}>
+            <Typography variant='subtitle1' sx={{ fontWeight: 700 }}>
               フィルター条件
             </Typography>
             <IconButton
@@ -417,7 +417,7 @@ const PracticalPatternsContent = () => {
               borderBottom: 1,
               borderColor: 'divider',
             }}>
-            <Typography variant='subtitle1' sx={{ fontWeight: 600 }}>
+            <Typography variant='subtitle1' sx={{ fontWeight: 700 }}>
               リソース詳細
             </Typography>
             <IconButton
@@ -439,7 +439,7 @@ const PracticalPatternsContent = () => {
                   spacing={1}
                   sx={{ mb: 1.5 }}>
                   <AssignmentIcon color='primary' />
-                  <Typography variant='h6' sx={{ fontWeight: 600 }}>
+                  <Typography variant='h6' sx={{ fontWeight: 700 }}>
                     Device-Alpha
                   </Typography>
                 </Stack>
@@ -453,7 +453,7 @@ const PracticalPatternsContent = () => {
                 <Typography
                   variant='caption'
                   color='text.secondary'
-                  sx={{ fontWeight: 600, mb: 1, display: 'block' }}>
+                  sx={{ fontWeight: 700, mb: 1, display: 'block' }}>
                   基本情報
                 </Typography>
                 <Stack spacing={1.5}>
@@ -469,7 +469,7 @@ const PracticalPatternsContent = () => {
                       <Typography variant='body2' color='text.secondary'>
                         {row.label}
                       </Typography>
-                      <Typography variant='body2' sx={{ fontWeight: 500 }}>
+                      <Typography variant='body2' sx={{ fontWeight: 400 }}>
                         {row.value}
                       </Typography>
                     </Box>
@@ -484,7 +484,7 @@ const PracticalPatternsContent = () => {
                 <Typography
                   variant='caption'
                   color='text.secondary'
-                  sx={{ fontWeight: 600, mb: 1, display: 'block' }}>
+                  sx={{ fontWeight: 700, mb: 1, display: 'block' }}>
                   稼働情報
                 </Typography>
                 <Stack spacing={1.5}>
@@ -501,7 +501,7 @@ const PracticalPatternsContent = () => {
                       <Typography variant='body2' color='text.secondary'>
                         {row.label}
                       </Typography>
-                      <Typography variant='body2' sx={{ fontWeight: 500 }}>
+                      <Typography variant='body2' sx={{ fontWeight: 400 }}>
                         {row.value}
                       </Typography>
                     </Box>

--- a/src/stories/04-Components/UI/List/List.stories.tsx
+++ b/src/stories/04-Components/UI/List/List.stories.tsx
@@ -57,7 +57,7 @@ export default meta
 
 const BasicContent = () => (
   <Box sx={{ maxWidth: 1200, mx: 'auto' }}>
-    <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+    <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
       基本リスト
     </Typography>
 
@@ -69,7 +69,7 @@ const BasicContent = () => (
             variant='caption'
             sx={{
               fontFamily: 'monospace',
-              fontWeight: 600,
+              fontWeight: 700,
               display: 'block',
               p: 2,
               pb: 0,
@@ -100,7 +100,7 @@ const BasicContent = () => (
             variant='caption'
             sx={{
               fontFamily: 'monospace',
-              fontWeight: 600,
+              fontWeight: 700,
               display: 'block',
               p: 2,
               pb: 0,
@@ -137,7 +137,7 @@ const BasicContent = () => (
             variant='caption'
             sx={{
               fontFamily: 'monospace',
-              fontWeight: 600,
+              fontWeight: 700,
               display: 'block',
               p: 2,
               pb: 0,
@@ -183,7 +183,7 @@ const InteractiveContent = () => {
 
   return (
     <Box sx={{ maxWidth: 800, mx: 'auto' }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
         インタラクティブリスト
       </Typography>
 
@@ -192,7 +192,7 @@ const InteractiveContent = () => {
         <Grid size={{ xs: 12, md: 6 }}>
           <Paper variant='outlined' sx={{ borderRadius: 2 }}>
             <Box sx={{ p: 2, borderBottom: 1, borderColor: 'divider' }}>
-              <Typography variant='body2' sx={{ fontWeight: 600 }}>
+              <Typography variant='body2' sx={{ fontWeight: 700 }}>
                 ナビゲーション（選択状態）
               </Typography>
             </Box>
@@ -217,7 +217,7 @@ const InteractiveContent = () => {
         <Grid size={{ xs: 12, md: 6 }}>
           <Paper variant='outlined' sx={{ borderRadius: 2 }}>
             <Box sx={{ p: 2, borderBottom: 1, borderColor: 'divider' }}>
-              <Typography variant='body2' sx={{ fontWeight: 600 }}>
+              <Typography variant='body2' sx={{ fontWeight: 700 }}>
                 セカンダリアクション
               </Typography>
             </Box>
@@ -287,7 +287,7 @@ const SettingsContent = () => {
 
   return (
     <Box sx={{ maxWidth: 500, mx: 'auto' }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
         設定リスト
       </Typography>
 

--- a/src/stories/04-Components/UI/Menu/Menu.stories.tsx
+++ b/src/stories/04-Components/UI/Menu/Menu.stories.tsx
@@ -80,7 +80,7 @@ const BasicContent = () => {
 
   return (
     <Box sx={{ maxWidth: 600, mx: 'auto' }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
         基本メニュー
       </Typography>
 
@@ -114,7 +114,7 @@ const WithIconsContent = () => {
 
   return (
     <Box sx={{ maxWidth: 600, mx: 'auto' }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
         アイコン付きメニュー
       </Typography>
 
@@ -208,7 +208,7 @@ const PracticalContent = () => {
 
   return (
     <Box sx={{ maxWidth: 900, mx: 'auto' }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
         実用パターン
       </Typography>
 
@@ -216,7 +216,7 @@ const PracticalContent = () => {
         {/* 編集メニュー */}
         <Grid size={{ xs: 12, md: 6 }}>
           <Paper variant='outlined' sx={{ p: 3, borderRadius: 2 }}>
-            <Typography variant='body2' sx={{ fontWeight: 600, mb: 2 }}>
+            <Typography variant='body2' sx={{ fontWeight: 700, mb: 2 }}>
               編集メニュー
             </Typography>
             <Button
@@ -272,7 +272,7 @@ const PracticalContent = () => {
         {/* ユーザーアクション */}
         <Grid size={{ xs: 12, md: 6 }}>
           <Paper variant='outlined' sx={{ p: 3, borderRadius: 2 }}>
-            <Typography variant='body2' sx={{ fontWeight: 600, mb: 2 }}>
+            <Typography variant='body2' sx={{ fontWeight: 700, mb: 2 }}>
               ユーザーメニュー
             </Typography>
             <Button variant='text' onClick={contextMenu.handleClick}>
@@ -304,7 +304,7 @@ const PracticalContent = () => {
             <Typography
               variant='body2'
               sx={{
-                fontWeight: 600,
+                fontWeight: 700,
                 p: 2,
                 borderBottom: 1,
                 borderColor: 'divider',

--- a/src/stories/04-Components/UI/Paper/Paper.stories.tsx
+++ b/src/stories/04-Components/UI/Paper/Paper.stories.tsx
@@ -33,7 +33,7 @@ export const Default: StoryObj<typeof Paper> = {
   },
   render: (args) => (
     <Paper {...args} sx={{ p: 4, maxWidth: 400 }}>
-      <Typography variant='body2' sx={{ fontWeight: 600, mb: 1 }}>
+      <Typography variant='body2' sx={{ fontWeight: 700, mb: 1 }}>
         Paper コンテンツ
       </Typography>
       <Typography variant='body2' color='text.secondary'>

--- a/src/stories/04-Components/UI/Snackbar/Snackbar.stories.tsx
+++ b/src/stories/04-Components/UI/Snackbar/Snackbar.stories.tsx
@@ -65,7 +65,7 @@ const BasicContent = () => {
 
   return (
     <Box sx={{ maxWidth: 1200, mx: 'auto' }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
         基本のSnackbar
       </Typography>
       <Typography variant='body2' color='text.secondary' sx={{ mb: 4 }}>
@@ -144,7 +144,7 @@ const WithAlertContent = () => {
 
   return (
     <Box sx={{ maxWidth: 1200, mx: 'auto' }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
         Alert付きSnackbar
       </Typography>
       <Typography variant='body2' color='text.secondary' sx={{ mb: 4 }}>
@@ -162,7 +162,7 @@ const WithAlertContent = () => {
                 textAlign: 'center',
                 borderRadius: 2,
               }}>
-              <Typography variant='body2' sx={{ fontWeight: 600, mb: 2 }}>
+              <Typography variant='body2' sx={{ fontWeight: 700, mb: 2 }}>
                 {v.label}
               </Typography>
               <Button
@@ -245,7 +245,7 @@ const PositionsContent = () => {
 
   return (
     <Box sx={{ maxWidth: 1200, mx: 'auto' }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
         表示位置
       </Typography>
       <Typography variant='body2' color='text.secondary' sx={{ mb: 4 }}>

--- a/src/stories/04-Components/UI/Table/ResourceTable.stories.tsx
+++ b/src/stories/04-Components/UI/Table/ResourceTable.stories.tsx
@@ -50,7 +50,7 @@ const sampleColumns: GridColDef<DeviceRow>[] = [
         <Box
           component='span'
           sx={{
-            fontWeight: 500,
+            fontWeight: 400,
             color: value < 30 ? 'error.main' : 'text.primary',
           }}>
           {value}%

--- a/src/stories/04-Components/UI/Table/Table.stories.tsx
+++ b/src/stories/04-Components/UI/Table/Table.stories.tsx
@@ -127,7 +127,7 @@ export const Default: StoryObj<typeof Table> = {
           {deviceRows.map((row) => (
             <TableRow key={row.id} hover>
               <TableCell>
-                <Typography variant='body2' fontWeight={500}>
+                <Typography variant='body2' fontWeight={400}>
                   {row.name}
                 </Typography>
                 <Typography variant='caption' color='text.secondary'>
@@ -152,7 +152,7 @@ export const Default: StoryObj<typeof Table> = {
                         : row.battery >= 30
                           ? 'warning.main'
                           : 'error.main',
-                    fontWeight: 600,
+                    fontWeight: 700,
                   }}>
                   {row.battery}%
                 </Typography>

--- a/src/stories/04-Components/UI/Text/Text.stories.tsx
+++ b/src/stories/04-Components/UI/Text/Text.stories.tsx
@@ -30,7 +30,6 @@ const meta: Meta<typeof PageTitle> = {
         'ml',
         'md',
         'sm',
-        'xs',
       ],
       description: 'タイトルサイズ',
     },

--- a/src/stories/05-Patterns/Dashboard.stories.tsx
+++ b/src/stories/05-Patterns/Dashboard.stories.tsx
@@ -114,7 +114,7 @@ function avatarIconColor(trend: StatCardItem['trend']): string {
 
 const StatCardsContent = () => (
   <Box sx={{ maxWidth: 1200, mx: 'auto' }}>
-    <Typography variant='h5' sx={{ fontWeight: 600, mb: 1 }}>
+    <Typography variant='h5' sx={{ fontWeight: 700, mb: 1 }}>
       KPI統計カード
     </Typography>
     <Typography variant='body2' color='text.secondary' sx={{ mb: 4 }}>
@@ -154,7 +154,7 @@ const StatCardsContent = () => (
                   </Typography>
                   <Typography
                     variant='caption'
-                    sx={{ color: trendColor(card.trend), fontWeight: 500 }}>
+                    sx={{ color: trendColor(card.trend), fontWeight: 400 }}>
                     {card.change}
                   </Typography>
                 </Box>
@@ -225,7 +225,7 @@ const activities: ActivityItem[] = [
 
 const ActivityFeedContent = () => (
   <Box sx={{ maxWidth: 640, mx: 'auto' }}>
-    <Typography variant='h5' sx={{ fontWeight: 600, mb: 1 }}>
+    <Typography variant='h5' sx={{ fontWeight: 700, mb: 1 }}>
       アクティビティフィード
     </Typography>
     <Typography variant='body2' color='text.secondary' sx={{ mb: 4 }}>
@@ -276,7 +276,7 @@ const ActivityFeedContent = () => (
                 secondary={item.secondary}
                 primaryTypographyProps={{
                   variant: 'body2',
-                  fontWeight: 500,
+                  fontWeight: 400,
                 }}
                 secondaryTypographyProps={{
                   variant: 'caption',
@@ -373,7 +373,7 @@ const schedules: ScheduleItem[] = [
 
 const FleetOverviewContent = () => (
   <Box sx={{ maxWidth: 1200, mx: 'auto' }}>
-    <Typography variant='h5' sx={{ fontWeight: 600, mb: 1 }}>
+    <Typography variant='h5' sx={{ fontWeight: 700, mb: 1 }}>
       車両概況
     </Typography>
     <Typography variant='body2' color='text.secondary' sx={{ mb: 4 }}>
@@ -403,7 +403,7 @@ const FleetOverviewContent = () => (
                     justifyContent='space-between'
                     sx={{ mb: 1 }}>
                     <Box>
-                      <Typography variant='body2' sx={{ fontWeight: 600 }}>
+                      <Typography variant='body2' sx={{ fontWeight: 700 }}>
                         {device.name}
                       </Typography>
                       <Typography variant='caption' color='text.secondary'>
@@ -447,7 +447,7 @@ const FleetOverviewContent = () => (
                       variant='caption'
                       sx={{
                         fontFamily: 'monospace',
-                        fontWeight: 600,
+                        fontWeight: 700,
                         minWidth: 36,
                         textAlign: 'right',
                       }}>
@@ -484,7 +484,7 @@ const FleetOverviewContent = () => (
                         width: 40,
                         height: 40,
                         fontWeight: 700,
-                        fontSize: '0.75rem',
+                        fontSize: '0.86rem',
                         fontFamily: 'monospace',
                       }}>
                       {item.time}
@@ -503,7 +503,7 @@ const FleetOverviewContent = () => (
                     }
                     primaryTypographyProps={{
                       variant: 'body2',
-                      fontWeight: 500,
+                      fontWeight: 400,
                     }}
                   />
                 </ListItem>

--- a/src/stories/05-Patterns/DataDisplay.stories.tsx
+++ b/src/stories/05-Patterns/DataDisplay.stories.tsx
@@ -302,7 +302,7 @@ const SearchableTableContent = () => {
 
   return (
     <Box sx={{ maxWidth: 1200, mx: 'auto' }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 1 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 1 }}>
         検索可能テーブル
       </Typography>
       <Typography variant='body2' color='text.secondary' sx={{ mb: 4 }}>
@@ -340,12 +340,12 @@ const SearchableTableContent = () => {
                   <TableCell>
                     <Typography
                       variant='body2'
-                      sx={{ fontFamily: 'monospace', fontWeight: 500 }}>
+                      sx={{ fontFamily: 'monospace', fontWeight: 400 }}>
                       {row.id}
                     </Typography>
                   </TableCell>
                   <TableCell>
-                    <Typography variant='body2' fontWeight={500}>
+                    <Typography variant='body2' fontWeight={400}>
                       {row.name}
                     </Typography>
                   </TableCell>
@@ -362,7 +362,7 @@ const SearchableTableContent = () => {
                       variant='body2'
                       sx={{
                         color: getBatteryColor(row.battery),
-                        fontWeight: 600,
+                        fontWeight: 700,
                         fontFamily: 'monospace',
                       }}>
                       {row.battery}%
@@ -433,7 +433,7 @@ const CardGridContent = () => {
 
   return (
     <Box sx={{ maxWidth: 1200, mx: 'auto' }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 1 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 1 }}>
         カードグリッド表示
       </Typography>
       <Typography variant='body2' color='text.secondary' sx={{ mb: 4 }}>
@@ -466,7 +466,7 @@ const CardGridContent = () => {
                     <Box sx={{ minWidth: 0, flex: 1 }}>
                       <Typography
                         variant='subtitle1'
-                        sx={{ fontWeight: 600, lineHeight: 1.3 }}>
+                        sx={{ fontWeight: 700, lineHeight: 1.3 }}>
                         {record.name}
                       </Typography>
                       <Typography variant='caption' color='text.secondary'>
@@ -495,7 +495,7 @@ const CardGridContent = () => {
                         variant='body2'
                         sx={{
                           color: getBatteryColor(record.battery),
-                          fontWeight: 600,
+                          fontWeight: 700,
                           fontFamily: 'monospace',
                         }}>
                         {record.battery}%
@@ -510,7 +510,7 @@ const CardGridContent = () => {
                       <Typography variant='body2' color='text.secondary'>
                         所在地
                       </Typography>
-                      <Typography variant='body2' fontWeight={500}>
+                      <Typography variant='body2' fontWeight={400}>
                         {record.location}
                       </Typography>
                     </Stack>

--- a/src/stories/05-Patterns/FormLayout.stories.tsx
+++ b/src/stories/05-Patterns/FormLayout.stories.tsx
@@ -128,7 +128,7 @@ const BasicFormContent = () => {
 
   return (
     <Box sx={{ maxWidth: 900, mx: 'auto' }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
         タスク計画登録フォーム
       </Typography>
       <Typography variant='body2' color='text.secondary' sx={{ mb: 4 }}>
@@ -363,7 +363,7 @@ const SettingsFormContent = () => {
 
   return (
     <Box sx={{ maxWidth: 700, mx: 'auto' }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
         設定ページ
       </Typography>
       <Typography variant='body2' color='text.secondary' sx={{ mb: 4 }}>
@@ -377,7 +377,7 @@ const SettingsFormContent = () => {
           <Stack spacing={5}>
             {/* セクション1: 通知設定 */}
             <Box>
-              <Typography variant='subtitle1' sx={{ fontWeight: 600, mb: 2 }}>
+              <Typography variant='subtitle1' sx={{ fontWeight: 700, mb: 2 }}>
                 通知設定
               </Typography>
               <Typography variant='body2' color='text.secondary' sx={{ mb: 3 }}>
@@ -418,7 +418,7 @@ const SettingsFormContent = () => {
 
             {/* セクション2: 表示設定 */}
             <Box>
-              <Typography variant='subtitle1' sx={{ fontWeight: 600, mb: 2 }}>
+              <Typography variant='subtitle1' sx={{ fontWeight: 700, mb: 2 }}>
                 表示設定
               </Typography>
               <Typography variant='body2' color='text.secondary' sx={{ mb: 3 }}>
@@ -468,7 +468,7 @@ const SettingsFormContent = () => {
 
             {/* セクション3: 安全設定 */}
             <Box>
-              <Typography variant='subtitle1' sx={{ fontWeight: 600, mb: 2 }}>
+              <Typography variant='subtitle1' sx={{ fontWeight: 700, mb: 2 }}>
                 安全設定
               </Typography>
               <Typography variant='body2' color='text.secondary' sx={{ mb: 3 }}>
@@ -587,7 +587,7 @@ const InlineEditFormContent = () => {
 
   return (
     <Box sx={{ maxWidth: 700, mx: 'auto' }}>
-      <Typography variant='h5' sx={{ fontWeight: 600, mb: 3 }}>
+      <Typography variant='h5' sx={{ fontWeight: 700, mb: 3 }}>
         インライン編集フォーム
       </Typography>
       <Typography variant='body2' color='text.secondary' sx={{ mb: 4 }}>
@@ -645,10 +645,10 @@ const InlineEditFormContent = () => {
                     <Typography
                       variant='body2'
                       color='text.secondary'
-                      sx={{ fontWeight: 500, minWidth: 140 }}>
+                      sx={{ fontWeight: 400, minWidth: 140 }}>
                       {field.label}
                     </Typography>
-                    <Typography variant='body2' sx={{ fontWeight: 500 }}>
+                    <Typography variant='body2' sx={{ fontWeight: 400 }}>
                       {data[field.key]}
                     </Typography>
                   </Box>

--- a/src/stories/05-Patterns/Navigation.stories.tsx
+++ b/src/stories/05-Patterns/Navigation.stories.tsx
@@ -216,7 +216,7 @@ const AppBarWithDrawerContent = () => {
 
           {/* コンテンツ表示領域 */}
           <Paper sx={{ p: 3 }}>
-            <Typography variant='h6' sx={{ fontWeight: 600, mb: 1 }}>
+            <Typography variant='h6' sx={{ fontWeight: 700, mb: 1 }}>
               タスク TSK-2024-042
             </Typography>
             <Typography variant='body2' color='text.secondary' sx={{ mb: 2 }}>
@@ -238,7 +238,7 @@ const AppBarWithDrawerContent = () => {
                     sx={{ minWidth: 100 }}>
                     {row.label}
                   </Typography>
-                  <Typography variant='body2' sx={{ fontWeight: 500 }}>
+                  <Typography variant='body2' sx={{ fontWeight: 400 }}>
                     {row.value}
                   </Typography>
                 </Box>
@@ -262,7 +262,7 @@ export const AppBarWithDrawer: StoryObj = {
 
 const BreadcrumbPatternsContent = () => (
   <Box sx={{ maxWidth: 800, mx: 'auto' }}>
-    <Typography variant='h5' sx={{ fontWeight: 600, mb: 1 }}>
+    <Typography variant='h5' sx={{ fontWeight: 700, mb: 1 }}>
       パンくずリストパターン
     </Typography>
     <Typography variant='body2' color='text.secondary' sx={{ mb: 4 }}>
@@ -272,7 +272,7 @@ const BreadcrumbPatternsContent = () => (
     <Stack spacing={3}>
       {/* --- 基本パターン --- */}
       <Paper variant='outlined' sx={{ p: 3, borderRadius: 2 }}>
-        <Typography variant='subtitle2' sx={{ fontWeight: 600, mb: 2 }}>
+        <Typography variant='subtitle2' sx={{ fontWeight: 700, mb: 2 }}>
           基本パターン
         </Typography>
         <Breadcrumbs
@@ -290,7 +290,7 @@ const BreadcrumbPatternsContent = () => (
 
       {/* --- アイコン付きパターン --- */}
       <Paper variant='outlined' sx={{ p: 3, borderRadius: 2 }}>
-        <Typography variant='subtitle2' sx={{ fontWeight: 600, mb: 2 }}>
+        <Typography variant='subtitle2' sx={{ fontWeight: 700, mb: 2 }}>
           アイコン付きパターン
         </Typography>
         <Breadcrumbs
@@ -331,7 +331,7 @@ const BreadcrumbPatternsContent = () => (
 
       {/* --- 折りたたみパターン --- */}
       <Paper variant='outlined' sx={{ p: 3, borderRadius: 2 }}>
-        <Typography variant='subtitle2' sx={{ fontWeight: 600, mb: 2 }}>
+        <Typography variant='subtitle2' sx={{ fontWeight: 700, mb: 2 }}>
           折りたたみパターン（深い階層）
         </Typography>
         <Breadcrumbs
@@ -361,7 +361,7 @@ const BreadcrumbPatternsContent = () => (
 
       {/* --- 現在ページChipパターン --- */}
       <Paper variant='outlined' sx={{ p: 3, borderRadius: 2 }}>
-        <Typography variant='subtitle2' sx={{ fontWeight: 600, mb: 2 }}>
+        <Typography variant='subtitle2' sx={{ fontWeight: 700, mb: 2 }}>
           現在ページ Chip パターン
         </Typography>
         <Breadcrumbs

--- a/src/stories/06-Tools/components/ComponentPalette.tsx
+++ b/src/stories/06-Tools/components/ComponentPalette.tsx
@@ -22,7 +22,7 @@ export const ComponentPalette = ({ onSelect }: ComponentPaletteProps) => (
       variant='caption'
       color='text.secondary'
       sx={{
-        fontWeight: 600,
+        fontWeight: 700,
         letterSpacing: '0.05em',
         mb: 1,
         display: 'block',
@@ -34,7 +34,7 @@ export const ComponentPalette = ({ onSelect }: ComponentPaletteProps) => (
         <Typography
           variant='caption'
           color='text.secondary'
-          sx={{ fontSize: 11, mb: 0.5, display: 'block' }}>
+          sx={{ fontSize: 12, mb: 0.5, display: 'block' }}>
           {cat.label}
         </Typography>
         <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
@@ -46,7 +46,7 @@ export const ComponentPalette = ({ onSelect }: ComponentPaletteProps) => (
               variant='outlined'
               onClick={() => onSelect(name)}
               sx={{
-                fontSize: 11,
+                fontSize: 12,
                 height: 24,
                 cursor: 'pointer',
                 '&:hover': { bgcolor: 'action.hover' },

--- a/src/stories/06-Tools/components/PromptInput.tsx
+++ b/src/stories/06-Tools/components/PromptInput.tsx
@@ -147,7 +147,7 @@ export const PromptInput = ({ onGenerate, isGenerating }: PromptInputProps) => {
       <Typography
         variant='caption'
         color='text.secondary'
-        sx={{ mt: 1, display: 'block', fontSize: 11, opacity: 0.7 }}>
+        sx={{ mt: 1, display: 'block', fontSize: 12, opacity: 0.7 }}>
         {modKey} + Enter で送信 / プリセットをクリックで即時生成
       </Typography>
     </Box>

--- a/src/stories/06-Tools/components/VisualEditor.tsx
+++ b/src/stories/06-Tools/components/VisualEditor.tsx
@@ -59,7 +59,7 @@ export const VisualEditor = () => {
               ? alpha(theme.palette.primary.main, 0.08)
               : alpha(theme.palette.primary.main, 0.04),
         }}>
-        <Typography sx={{ fontSize: 14, fontWeight: 600 }}>
+        <Typography sx={{ fontSize: 14, fontWeight: 700 }}>
           Visual Editor
         </Typography>
         <Typography variant='caption' color='text.secondary'>

--- a/src/stories/_shared/CodeBlock.tsx
+++ b/src/stories/_shared/CodeBlock.tsx
@@ -93,7 +93,7 @@ const CodeBlock = ({ children, language = 'tsx', caption }: CodeBlockProps) => {
           sx={{
             display: 'block',
             mt: 0.5,
-            fontSize: 11,
+            fontSize: 12,
             color: 'text.secondary',
           }}>
           {caption}

--- a/src/stories/_shared/DocComponents.tsx
+++ b/src/stories/_shared/DocComponents.tsx
@@ -54,7 +54,7 @@ const PageHero = ({ title, subtitle, gradient }: PageHeroProps) => {
       <Typography
         variant='displayMedium'
         component='h1'
-        className='mb-3 font-extrabold tracking-tight text-foreground'>
+        className='mb-3 font-bold tracking-tight text-foreground'>
         {title}
       </Typography>
       <Typography
@@ -81,7 +81,7 @@ const SectionHeader = ({ title, subtitle }: SectionHeaderProps) => (
     <Typography
       variant='h2'
       component='h2'
-      className='font-extrabold tracking-tight text-foreground'>
+      className='font-bold tracking-tight text-foreground'>
       {title}
     </Typography>
     {subtitle && (
@@ -104,7 +104,7 @@ interface SectionLabelProps {
 }
 
 const SectionLabel = ({ children }: SectionLabelProps) => (
-  <p className='mb-3 block text-[11px] font-bold uppercase tracking-[0.1em] text-primary'>
+  <p className='mb-3 block text-[12px] font-bold uppercase tracking-[0.1em] text-primary'>
     {children}
   </p>
 )
@@ -243,7 +243,7 @@ interface DemoPanelProps {
 
 const DemoPanel = ({ label, children }: DemoPanelProps) => (
   <div className='mb-10 rounded-2xl border border-border/50 p-8 dark:border-white/[0.08]'>
-    <p className='mb-6 text-[11px] font-bold uppercase tracking-[0.1em] text-primary'>
+    <p className='mb-6 text-[12px] font-bold uppercase tracking-[0.1em] text-primary'>
       {label}
     </p>
     {children}

--- a/src/styles/tokens.ts
+++ b/src/styles/tokens.ts
@@ -134,13 +134,10 @@ export const typography = {
     '5xl': '3rem', // 48px
     '6xl': '3.75rem', // 60px
   },
+  // ウェイトは 2 値のみ。中間値を持たせると、どれが正か決められなくなる
   fontWeight: {
-    light: 300,
     normal: 400,
-    medium: 500,
-    semibold: 600,
     bold: 700,
-    extrabold: 800,
   },
   lineHeight: {
     tight: 1.25,

--- a/src/themes/__tests__/app-themes.test.ts
+++ b/src/themes/__tests__/app-themes.test.ts
@@ -72,7 +72,7 @@ describe('プロダクトテーマが光学タイポグラフィを継承して�
       )
       expect(t.typography.h1.lineHeight, 'h1 行送り').toBe(1.3)
       expect(t.typography.body1.lineHeight, 'body1 行送り').toBe(1.6)
-      expect(t.typography.button.fontWeight, 'button ウェイト').toBe(500)
+      expect(t.typography.button.fontWeight, 'button ウェイト').toBe(400)
     })
   }
 })
@@ -157,7 +157,7 @@ describe('colorSchemes 版テーマ (saas-dashboard / sky-kaze が使用)', () =
     it(`${name}: 光学タイポグラフィを継承している`, () => {
       expect(t.typography.h1.letterSpacing).toBe(letterSpacingVariant.xxl)
       expect(t.typography.body1.lineHeight).toBe(1.6)
-      expect(t.typography.button.fontWeight).toBe(500)
+      expect(t.typography.button.fontWeight).toBe(400)
     })
 
     it(`${name}: ダークスキームでもリムライトが効く`, () => {

--- a/src/themes/__tests__/typography-usage.test.ts
+++ b/src/themes/__tests__/typography-usage.test.ts
@@ -1,0 +1,224 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+/**
+ * タイポグラフィの禁止パターンをリポジトリ全体で機械的に止める。
+ *
+ * 対象は 2 つ。
+ *
+ * 1. **12px 未満のフォントサイズ**
+ *    実測で 201 story に 437 箇所あり、最小は 8.4px だった。小さすぎる文字は
+ *    読めないだけでなく、ブラウザの拡大に頼る前提の設計になってしまう。
+ *
+ * 2. **400 / 700 以外のフォントウェイト**
+ *    直書き 528 箇所に 200/300/380/400/420/500/600/700/800/900 の 10 種類が
+ *    混在していた。380 や 420 のように由来を説明できない値まであった。
+ *    「少し強調」に対する正解が人によって違うと、レビューで判断できない。
+ *
+ * どちらも人が気をつけるより、混入した時点で落とす方が安い。
+ *
+ * **rem の基準は 14px**（`MuiCssBaseline` が `html { font-size: 14px }` を
+ * 設定している）。`0.857rem` は 11.998px で下限を割るので、トークンと同じ
+ * `0.86rem` (12.04px) を使うこと。
+ */
+
+const BASE_FONT_SIZE = 14
+const MIN_PX = 12
+const ALLOWED_WEIGHTS = new Set([400, 700])
+
+const ROOTS = ['src', 'apps', '.storybook']
+const SKIP_DIRS = new Set([
+  'node_modules',
+  'dist',
+  'coverage',
+  'storybook-static',
+  '__tests__',
+])
+// .css / .html まで見る。最初 .ts/.tsx だけを走査して緑にしたが、実ビルドを
+// ブラウザで測ると 440 箇所が残っていた。指定の形式は 1 つではない
+const EXTENSIONS = ['.ts', '.tsx', '.css', '.html']
+
+const collect = (dir: string, out: string[] = []): string[] => {
+  let entries: string[]
+  try {
+    entries = readdirSync(dir)
+  } catch {
+    return out
+  }
+  for (const entry of entries) {
+    if (SKIP_DIRS.has(entry)) continue
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      collect(full, out)
+    } else if (EXTENSIONS.some((ext) => entry.endsWith(ext))) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+const FILES = ROOTS.flatMap((r) => collect(r))
+
+interface Hit {
+  file: string
+  line: number
+  text: string
+}
+
+/**
+ * コメントを落とす。禁止値を説明する文（「以前は 10px だった」等）を
+ * 違反として拾ってしまうと、規約を文書化できなくなる
+ */
+const stripComments = (line: string): string => {
+  const t = line.trim()
+  if (t.startsWith('//') || t.startsWith('*') || t.startsWith('/*')) return ''
+  return line.replace(/\/\/.*$/, '')
+}
+
+const scan = (re: RegExp, judge: (m: RegExpExecArray) => boolean): Hit[] => {
+  const hits: Hit[] = []
+  for (const file of FILES) {
+    const src = readFileSync(file, 'utf8')
+    src.split('\n').forEach((raw, i) => {
+      const text = stripComments(raw)
+      if (!text) return
+      const rx = new RegExp(re.source, re.flags.includes('g') ? re.flags : re.flags + 'g')
+      let m: RegExpExecArray | null
+      while ((m = rx.exec(text)) !== null) {
+        if (judge(m)) hits.push({ file, line: i + 1, text: text.trim().slice(0, 96) })
+      }
+    })
+  }
+  return hits
+}
+
+const format = (hits: Hit[]) => hits.map((h) => `${h.file}:${h.line}  ${h.text}`)
+
+describe('フォントサイズの下限', () => {
+  it('走査対象を取りこぼしていない', () => {
+    // 対象が 0 件だと、以下の検査が「何も見ずに緑」になる
+    expect(FILES.length).toBeGreaterThan(100)
+  })
+
+  it(`rem 指定が ${MIN_PX}px を下回らない`, () => {
+    const hits = scan(
+      /fontSize: *'([0-9.]+)rem'/,
+      (m) => Number.parseFloat(m[1]) * BASE_FONT_SIZE < MIN_PX
+    )
+    expect(format(hits), `rem × ${BASE_FONT_SIZE}px が ${MIN_PX}px 未満`).toEqual([])
+  })
+
+  it(`px 指定が ${MIN_PX}px を下回らない`, () => {
+    const hits = scan(
+      /fontSize: *'([0-9.]+)px'/,
+      (m) => Number.parseFloat(m[1]) < MIN_PX
+    )
+    expect(format(hits), `${MIN_PX}px 未満の直接指定`).toEqual([])
+  })
+
+  it(`単位なしの数値指定が ${MIN_PX} を下回らない`, () => {
+    // sx の `fontSize: 10` は 10px。クォート付きだけ見ていると素通りする
+    const hits = scan(
+      /fontSize[:=] *\{?([0-9]+)/,
+      (m) => Number.parseInt(m[1], 10) < MIN_PX
+    )
+    expect(format(hits), `単位なし ${MIN_PX} 未満`).toEqual([])
+  })
+
+  it(`CSS の font-size が ${MIN_PX}px を下回らない`, () => {
+    const hits = scan(
+      /font-size: *([0-9.]+)(px|rem)/,
+      (m) =>
+        (m[2] === 'rem'
+          ? Number.parseFloat(m[1]) * BASE_FONT_SIZE
+          : Number.parseFloat(m[1])) < MIN_PX
+    )
+    expect(format(hits), `CSS で ${MIN_PX}px 未満`).toEqual([])
+  })
+
+  it(`Tailwind の任意値が ${MIN_PX}px を下回らない`, () => {
+    const hits = scan(
+      /text-\[([0-9.]+)px\]/,
+      (m) => Number.parseFloat(m[1]) < MIN_PX
+    )
+    expect(format(hits), `text-[Npx] で ${MIN_PX}px 未満`).toEqual([])
+  })
+
+  it('トークン自体が下限を満たす', () => {
+    // ここが割れていると、トークンに従った実装がすべて違反になる
+    const src = readFileSync('src/themes/typography.ts', 'utf8')
+      .split('\n')
+      .map(stripComments)
+      .join('\n')
+    const sizes = [...src.matchAll(/(\w+): pxToRem\((\d+)\)/g)]
+    expect(sizes.length).toBeGreaterThan(5)
+    const under = sizes
+      .filter(([, , px]) => Number.parseInt(px, 10) < MIN_PX)
+      .map(([, name, px]) => `${name}: ${px}px`)
+    expect(under).toEqual([])
+  })
+})
+
+describe('フォントウェイトの 2 値化', () => {
+  it('400 / 700 以外の数値を直書きしていない', () => {
+    // `fontWeight: 500` と JSX prop の `fontWeight={500}` の両方を見る。
+    // コロン形だけ見ていて prop 形を取りこぼし、実測で 8 箇所残っていた
+    // クォート付きの `fontWeight: '600'` も見る。数値だけ見ていて
+    // 1 箇所取りこぼし、実測で初めて出た
+    const hits = scan(
+      /fontWeight[:=] *\{?['\"]?([0-9]{3})['\"]?/,
+      (m) => !ALLOWED_WEIGHTS.has(Number.parseInt(m[1], 10))
+    )
+    expect(format(hits), '許可は 400 (normal) と 700 (bold) のみ').toEqual([])
+  })
+
+  it('MUI 自身のウェイトスケールも 2 値に潰してある', () => {
+    // theme.typography.fontWeightMedium を参照している箇所があり、
+    // ここが 500 のままだと自リポジトリを全部直しても描画に 500 が残る
+    const src = readFileSync('src/themes/typography.ts', 'utf8')
+      .split('\n')
+      .map(stripComments)
+      .join('\n')
+    const scale = [...src.matchAll(/fontWeight(Light|Regular|Medium|Bold): *([0-9]{3})/g)]
+    expect(scale.length, 'MUI のウェイトスケールが見つからない').toBe(4)
+    const bad = scale
+      .filter(([, , w]) => !ALLOWED_WEIGHTS.has(Number.parseInt(w, 10)))
+      .map(([, name, w]) => `fontWeight${name}: ${w}`)
+    expect(bad).toEqual([])
+  })
+
+  it('中間ウェイトのキーワードを使っていない', () => {
+    const hits = scan(
+      /fontWeight: *'(medium|semibold|light|extrabold|black|lighter|bolder)'/,
+      () => true
+    )
+    expect(format(hits), 'normal / bold 以外のキーワードは使わない').toEqual([])
+  })
+
+  it('CSS の font-weight が 400 / 700 以外でない', () => {
+    const hits = scan(
+      /font-weight: *([0-9]{3})/,
+      (m) => !ALLOWED_WEIGHTS.has(Number.parseInt(m[1], 10))
+    )
+    expect(format(hits), 'CSS も 400 / 700 のみ').toEqual([])
+  })
+
+  it('Tailwind の中間ウェイトクラスを使っていない', () => {
+    // font-normal / font-bold 以外は 2 値の外に出る
+    const hits = scan(
+      /\bfont-(medium|semibold|light|thin|extrabold|black|extralight)\b/,
+      () => true
+    )
+    expect(format(hits), 'font-normal / font-bold のみ').toEqual([])
+  })
+
+  it('トークンが normal と bold の 2 つだけを持つ', () => {
+    const src = readFileSync('src/themes/typography.ts', 'utf8')
+    const block = src.match(/const fontWeight = \{([^}]*)\}/)
+    expect(block, 'fontWeight トークンの定義が見つからない').not.toBeNull()
+    const keys = [...(block?.[1] ?? '').matchAll(/(\w+):/g)].map((m) => m[1])
+    expect(keys.sort()).toEqual(['bold', 'normal'])
+  })
+})

--- a/src/themes/__tests__/typography.test.ts
+++ b/src/themes/__tests__/typography.test.ts
@@ -23,7 +23,6 @@ const SCALE_DESC = [
   'ml',
   'md',
   'sm',
-  'xs',
 ] as const
 
 describe('光学的トラッキング (letterSpacingVariant)', () => {
@@ -47,7 +46,6 @@ describe('光学的トラッキング (letterSpacingVariant)', () => {
 
   it('display 帯は負のトラッキング、最小サイズは正のトラッキング', () => {
     expect(toEm(letterSpacingVariant.displayLarge)).toBeLessThan(0)
-    expect(toEm(letterSpacingVariant.xs)).toBeGreaterThan(0)
   })
 
   it('Inter のダイナミックメトリクス式と一致する', () => {
@@ -76,7 +74,7 @@ describe('光学的な行送り・ウェイト', () => {
   it('display 帯は詰めた行送り (1.2) と semibold (600)', () => {
     for (const name of ['displayLarge', 'displayMedium', 'displaySmall']) {
       expect(variantOf(name).lineHeight, name).toBe(1.2)
-      expect(variantOf(name).fontWeight, name).toBe(600)
+      expect(variantOf(name).fontWeight, name).toBe(700)
     }
   })
 
@@ -179,7 +177,7 @@ describe('variant の一意性', () => {
   })
 
   it('サイズ帯 (xxl-xs) は太さを主張しない', () => {
-    for (const name of ['xxl', 'xl', 'lg', 'ml', 'md', 'sm', 'xs']) {
+    for (const name of ['xxl', 'xl', 'lg', 'ml', 'md', 'sm']) {
       const v = typographyOptions[name] as { fontWeight?: number }
       expect(v.fontWeight, name).toBe(400)
     }

--- a/src/themes/kazeMixins.ts
+++ b/src/themes/kazeMixins.ts
@@ -63,8 +63,8 @@ export const KAZE_META: CSSProperties = {
 /** 袖見出し (EYEBROW): editorial 標準語、section 頭の小ラベル */
 export const KAZE_EYEBROW: CSSProperties = {
   fontFamily: 'var(--kaze-font-mono)',
-  fontSize: '0.75rem',
-  fontWeight: 500,
+  fontSize: '0.86rem',
+  fontWeight: 400,
   letterSpacing: '0.24em',
   textTransform: 'uppercase',
 }
@@ -72,7 +72,7 @@ export const KAZE_EYEBROW: CSSProperties = {
 /** 活字 (PRINT): Fraunces Variable の基調。display 見出し */
 export const KAZE_PRINT: CSSProperties = {
   fontFamily: 'var(--kaze-font-display)',
-  fontWeight: 380,
+  fontWeight: 400,
   letterSpacing: '-0.02em',
   fontVariationSettings: "'opsz' 144, 'wght' 380, 'SOFT' 30, 'WONK' 0",
 }
@@ -81,7 +81,7 @@ export const KAZE_PRINT: CSSProperties = {
 export const KAZE_ACCENT: CSSProperties = {
   fontFamily: 'var(--kaze-font-display)',
   fontStyle: 'italic',
-  fontWeight: 420,
+  fontWeight: 400,
   letterSpacing: '-0.02em',
   fontVariationSettings: "'opsz' 144, 'wght' 420, 'SOFT' 70, 'WONK' 1",
 }

--- a/src/themes/theme.ts
+++ b/src/themes/theme.ts
@@ -48,7 +48,7 @@ const CommomButtonStyles = {
   alignItems: 'center',
   justifyContent: 'center',
   lineHeight: 1.5,
-  fontWeight: 500,
+  fontWeight: 400,
   whiteSpace: 'nowrap',
 }
 
@@ -195,7 +195,7 @@ const componentStyles = {
         transition: 'none',
         pointerEvents: 'auto',
         fontSize: fontSizesVariant.md,
-        fontWeight: 500,
+        fontWeight: 400,
         color: theme.palette.text.primary,
         marginBottom: 4,
         '&.Mui-focused': {
@@ -254,11 +254,40 @@ const componentStyles = {
       }),
     },
   },
+  // MUI 既定のウェイトを 2 値へ寄せる。
+  //
+  // Badge / Slider / StepLabel / DataGrid は MUI 側が fontWeight: 500 を
+  // 持っており、こちらのソースを全部直しても描画には 500 が残る。
+  // ソース走査だけで「0 件」と判断すると必ず取りこぼす（実測で判明した）。
+  MuiBadge: {
+    styleOverrides: {
+      badge: { fontWeight: 700 },
+    },
+  },
+  MuiSlider: {
+    styleOverrides: {
+      valueLabel: { fontWeight: 700 },
+    },
+  },
+  MuiStepLabel: {
+    styleOverrides: {
+      label: {
+        fontWeight: 400,
+        '&.Mui-active, &.Mui-completed': { fontWeight: 700 },
+      },
+    },
+  },
+  MuiDataGrid: {
+    styleOverrides: {
+      columnHeaderTitle: { fontWeight: 700 },
+    },
+  },
   // ツールチップのカスタマイズ
   MuiTooltip: {
     styleOverrides: {
       tooltip: ({ theme }: { theme: Theme }) => ({
         fontSize: fontSizesVariant.md,
+        fontWeight: 400,
         backgroundColor:
           theme.palette.mode === 'dark'
             ? theme.palette.grey[700]
@@ -365,7 +394,7 @@ const componentStyles = {
         borderBottom: `1px solid ${theme.palette.divider}`,
         '& .MuiCardHeader-title': {
           fontSize: fontSizesVariant.md,
-          fontWeight: 600,
+          fontWeight: 700,
           color: theme.palette.text.primary,
         },
         '& .MuiCardHeader-subheader': {
@@ -400,7 +429,7 @@ const componentStyles = {
     styleOverrides: {
       root: ({ theme }: { theme: Theme }) => ({
         borderRadius: 3,
-        fontWeight: 600,
+        fontWeight: 700,
         fontSize: fontSizesVariant.sm, // 最小フォントサイズ12px原則に準拠
         height: 24,
         '& .MuiChip-label': {
@@ -509,7 +538,7 @@ const componentStyles = {
       root: ({ theme }: { theme: Theme }) => ({
         '& .MuiTableCell-head': {
           backgroundColor: theme.palette.action.hover,
-          fontWeight: 600,
+          fontWeight: 700,
           fontSize: fontSizesVariant.sm, // 最小フォントサイズ12px原則に準拠
           color: theme.palette.text.secondary,
           textTransform: 'uppercase',
@@ -600,14 +629,14 @@ const componentStyles = {
     styleOverrides: {
       root: ({ theme }: { theme: Theme }) => ({
         textTransform: 'none',
-        fontWeight: 500,
+        fontWeight: 400,
         fontSize: fontSizesVariant.sm,
         minHeight: 40,
         padding: '8px 16px',
         color: theme.palette.text.secondary,
         '&.Mui-selected': {
           color: theme.palette.primary.main,
-          fontWeight: 600,
+          fontWeight: 700,
         },
       }),
     },
@@ -621,7 +650,7 @@ const componentStyles = {
         // ここでは基準がずれる（白文字が 3.95:1 まで落ちていた）。
         // light 面に対して実測した onLight を使う
         color: theme.palette.primary.onLight,
-        fontWeight: 600,
+        fontWeight: 700,
         fontSize: fontSizesVariant.sm,
       }),
     },
@@ -697,7 +726,7 @@ const componentStyles = {
       root: ({ theme }: { theme: Theme }) => ({
         padding: '20px 24px 16px',
         fontSize: fontSizesVariant.lg,
-        fontWeight: 600,
+        fontWeight: 700,
         color: theme.palette.text.primary,
         borderBottom: `1px solid ${theme.palette.divider}`,
       }),

--- a/src/themes/typography.ts
+++ b/src/themes/typography.ts
@@ -25,7 +25,6 @@ declare module '@mui/material/styles' {
     ml: React.CSSProperties
     md: React.CSSProperties
     sm: React.CSSProperties
-    xs: React.CSSProperties
   }
 
   interface TypographyVariantsOptions {
@@ -41,7 +40,6 @@ declare module '@mui/material/styles' {
     ml?: React.CSSProperties
     md?: React.CSSProperties
     sm?: React.CSSProperties
-    xs?: React.CSSProperties
   }
 }
 
@@ -57,7 +55,6 @@ declare module '@mui/material/Typography' {
     ml: true
     md: true
     sm: true
-    xs: true
   }
 }
 
@@ -72,7 +69,6 @@ declare module '@mui/material/styles' {
     ml?: CSSProperties
     md?: CSSProperties
     sm?: CSSProperties
-    xs?: CSSProperties
   }
 }
 
@@ -93,16 +89,22 @@ export const fontSizesVariant = {
   lg: pxToRem(18),
   ml: pxToRem(16),
   md: pxToRem(14),
+  // 12px が下限。これ未満は用途を問わず使わない。
+  // 以前は xs: pxToRem(10) があったが 9.94px になり規約を満たさず、
+  // 12px に上げると sm と同値になるため variant ごと廃止した
   sm: pxToRem(12),
-  xs: pxToRem(10), // 最小サイズ（特殊用途のみ）
 }
 
+// ウェイトは 2 値のみ。normal か bold か、それ以外は無い。
+//
+// 中間ウェイト（500 / 600 / 800 等）を許すと、同じ「少し強調」に対して
+// 書き手ごとに違う数値が入り、どれが正なのか誰にも分からなくなる。
+// 実際 528 箇所の直書きに 200/300/380/400/420/500/600/700/800/900 の
+// 10 種類が混在し、380 や 420 のように由来を説明できない値まであった。
 const fontWeight = {
-  bold: 700,
-  semibold: 600,
-  medium: 500,
   normal: 400,
-}
+  bold: 700,
+} as const
 
 const lineHeight = {
   large: 1.8,
@@ -144,12 +146,11 @@ export const letterSpacingVariant = {
   ml: trackingFor(16),
   md: trackingFor(14),
   sm: trackingFor(12),
-  xs: trackingFor(10),
 }
 
 /** display 帯 (24px 以上): 太字は大きいほど重く見えるため semibold + 詰めた行送り */
 const display = {
-  fontWeight: fontWeight.semibold,
+  fontWeight: fontWeight.bold,
   lineHeight: lineHeight.tight,
 }
 
@@ -166,14 +167,14 @@ const headingSmall = {
 }
 
 /**
- * サイズ帯 (xxl - xs): 寸法だけを与え、太さは呼び出し側の裁量に残す。
+ * サイズ帯 (xxl - sm): 寸法だけを与え、太さは呼び出し側の裁量に残す。
  *
  * 以前は xxl/xl/lg だけが bold + 行送り 1.3、ml 以下が normal + 1.4 で、
  * 同じ命名軸の途中で太さが切り替わっていた。結果として、見出しに使う側は
  * 必ず fontWeight を書き足し（serviceCard は variant='md' に 600 を追加）、
  * サイズ帯に使う側は太さを打ち消す必要があった。
  *
- * 意味 (h1-h6 / display) と寸法 (xxl-xs) を別の軸として扱い、
+ * 意味 (h1-h6 / display) と寸法 (xxl-sm) を別の軸として扱い、
  * 寸法側は太さを主張しない。
  */
 const sizeOnly = {
@@ -186,9 +187,11 @@ export const typographyOptions: TypographyOptions = {
   htmlFontSize: baseFontSize,
   fontSize: baseFontSize,
   fontFamily: 'Inter, Noto Sans JP, Helvetica, Arial, sans-serif',
-  fontWeightLight: 300,
+  // MUI 自身のスケールも 2 値に潰す。theme.typography.fontWeightMedium を
+  // 参照している箇所があり、ここが 500 のままだと描画に 500 が残る
+  fontWeightLight: 400,
   fontWeightRegular: 400,
-  fontWeightMedium: 500,
+  fontWeightMedium: 400,
   fontWeightBold: 700,
   allVariants: {
     fontFamily: 'Inter, Noto Sans JP, Helvetica, Arial, sans-serif',
@@ -246,18 +249,20 @@ export const typographyOptions: TypographyOptions = {
   // 行送り 1.4・weight 400 の同値だった。名前が 4 つあって見た目が 1 つでは
   // 段として機能しないため、呼び出し側は毎回 sx で打ち消していた。
   // 見出しと本文の間を埋める段として、それぞれに役割を与える。
-  /** 見出しに添える導入文。本文よりわずかに大きく、やや重い */
+  /** 見出しに添える導入文。本文より一段大きく、bold で立てる */
   subtitle1: {
     fontSize: fontSizesVariant.ml,
-    fontWeight: fontWeight.medium,
+    fontWeight: fontWeight.bold,
     lineHeight: lineHeight.small,
     letterSpacing: letterSpacingVariant.ml,
   },
-  /** 小見出しに添える補足。本文と同じ寸法で、太さだけで区別する */
+  /** 小見出しに添える補足。本文と同じ寸法で、太さ (bold) だけで区別する */
   subtitle2: {
     fontSize: fontSizesVariant.md,
-    fontWeight: fontWeight.medium,
-    lineHeight: lineHeight.small,
+    fontWeight: fontWeight.bold,
+    // h5 も md + bold。見出しは行送りを締め (small)、副題は文として
+    // 読ませるので緩める (medium)。ウェイトが 2 値なので太さでは分けられない
+    lineHeight: lineHeight.medium,
     letterSpacing: letterSpacingVariant.md,
   },
   /** 図版の説明・補助テキスト。最小フォントサイズ 12px 原則に準拠 */
@@ -275,14 +280,14 @@ export const typographyOptions: TypographyOptions = {
    */
   overline: {
     fontSize: fontSizesVariant.sm,
-    fontWeight: fontWeight.medium,
+    fontWeight: fontWeight.normal,
     lineHeight: lineHeight.small,
     letterSpacing: '0.1em',
     textTransform: 'uppercase',
   },
   button: {
     fontSize: fontSizesVariant.md,
-    fontWeight: fontWeight.medium, // ラベルは本文より一段重く、押せる面に見せる
+    fontWeight: fontWeight.normal, // ラベルは本文より一段重く、押せる面に見せる
     lineHeight: lineHeight.medium,
     letterSpacing: letterSpacingVariant.md,
     textTransform: 'none',
@@ -332,11 +337,6 @@ export const typographyOptions: TypographyOptions = {
     letterSpacing: letterSpacingVariant.sm,
     ...sizeOnly,
   },
-  xs: {
-    fontSize: fontSizesVariant.xs,
-    letterSpacing: letterSpacingVariant.xs,
-    ...sizeOnly,
-  },
 }
 
 export const typographyComponentsOverrides = {
@@ -365,7 +365,6 @@ export const typographyComponentsOverrides = {
         ml: 'p',
         md: 'p',
         sm: 'p',
-        xs: 'p',
       },
     },
     styleOverrides: {

--- a/src/utils/className.ts
+++ b/src/utils/className.ts
@@ -110,7 +110,7 @@ export const variants = {
   // Button variants
   button: {
     default:
-      'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+      'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-normal transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
     primary: 'bg-primary-main text-primary-foreground hover:bg-primary-dark',
     secondary:
       'bg-secondary-main text-secondary-foreground hover:bg-secondary-dark',
@@ -126,9 +126,9 @@ export const variants = {
 
   // Text variants
   text: {
-    h1: 'scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl',
-    h2: 'scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight',
-    h3: 'scroll-m-20 text-2xl font-semibold tracking-tight',
+    h1: 'scroll-m-20 text-4xl font-bold tracking-tight lg:text-5xl',
+    h2: 'scroll-m-20 border-b pb-2 text-3xl font-bold tracking-tight',
+    h3: 'scroll-m-20 text-2xl font-bold tracking-tight',
     p: 'leading-7 [&:not(:first-child)]:mt-6',
     muted: 'text-sm text-muted-foreground',
   },


### PR DESCRIPTION
## 背景

201 story を実ブラウザで走査したところ、**12px 未満のテキストが 437 箇所**（最小 8.4px）、**400/700 以外のウェイトが 272 箇所**あった。

原因はトークン自体にもあった。`xs: pxToRem(10)` は `html { font-size: 14px }` の下で 9.94px になり、**トークンに従っても規約違反**だった。ウェイトも `semibold: 600` / `medium: 500` を持っていた。

## 変更

### サイズ

- `xs` variant を廃止。12px に上げると `sm` と同値になるため（既存テスト「同じ見た目の variant が複数存在しない」が検出した）
- 直書き 167 箇所を 12px 以上へ
- `kazeLogo` は `size` prop から計算しており静的検査で捕まらない。`Math.max(12, ...)` で下限をコードに埋めた

### ウェイト

- トークンを `normal: 400` / `bold: 700` の 2 値に
- **MUI 自身のスケール**（`fontWeightLight` / `fontWeightMedium`）も 400 に。`theme.typography.fontWeightMedium` の参照があり、ここが 500 のままだと自リポジトリを全部直しても描画に 500 が残る
- `src/styles/tokens.ts` に**もう 1 つ**ウェイトトークンがあった。同じく 2 値に
- MUI 既定値が残る Badge / Slider / StepLabel / DataGrid に `styleOverrides`
- 直書き 560 箇所を 400 / 700 に（中間 550 を境に丸める）

### 設計上の帰結

`subtitle1` / `subtitle2` は「本文と同じ寸法で**太さだけで区別する**」設計だった。2 値では成立しないので bold に寄せたところ `h5` と同値になり、**行送りで分けた**（見出しは締める 1.4、副題は文として読ませる 1.6）。

## 退行防止

`typography-usage.test.ts`（13 件）を追加。

**ソース走査だけでは足りない。** 実ビルドを測るたびに新しい指定形式が見つかり、最終的に 8 種類あった。

| 回 | 12px 未満 | weight 違反 | その回に判明した形式 |
| --- | --- | --- | --- |
| 1 | 440 | 272 | 単位なし数値 / Tailwind / CSS |
| 2 | 37 | 254 | 三項演算子 / SVG 属性 / **MUI 既定値** |
| 3 | 2 | 31 | JSX prop / データ配列 / MUI の weight スケール / 未発見のトークンファイル |
| 4 | 1 | 1 | クォート付き文字列 |
| 5 | **0** | **0** | |

計算値（`${size * 0.5}px`）だけは静的に追えないため、値ではなくコード側でクランプする方針にした。

## 検証

- **実ブラウザ 201 story で 12px 未満 0 件 / 400,700 以外 0 件**
- 675 テスト通過、型チェック通過
- ガードに違反を仕込むと落ちることを確認（緑だけを見て信用しない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jav2H6vtcjoLJk6N34N8hD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * アプリ全体のフォントウェイトをRegular／Bold中心に統一しました。
  * 小さな文字やラベルを拡大し、見出し・数値・重要情報の視認性を改善しました。
  * ナビゲーション、ボタン、カード、テーブル、カレンダーなどの表示を調整しました。
  * タイポグラフィの最小サイズを12pxに統一し、極小サイズの選択肢を削除しました。
* **テスト**
  * フォントサイズとウェイトのルールを自動検証するチェックを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->