### PR TITLE
fix(a11y): 条件式の中のウェイトを 2 値に統一し、アプリ 3 つでも実測 0 にする

### DIFF
--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -11,7 +11,7 @@ const logoSvg = `data:image/svg+xml,${encodeURIComponent(
     '<path d="M14 18 A7 7 0 0 0 28 18 Z"/>' +
     '</g>' +
     '<text x="40" y="22" font-family="Inter,sans-serif" font-size="16"' +
-    ' font-weight="600" letter-spacing="-0.3" fill="#e4e9f0">Kaze</text>' +
+    ' font-weight="700" letter-spacing="-0.3" fill="#e4e9f0">Kaze</text>' +
     '</svg>'
 )}`
 

--- a/apps/kaze-eats/src/pages/HomePage.tsx
+++ b/apps/kaze-eats/src/pages/HomePage.tsx
@@ -132,7 +132,7 @@ export const HomePage = () => {
               color={selectedCategory === cat.id ? 'success' : 'default'}
               sx={{
                 flexShrink: 0,
-                fontWeight: selectedCategory === cat.id ? 600 : 400,
+                fontWeight: selectedCategory === cat.id ? 700 : 400,
                 px: 1,
                 cursor: 'pointer',
               }}

--- a/apps/kaze-eats/src/pages/OrderHistoryPage.tsx
+++ b/apps/kaze-eats/src/pages/OrderHistoryPage.tsx
@@ -284,7 +284,7 @@ export const OrderHistoryPage = () => {
             color={statusFilter === filter.value ? 'success' : 'default'}
             sx={{
               cursor: 'pointer',
-              fontWeight: statusFilter === filter.value ? 600 : 400,
+              fontWeight: statusFilter === filter.value ? 700 : 400,
             }}
           />
         ))}

--- a/apps/saas-dashboard/src/pages/InvoicesPage.tsx
+++ b/apps/saas-dashboard/src/pages/InvoicesPage.tsx
@@ -447,7 +447,7 @@ export const InvoicesPage = () => {
             color={statusFilter === filter.value ? 'primary' : 'default'}
             sx={{
               cursor: 'pointer',
-              fontWeight: statusFilter === filter.value ? 600 : 400,
+              fontWeight: statusFilter === filter.value ? 700 : 400,
             }}
           />
         ))}

--- a/apps/saas-dashboard/src/pages/ProjectsPage.tsx
+++ b/apps/saas-dashboard/src/pages/ProjectsPage.tsx
@@ -243,7 +243,7 @@ export const ProjectsPage = () => {
             color={filter === opt.value ? 'primary' : 'default'}
             sx={{
               cursor: 'pointer',
-              fontWeight: filter === opt.value ? 600 : 400,
+              fontWeight: filter === opt.value ? 700 : 400,
             }}
           />
         ))}

--- a/apps/sky-kaze/src/components/HeaderBar.tsx
+++ b/apps/sky-kaze/src/components/HeaderBar.tsx
@@ -133,7 +133,7 @@ export const HeaderBar = () => {
               <Typography
                 sx={{
                   fontSize: '15px',
-                  fontWeight: active ? 700 : 500,
+                  fontWeight: active ? 700 : 400,
                   lineHeight: 1.3,
                 }}>
                 {tab.label}

--- a/apps/sky-kaze/src/components/TimelineBar.tsx
+++ b/apps/sky-kaze/src/components/TimelineBar.tsx
@@ -166,7 +166,7 @@ export const TimelineBar = () => {
                 py: 0.25,
                 borderRadius: 1,
                 fontSize: '14px',
-                fontWeight: speed === s ? 800 : 700,
+                fontWeight: speed === s ? 700 : 700,
                 fontFamily: "'JetBrains Mono', monospace",
                 cursor: 'pointer',
                 bgcolor: 'transparent',

--- a/src/components/ui/AppSwitcher.tsx
+++ b/src/components/ui/AppSwitcher.tsx
@@ -177,7 +177,7 @@ export const AppSwitcher = ({ currentApp }: AppSwitcherProps) => {
                     <Typography
                       sx={{
                         fontSize: '14px',
-                        fontWeight: isCurrent ? 700 : 500,
+                        fontWeight: isCurrent ? 700 : 400,
                         color: 'text.primary',
                         lineHeight: 1.3,
                       }}>

--- a/src/components/ui/calendar/monthView.tsx
+++ b/src/components/ui/calendar/monthView.tsx
@@ -189,7 +189,7 @@ export const MonthView = ({
                               : isSaturday(dayIndex)
                                 ? 'info.main'
                                 : 'text.primary',
-                        fontWeight: isToday(date) ? 600 : 400,
+                        fontWeight: isToday(date) ? 700 : 400,
                       }}>
                       {date.date()}
                     </Typography>

--- a/src/themes/__tests__/typography-usage.test.ts
+++ b/src/themes/__tests__/typography-usage.test.ts
@@ -163,13 +163,22 @@ describe('フォントサイズの下限', () => {
 
 describe('フォントウェイトの 2 値化', () => {
   it('400 / 700 以外の数値を直書きしていない', () => {
-    // `fontWeight: 500` と JSX prop の `fontWeight={500}` の両方を見る。
-    // コロン形だけ見ていて prop 形を取りこぼし、実測で 8 箇所残っていた
-    // クォート付きの `fontWeight: '600'` も見る。数値だけ見ていて
-    // 1 箇所取りこぼし、実測で初めて出た
+    // 値が `fontWeight` の直後に来るとは限らない。実測で判明した形式:
+    //   fontWeight: 500              コロン + 数値
+    //   fontWeight={500}             JSX prop
+    //   fontWeight: '600'            クォート付き
+    //   fontWeight: active ? 600 : 400   条件式（直後に来ない）
+    //
+    // 直後だけを見る正規表現で 3 回取りこぼし、そのたびに実ビルドの
+    // 計測で初めて発覚した。**`fontWeight` を含む行の 3 桁数値をすべて見る**
+    // 値の範囲は次の , ; } 改行 まで。行全体を見ると同じ行の
+    // `minWidth: 130` のような無関係な数値を拾って誤検出になる
     const hits = scan(
-      /fontWeight[:=] *\{?['\"]?([0-9]{3})['\"]?/,
-      (m) => !ALLOWED_WEIGHTS.has(Number.parseInt(m[1], 10))
+      /(?:fontWeight|font-weight)\s*[:=]\s*\{?([^,;}\n]*)/,
+      (m) =>
+        [...m[1].matchAll(/\b([0-9]{3})\b/g)].some(
+          (x) => !ALLOWED_WEIGHTS.has(Number.parseInt(x[1], 10))
+        )
     )
     expect(format(hits), '許可は 400 (normal) と 700 (bold) のみ').toEqual([])
   })


### PR DESCRIPTION
## 背景

#106 のあと Storybook では 0 件だったが、**アプリ 3 つを実ブラウザで測ると weight 違反が 6 箇所残っていた**。Storybook の story だけを走査していて、アプリの画面を一度も測っていなかった。

## 原因: 9 つ目の指定形式

```ts
fontWeight: selectedCategory === cat.id ? 600 : 400
```

値が `fontWeight:` の直後に来ないため、直後だけを見る正規表現が届かない。**3 回目の取りこぼし**で、そのたびに実測で初めて発覚している。

## 変更

- 条件式の中のウェイト 8 箇所を是正
- `.storybook/manager.ts` の SVG 文字列内 `font-weight="600"` を是正
- ガードを「**値の範囲**（次の `,` `;` `}` まで）を見る」形に修正

最初は行全体を見る実装にしたが、同じ行の `minWidth: 130` のような無関係な数値を **15 件誤検出**した。値の範囲を正しく区切る必要がある。

## 検証

- **アプリ 3 つ**（saas-dashboard / kaze-eats / sky-kaze）を実ブラウザで走査し **size 0 件 / weight 0 件**
- Storybook 201 story も 0 / 0 を維持
- 675 テスト通過、型チェック通過

## 積み残しの所見

`kaze-ux` 本体のテーマ override が効いていることを、同じブロックの別プロパティ（`borderRadius: 3px` / `height: 24px` / `fontSize: 12.04px`）で確認したうえで、`fontWeight` だけが 600 だったことから利用側の `sx` に絞り込んだ。**「override が効いていない」と「効いているが別の指定に負けている」は切り分けが要る。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jav2H6vtcjoLJk6N34N8hD