### PR TITLE
fix(a11y): 面のための色を文字に使っている箇所を前景色に寄せる

### DIFF
--- a/src/components/ui/chip/connectionStatusChip.tsx
+++ b/src/components/ui/chip/connectionStatusChip.tsx
@@ -19,7 +19,11 @@ const StyledStatusChip = styled(Chip, {
     : theme.palette.mode === 'light'
       ? theme.palette.error.lighter
       : `${theme.palette.error.main}20`,
-  color: connected ? theme.palette.success.dark : theme.palette.error.dark,
+  // 面は main の 12% tint。その上に置くので、素の面向けの dark では届かない
+  // （実測 4.32:1）。tint 面を見込んだ余裕を持つ textContrast を使う
+  color: connected
+    ? theme.palette.success.textContrast
+    : theme.palette.error.textContrast,
   borderRadius: theme.shape.borderRadius,
   paddingLeft: theme.spacing(1),
   paddingRight: theme.spacing(1),

--- a/src/stories/03-Layout/Grid.stories.tsx
+++ b/src/stories/03-Layout/Grid.stories.tsx
@@ -38,8 +38,10 @@ const DemoItem = ({
       alignItems: 'center',
       justifyContent: 'center',
       textAlign: 'center',
-      bgcolor: 'primary.light',
-      color: 'primary.contrastText',
+      // contrastText は main の面に対して設計された色。light に重ねると
+      // 3.95:1 で届かない。淡い面には前景用の textContrast を合わせる
+      bgcolor: 'primary.lighter',
+      color: 'primary.textContrast',
       fontWeight: 700,
       fontSize: '0.86rem',
       borderRadius: 1.5,

--- a/src/stories/04-Components/UI/Card/Card.stories.tsx
+++ b/src/stories/04-Components/UI/Card/Card.stories.tsx
@@ -100,7 +100,12 @@ const BasicContent = () => (
       <Grid size={{ xs: 12, md: 4 }}>
         <Card>
           <CardHeader
-            avatar={<Avatar sx={{ bgcolor: 'primary.main' }}>K</Avatar>}
+            avatar={
+              <Avatar
+                sx={{ bgcolor: 'primary.main', color: 'primary.contrastText' }}>
+                K
+              </Avatar>
+            }
             action={
               <IconButton size='small'>
                 <MoreVertIcon />
@@ -176,7 +181,11 @@ const DeviceStatusContent = () => {
             <Card>
               <CardHeader
                 avatar={
-                  <Avatar sx={{ bgcolor: `${device.statusColor}.main` }}>
+                  <Avatar
+                    sx={{
+                      bgcolor: `${device.statusColor}.main`,
+                      color: `${device.statusColor}.contrastText`,
+                    }}>
                     <DevicesIcon />
                   </Avatar>
                 }
@@ -340,7 +349,7 @@ const LayoutPatternsContent = () => (
                     variant='caption'
                     sx={{
                       color: stat.change.startsWith('+')
-                        ? 'success.main'
+                        ? 'success.textContrast'
                         : 'text.secondary',
                       fontWeight: 400,
                     }}>

--- a/src/stories/04-Components/UI/Table/Table.stories.tsx
+++ b/src/stories/04-Components/UI/Table/Table.stories.tsx
@@ -146,12 +146,14 @@ export const Default: StoryObj<typeof Table> = {
                 <Typography
                   variant='body2'
                   sx={{
+                    // main は面のための色。文字に使うと 12px で 2.7:1 前後に
+                    // しかならない。前景用の textContrast を使う
                     color:
                       row.battery >= 70
-                        ? 'success.main'
+                        ? 'success.textContrast'
                         : row.battery >= 30
-                          ? 'warning.main'
-                          : 'error.main',
+                          ? 'warning.textContrast'
+                          : 'error.textContrast',
                     fontWeight: 700,
                   }}>
                   {row.battery}%

--- a/src/stories/05-Patterns/Dashboard.stories.tsx
+++ b/src/stories/05-Patterns/Dashboard.stories.tsx
@@ -93,8 +93,8 @@ const statCards: StatCardItem[] = [
 
 /** 変化方向に対応する色を返す */
 function trendColor(trend: StatCardItem['trend']): string {
-  if (trend === 'positive') return 'success.main'
-  if (trend === 'negative') return 'error.main'
+  if (trend === 'positive') return 'success.textContrast'
+  if (trend === 'negative') return 'error.textContrast'
   return 'text.secondary'
 }
 

--- a/src/stories/05-Patterns/DataDisplay.stories.tsx
+++ b/src/stories/05-Patterns/DataDisplay.stories.tsx
@@ -72,9 +72,9 @@ function getStatusColor(
 
 /** バッテリー残量に応じたテキスト色を返す */
 function getBatteryColor(battery: number): string {
-  if (battery >= 70) return 'success.main'
-  if (battery >= 30) return 'warning.main'
-  return 'error.main'
+  if (battery >= 70) return 'success.textContrast'
+  if (battery >= 30) return 'warning.textContrast'
+  return 'error.textContrast'
 }
 
 /** フィルターの選択肢 */

--- a/src/themes/theme.ts
+++ b/src/themes/theme.ts
@@ -181,6 +181,43 @@ const componentStyles = {
               : colorData.grey[700],
         },
       }),
+      // text / outlined の Button は文字色に main を使う。main は面のための
+      // 色なので、白地に置くと届かない。実測で Toast の「情報」が 2.52:1、
+      // 「警告」が 2.61:1 だった。Chip と同じく textContrast へ寄せる。
+      //
+      // スロット単位で上書きするのは Chip と同じ理由。複合セレクタ
+      // (&.MuiButton-textWarning) は sx より詳細度が高く、使う側の指定を
+      // 握り潰してしまう
+      ...Object.fromEntries(
+        (
+          [
+            'primary',
+            'secondary',
+            'success',
+            'error',
+            'warning',
+            'info',
+          ] as const
+        ).flatMap((key) => {
+          const cap = key[0].toUpperCase() + key.slice(1)
+          const slot = ({ theme }: { theme: Theme }) => ({
+            color: theme.palette[key].textContrast,
+          })
+          return [
+            [`text${cap}`, slot],
+            [`outlined${cap}`, slot],
+          ]
+        })
+      ),
+    },
+  },
+  // 補助テキストのエラー表示。MUI 既定は error.main を使うが、これは面の
+  // ための色で、白地の 12px に置くと 4.38:1 にしかならない
+  MuiFormHelperText: {
+    styleOverrides: {
+      root: ({ theme }: { theme: Theme }) => ({
+        '&.Mui-error': { color: theme.palette.error.textContrast },
+      }),
     },
   },
   // フォームラベル: 分離スタイル（アニメーションなし、常に上部固定）
@@ -201,8 +238,10 @@ const componentStyles = {
         '&.Mui-focused': {
           color: theme.palette.text.primary,
         },
+        // error.main は面のための色。文字に使うと 12px で 4.38:1 になり
+        // 本文 AA を割る
         '&.Mui-error': {
-          color: theme.palette.error.main,
+          color: theme.palette.error.textContrast,
         },
       }),
       sizeSmall: {
@@ -249,8 +288,9 @@ const componentStyles = {
           color: theme.palette.text.primary,
         },
       }),
+      // 必須マークも文字。面のための main ではなく前景用の色を使う
       asterisk: ({ theme }: { theme: Theme }) => ({
-        color: theme.palette.error.main,
+        color: theme.palette.error.textContrast,
       }),
     },
   },


### PR DESCRIPTION
## 実測

部品 138 story を実ブラウザで測ると、**コントラスト不足が 55 箇所（15 パターン）**あった。原因は 1 つに収束していて、**セマンティックカラーの `main` を文字色として使っていた**。`main` は面のための色で、白地の 12px に置くと 2.5〜2.9:1 にしかならない。

このリポジトリには既に `textContrast`（前景専用スロット、淡い tint 面に重ねても割れないよう 1.2 倍の余裕を持つ）があり、**Chip の 6 スロットにだけ**適用されていた。同じ考え方を広げる。

## テーマ層（利用側が何を書いても効く）

- `MuiButton` の text / outlined **12 スロット**（6 色 × 2 variant）。Toast の「情報」が 2.52:1、「警告」が 2.61:1 だった
- `MuiFormHelperText` の `Mui-error` を追加。MUI 既定は `error.main` を使う
- `MuiInputLabel` の `Mui-error`、`MuiFormLabel` の `asterisk`
- `ConnectionStatusChip` は `main` の 12% tint 面に `dark` を載せていた（4.32:1）

スロット単位で上書きするのは Chip と同じ理由。複合セレクタ（`&.MuiButton-textWarning`）は `sx` より詳細度が高く、**使う側の指定を握り潰す**。

## 呼び出し側（デザインシステムの実例なので正しい書き方を示す）

- Table / Card / DataDisplay / Dashboard の Story: `main` → `textContrast`
- Card の Avatar: `bgcolor` に `main` を敷いて**文字色が未指定**だった
- Grid: `bgcolor: primary.light` に `color: primary.contrastText`。**`contrastText` は `main` の面に対して設計された色**で、`light` には合わない（3.95:1）

## やらなかったこと

`color: 'X.main'` は 72 箇所あるが、**うち 32 は `primary.main` で実測では落ちていない**（primary は濃いブルーなので白地で届く）。一括置換はせず、測定で落ちた箇所だけを直した。**閾値を満たしているものを変える理由がない。**

## 測り方

- **半透明を合成してから測る。** 祖先を辿って α を持つ層を集め、下から合成した実効背景で比を出す。これを省くと数字が嘘になる
- WCAG 1.4.3 の除外規定に従い、無効化された UI 部品と `aria-hidden` は対象外（実測で 11 件）
- 閾値は文字サイズと太さで分ける。24px 以上または 18.66px 以上の bold は 3:1、それ以外は 4.5:1。一律 4.5 だと大きな見出しを過剰に拾う

## 検証

- 部品 138 story / 1022 要素で **違反 0 件**（15 → 8 → 5 → 3 → 0 と収束）
- 675 テスト通過、型チェック通過

## 残っているもの

解説ページ（Guide / Design Tokens / Design Philosophy）には 500 箇所以上残っているが、性質が違う。`"rgba (コントラスト比算出不可)"` のように**その問題を説明している Story** や、コードのシンタックスハイライトが大半。別途仕分けが要る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jav2H6vtcjoLJk6N34N8hD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - ボタン、入力フォーム、ラベル、ステータス表示の文字色を見直し、背景色に応じたコントラストを確保しました。
  - カード、テーブル、ダッシュボード、データ表示の色表現を調整し、状態や傾向をより読み取りやすくしました。
  - 成功・警告・エラー状態の表示で、視認性とアクセシビリティが向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->