### PR TITLE
feat(vrt): 見た目の退行を検出する pnpm vrt を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ zenn-storybook-ai-chat.md
 
 # Figma plugin build output
 figma-plugin/code.js
+# VRT の作業ディレクトリ（ビルド成果物とスクリーンショット）
+.vrt/

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "check:anon": "node scripts/check-anonymity.mjs",
     "check:live": "node scripts/check-live-secrets.mjs",
     "check:typo": "node scripts/check-rendered-typography.mjs",
+    "vrt": "node scripts/vrt.mjs",
     "check:share": "pnpm run check:anon && pnpm run check:live"
   },
   "peerDependencies": {

--- a/scripts/vrt.mjs
+++ b/scripts/vrt.mjs
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+/**
+ * 見た目の退行を検出する。2 つの git ref を同じマシンでビルドして撮り比べる。
+ *
+ *   pnpm vrt                 origin/main と作業ツリーを比較
+ *   pnpm vrt 773f2ba         指定 ref と比較
+ *   pnpm vrt main --limit 30 story 数を絞って試す
+ *
+ * ## なぜベースライン画像を保存しないか
+ *
+ * フォントの描画はマシンに依存する。macOS で撮った画像は Linux の CI で
+ * 必ず落ちる。画像を持たず、比較のたびに両方をこの場でビルドすれば、
+ * 保存も更新も要らず、いつでも同じ条件で比べられる。
+ *
+ * 代償はビルド 2 回分の時間。退行検出は毎コミット回すものではなく、
+ * 見た目に触れた変更のときに意図的に回すものなので、これで釣り合う。
+ *
+ * ## なぜ無視リストを持たないか
+ *
+ * 地図タイルのように毎回描画が変わる story がある（実測で 64,126px の
+ * 自己差分が出た）。これを手動の無視リストで external すると、リストが
+ * 古くなったことに誰も気づけない。
+ *
+ * 代わりに、差分が出た story だけ**同じ版で 2 回撮り直して自己差分を測る**。
+ * 自己差分が同程度なら描画のゆらぎ、明確に小さければ本物の変化と判定する。
+ * ノイズを列挙するのではなく毎回測る。
+ *
+ * ## テストとの役割分担
+ *
+ * typography-usage.test.ts と check:typo は「規約に適合しているか」を見る。
+ * 数値しか見ないので、太さを落として強調が消えたような変化は検出できない。
+ * こちらは「見た目が変わったか」だけを見て、良し悪しは人が判断する。
+ */
+
+import { execFileSync, execSync } from 'node:child_process'
+import { existsSync, mkdirSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { chromium } from 'playwright'
+
+const VIEWPORT = { width: 1280, height: 900 }
+const PORT_BASE = 6301
+const PORT_HEAD = 6302
+/** 自己差分がこの割合を超えたら、描画のゆらぎとみなす */
+const NOISE_RATIO = 0.5
+
+const args = process.argv.slice(2)
+const limitAt = args.indexOf('--limit')
+const LIMIT = limitAt >= 0 ? Number.parseInt(args[limitAt + 1], 10) : Infinity
+const BASE_REF =
+  args.find((a) => !a.startsWith('--') && a !== String(LIMIT)) ?? 'origin/main'
+
+const ROOT = process.cwd()
+const WORK = join(ROOT, '.vrt')
+const OUT = join(WORK, 'out')
+const TREE = join(WORK, 'base')
+
+const sh = (cmd, cwd = ROOT) =>
+  execSync(cmd, {
+    cwd,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    encoding: 'utf8',
+  }).trim()
+
+console.log(`比較: ${BASE_REF} → 作業ツリー`)
+
+// --- 両方をビルド -----------------------------------------------------------
+
+rmSync(WORK, { recursive: true, force: true })
+mkdirSync(OUT, { recursive: true })
+for (const d of ['before', 'after', 'diff'])
+  mkdirSync(join(OUT, d), { recursive: true })
+
+try {
+  sh(`git rev-parse --verify ${BASE_REF}`)
+} catch {
+  console.error(`❌ ref が見つかりません: ${BASE_REF}`)
+  process.exit(1)
+}
+
+console.log('  比較元を展開中...')
+sh(`git worktree add --detach "${TREE}" ${BASE_REF}`)
+try {
+  console.log('  比較元を install / build 中...')
+  sh('pnpm install --prefer-offline', TREE)
+  sh('pnpm build-storybook -o sb', TREE)
+
+  console.log('  作業ツリーを build 中...')
+  sh(`pnpm build-storybook -o "${join(WORK, 'head')}"`)
+
+  // --- 配信 ---------------------------------------------------------------
+
+  const serve = (dir, port) =>
+    execFileSync('sh', [
+      '-c',
+      `npx --yes http-server "${dir}" -p ${port} --silent >/dev/null 2>&1 &`,
+    ])
+  serve(join(TREE, 'sb'), PORT_BASE)
+  serve(join(WORK, 'head'), PORT_HEAD)
+
+  const BASE = `http://localhost:${PORT_BASE}`
+  const HEAD = `http://localhost:${PORT_HEAD}`
+  const wait = async (url) => {
+    for (let i = 0; i < 30; i++) {
+      try {
+        await fetch(`${url}/index.json`)
+        return true
+      } catch {
+        await new Promise((r) => setTimeout(r, 1000))
+      }
+    }
+    return false
+  }
+  if (!(await wait(BASE)) || !(await wait(HEAD))) {
+    console.error('❌ 配信を開始できませんでした')
+    process.exit(1)
+  }
+
+  // --- 撮影 ---------------------------------------------------------------
+
+  const idsOf = async (base) => {
+    const idx = await (await fetch(`${base}/index.json`)).json()
+    return new Set(
+      Object.values(idx.entries)
+        .filter((e) => e.type === 'story')
+        .map((e) => e.id)
+    )
+  }
+  const [bIds, hIds] = await Promise.all([idsOf(BASE), idsOf(HEAD)])
+  const common = [...bIds].filter((id) => hIds.has(id)).slice(0, LIMIT)
+  const added = [...hIds].filter((id) => !bIds.has(id))
+  const removed = [...bIds].filter((id) => !hIds.has(id))
+
+  const browser = await chromium.launch()
+  const shoot = async (base, id, file) => {
+    const page = await browser.newPage({ viewport: VIEWPORT })
+    try {
+      await page.goto(`${base}/iframe.html?id=${id}&viewMode=story`, {
+        waitUntil: 'load',
+        timeout: 20000,
+      })
+      // 動きを止めて撮る。止めないと差分がゆらぎで埋まる
+      await page.addStyleTag({
+        content:
+          '*,*::before,*::after{animation:none!important;transition:none!important;caret-color:transparent!important}',
+      })
+      await page.waitForTimeout(320)
+      await page.screenshot({ path: file })
+      return true
+    } catch {
+      return false
+    } finally {
+      await page.close()
+    }
+  }
+
+  /** compare -metric AE。異なる画素数を返す */
+  const pixelDiff = (a, b, out) => {
+    try {
+      execFileSync('compare', ['-metric', 'AE', a, b, out], {
+        stdio: ['ignore', 'ignore', 'pipe'],
+      })
+      return 0
+    } catch (e) {
+      const n = Number.parseInt(
+        (e.stderr ?? Buffer.from('')).toString().trim().split(/\s+/)[0],
+        10
+      )
+      return Number.isNaN(n) ? -1 : n
+    }
+  }
+
+  console.log(`  ${common.length} story を撮影中...`)
+  const diffs = []
+  let failed = 0
+  for (const id of common) {
+    const bf = join(OUT, 'before', `${id}.png`)
+    const hf = join(OUT, 'after', `${id}.png`)
+    const df = join(OUT, 'diff', `${id}.png`)
+    if (!(await shoot(BASE, id, bf)) || !(await shoot(HEAD, id, hf))) {
+      failed++
+      continue
+    }
+    const d = pixelDiff(bf, hf, df)
+    if (d > 0) diffs.push({ id, diff: d })
+  }
+
+  // --- 差分が出たものだけ、同じ版で 2 回撮って自己差分を測る ----------------
+
+  console.log(`  差分 ${diffs.length} 件のゆらぎを測定中...`)
+  const noiseFile = join(WORK, 'noise.png')
+  for (const r of diffs) {
+    const n1 = join(WORK, 'n1.png')
+    if (!(await shoot(HEAD, r.id, n1))) {
+      r.noise = -1
+      continue
+    }
+    r.noise = pixelDiff(join(OUT, 'after', `${r.id}.png`), n1, noiseFile)
+  }
+
+  await browser.close()
+
+  // --- 結果 ---------------------------------------------------------------
+
+  const real = diffs.filter(
+    (r) => r.noise >= 0 && r.noise < r.diff * NOISE_RATIO
+  )
+  const noisy = diffs.filter(
+    (r) => !(r.noise >= 0 && r.noise < r.diff * NOISE_RATIO)
+  )
+  const total = VIEWPORT.width * VIEWPORT.height
+
+  console.log(`\n撮影 ${common.length - failed} 件（失敗 ${failed}）`)
+  console.log(`  完全一致 ${common.length - failed - diffs.length} 件`)
+  console.log(`  見た目が変わった ${real.length} 件`)
+  console.log(`  描画のゆらぎ ${noisy.length} 件（自己差分が同程度）`)
+  if (added.length) console.log(`  追加された story ${added.length} 件`)
+  if (removed.length) console.log(`  削除された story ${removed.length} 件`)
+
+  if (real.length) {
+    console.log('\n見た目が変わった story（差分の大きい順）:')
+    for (const r of real.sort((a, b) => b.diff - a.diff)) {
+      const pct = ((r.diff / total) * 100).toFixed(2)
+      console.log(
+        `  ${String(r.diff).padStart(8)} px (${pct.padStart(5)}%)  ${r.id}`
+      )
+    }
+  }
+  if (noisy.length) {
+    console.log('\n描画のゆらぎと判定（同じ版でも同程度の差が出る）:')
+    for (const r of noisy) {
+      console.log(`  差分 ${r.diff} / 自己差分 ${r.noise}  ${r.id}`)
+    }
+  }
+
+  console.log(`\n画像: ${OUT}/{before,after,diff}/`)
+  console.log(
+    '差分は自動では判定できない。意図した変化かどうかは画像を見て決める。'
+  )
+} finally {
+  execFileSync('sh', [
+    '-c',
+    `lsof -nP -iTCP:${PORT_BASE},${PORT_HEAD} -sTCP:LISTEN -t 2>/dev/null | xargs -r kill 2>/dev/null || true`,
+  ])
+  if (existsSync(TREE)) {
+    try {
+      sh(`git worktree remove -f "${TREE}"`)
+    } catch {
+      /* 残っても out/ は使えるので握りつぶす */
+    }
+  }
+}


### PR DESCRIPTION
```
pnpm vrt              origin/main と作業ツリーを比較
pnpm vrt <ref>        指定 ref と比較
pnpm vrt <ref> --limit 30
```

## 既存の検査では見えないもの

`typography-usage.test.ts` と `check:typo` は「**規約に適合しているか**」を見る。数値しか見ないので、太さを落として強調が消えたような変化は検出できない。

実例として、#106 で 727 箇所の見た目を変えたが、**検証したのは適合だけで、見た目が壊れていないかは一度も見ていなかった**。後から 201 story を撮り比べて意図した変化であることを確認した。

## 設計判断

**ベースライン画像を保存しない。** フォントの描画はマシンに依存し、macOS で撮った画像は Linux の CI で必ず落ちる。比較のたびに 2 つの ref をこの場でビルドすれば、保存も更新も要らず常に同条件になる。代償はビルド 2 回分の時間だが、VRT は毎コミット回すものではなく見た目に触れた変更時に回すものなので釣り合う。

**無視リストを持たない。** 地図タイルのように毎回描画が変わる story がある（実測で自己差分 64,126px）。手動リストで除外すると、リストが古くなったことに誰も気づけない。代わりに**差分が出た story だけ同じ版で 2 回撮り直して自己差分を測り**、ゆらぎか本物かを毎回判定する。

**良し悪しは判定しない。** 差分の有無だけを出す。今日の作業では 8.59% の差分が意図どおりで、1.06% が元からの描画エラーだった。**大きさと重大さは相関しない。**

## 検証

- `773f2ba` と比較して既知の差分 6 件を検出（全件比較の値と一致）
- 同一 ref で 12/12 完全一致、**誤検出ゼロ**
- 検出できることと誤検出しないことの**両方**を確認した

## 役割分担

| | 見るもの |
| --- | --- |
| `typography-usage.test.ts` | ソースの指定形式が規約に合っているか |
| `pnpm check:typo` | 描画された数値が規約に合っているか |
| `pnpm vrt` | 見た目が変わったか（良し悪しは人が判断） |

数値の適合と見た目の正しさは別物。規約に 100% 適合しながら Calendar の 2 story が描画エラーという状態が実在した（別 issue）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jav2H6vtcjoLJk6N34N8hD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 指定したバージョンと現在の変更内容を対象に、Storybookの画面差分を自動比較できるようになりました。
  - 画面表示のノイズと実際の変更を分類し、差分のあるストーリーや追加・削除されたストーリーを確認できます。
  - `vrt`コマンドからビジュアルリグレッションテストを実行できます。

- **改善**
  - テスト終了時に一時的な環境やサーバーを自動的に整理するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->