### PR TITLE
feat(a11y): 描画したコントラストを CI で測る gate を入れ、部品側の違反を直す

### DIFF
--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -179,6 +179,35 @@ jobs:
         env:
           NODE_OPTIONS: --max_old_space_size=4096
 
+      # preview.tsx は axe の自動実行を切っている（開発が重くなるため）。
+      # パネルから手で押せば動くが CI では誰も押さないので、
+      # ビルドした物を実際に描画して測る
+      - name: Install Chromium for a11y check
+        run: pnpm exec playwright install --with-deps chromium
+
+      # 配信と検査を 1 ステップにまとめる。
+      # ステップをまたいで背景プロセスが生きている前提を持たない
+      - name: Check contrast (rendered)
+        run: |
+          # 出力を捨てないと、背景プロセスがステップの stdout を掴んだままになり
+          # ログ収集が EOF を待って終わらない（ローカル実行で実際に詰まった）。
+          # 停止処理は置かない。非対話 bash では背景ジョブがスクリプト自身と
+          # 同じプロセスグループに入るため、グループごと kill すると
+          # ステップ自体が死ぬ（これもローカル実行で踏んだ）。
+          # job の終了時にランナーごと片付くので放置してよい
+          npx --yes http-server storybook-static -p 6099 --silent >/dev/null 2>&1 &
+          ready=0
+          for i in $(seq 1 30); do
+            if curl -sf -o /dev/null http://127.0.0.1:6099/index.json; then
+              ready=1; break
+            fi
+            sleep 1
+          done
+          if [ "$ready" != "1" ]; then
+            echo "Storybook を配信できませんでした"; exit 1
+          fi
+          pnpm check:a11y
+
   # Change Analysis
   change-analysis:
     name: Change Analysis

--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
     "check:live": "node scripts/check-live-secrets.mjs",
     "check:typo": "node scripts/check-rendered-typography.mjs",
     "vrt": "node scripts/vrt.mjs",
-    "check:share": "pnpm run check:anon && pnpm run check:live"
+    "check:share": "pnpm run check:anon && pnpm run check:live",
+    "check:a11y": "node scripts/check-a11y.mjs"
   },
   "peerDependencies": {
     "@emotion/react": "^11.13.5",

--- a/scripts/audit-contrast.mjs
+++ b/scripts/audit-contrast.mjs
@@ -23,141 +23,14 @@
  */
 import { chromium } from 'playwright'
 
+import { CONTRAST_AUDIT } from './lib/contrast-audit.mjs'
+
 const TARGETS = [
   ['LP', 'http://localhost:5174/'],
   ['SaaS', 'http://localhost:3003/'],
   ['KazeEats', 'http://localhost:3002/'],
   ['KazeLogistics', 'http://localhost:3004/'],
 ]
-
-const AUDIT = () => {
-  const parse = (c) => {
-    const m = c.match(/rgba?\(([^)]+)\)/)
-    if (!m) return null
-    const p = m[1].split(',').map(Number)
-    return { r: p[0], g: p[1], b: p[2], a: p.length > 3 ? p[3] : 1 }
-  }
-  const lum = ({ r, g, b }) => {
-    const f = (v) => {
-      const c = v / 255
-      return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
-    }
-    return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b)
-  }
-  // 親も子も半透明のとき、合成結果を不透明として扱うと走査がそこで
-  // 止まり、実際とは違う背景色を報告する。アルファを保って積み上げる
-  const over = (fg, bg) => {
-    const a = fg.a + bg.a * (1 - fg.a)
-    if (a === 0) return { r: 0, g: 0, b: 0, a: 0 }
-    return {
-      r: (fg.r * fg.a + bg.r * bg.a * (1 - fg.a)) / a,
-      g: (fg.g * fg.a + bg.g * bg.a * (1 - fg.a)) / a,
-      b: (fg.b * fg.a + bg.b * bg.a * (1 - fg.a)) / a,
-      a,
-    }
-  }
-  const ratio = (a, b) => {
-    const [x, y] = [lum(a), lum(b)].sort((p, q) => q - p)
-    return (x + 0.05) / (y + 0.05)
-  }
-  // 背景画像やグラデーションが挟まると、実際に描かれる面は計算できない。
-  // 「基準を割っている」と誤って報告しないよう、判定不能として分ける
-  const hasImageBackdrop = (el) => {
-    let node = el
-    while (node && node !== document.documentElement.parentNode) {
-      if (getComputedStyle(node).backgroundImage !== 'none') return true
-      node = node.parentElement
-    }
-    return false
-  }
-  const effectiveBg = (el) => {
-    let node = el,
-      acc = null
-    while (node && node !== document.documentElement.parentNode) {
-      const bg = parse(getComputedStyle(node).backgroundColor)
-      if (bg && bg.a > 0) {
-        acc = acc ? over(acc, bg) : bg
-        if (acc.a >= 1) return acc
-      }
-      node = node.parentElement
-    }
-    // 走査しきっても不透明にならなければ、ページの地（キャンバス）に落とす
-    const canvas = parse(
-      getComputedStyle(document.documentElement).backgroundColor
-    ) ?? { r: 255, g: 255, b: 255, a: 1 }
-    const base = canvas.a > 0 ? canvas : { r: 255, g: 255, b: 255, a: 1 }
-    return acc ? over(acc, { ...base, a: 1 }) : { ...base, a: 1 }
-  }
-  const out = []
-  const unknown = []
-  for (const el of document.querySelectorAll('*')) {
-    const text = [...el.childNodes]
-      .filter((n) => n.nodeType === 3)
-      .map((n) => n.textContent.trim())
-      .join('')
-    if (!text) continue
-    const cs = getComputedStyle(el)
-    if (
-      cs.visibility === 'hidden' ||
-      cs.display === 'none' ||
-      Number(cs.opacity) === 0
-    )
-      continue
-    const r = el.getBoundingClientRect()
-    if (r.width < 2 || r.height < 2) continue
-    // SVG の文字は color ではなく fill で描かれる。color を読むと
-    // 親アイコンの色を文字色と取り違える
-    const isSvgText = el.ownerSVGElement != null || el.tagName === 'text'
-    const fg = parse(isSvgText ? cs.fill : cs.color)
-    if (!fg) continue
-    const bg = effectiveBg(el)
-    const composed = fg.a < 1 ? over(fg, bg) : fg
-    const size = parseFloat(cs.fontSize)
-    const bold = Number(cs.fontWeight) >= 700
-    const large = size >= 24 || (size >= 18.66 && bold)
-    const need = large ? 3 : 4.5
-    const got = ratio(composed, bg)
-    if (got < need) {
-      // 絶対配置の要素は、背後に何が敷かれているか DOM の祖先からは分からない
-      // （兄弟のスクリムや画像の上に乗る）。破綻と断定できない
-      const floating = (() => {
-        let n = el
-        while (n && n !== document.body) {
-          const pos = getComputedStyle(n).position
-          if (pos === 'absolute' || pos === 'fixed') return true
-          n = n.parentElement
-        }
-        return false
-      })()
-      if (hasImageBackdrop(el) || floating) {
-        unknown.push(text.slice(0, 30))
-        continue
-      }
-      out.push({
-        text: text.slice(0, 34),
-        got: Math.round(got * 100) / 100,
-        need,
-        color: cs.color,
-        bg: `rgb(${Math.round(bg.r)},${Math.round(bg.g)},${Math.round(bg.b)})`,
-        size,
-        disabled: el.closest('[disabled],.Mui-disabled') != null,
-      })
-    }
-  }
-  // 明るい面がダークに混ざっていないか
-  const bright = []
-  for (const el of document.querySelectorAll('*')) {
-    const bg = parse(getComputedStyle(el).backgroundColor)
-    if (!bg || bg.a < 0.9) continue
-    const r = el.getBoundingClientRect()
-    if (r.width * r.height < 4000) continue
-    if (lum(bg) > 0.5)
-      bright.push(
-        `${el.tagName}.${String(el.className).slice(0, 24)} rgb(${bg.r},${bg.g},${bg.b})`
-      )
-  }
-  return { fails: out, unknown, bright: bright.slice(0, 6) }
-}
 
 const SCHEMES = (process.env.AUDIT_SCHEMES ?? 'light').split(',')
 
@@ -172,7 +45,7 @@ for (const [name, url] of TARGETS) {
     try {
       await p.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 })
       await p.waitForTimeout(4000)
-      const r = await p.evaluate(AUDIT)
+      const r = await p.evaluate(CONTRAST_AUDIT)
       const real = r.fails.filter((f) => !f.disabled)
       console.log(
         `\n### ${name} / ${scheme}: 破綻 ${real.length} 件 (disabled 除外 ${r.fails.length - real.length} / 背景画像で判定不能 ${r.unknown.length})`

--- a/scripts/check-a11y.mjs
+++ b/scripts/check-a11y.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+/**
+ * **描画された** Storybook のコントラストを検査する。
+ *
+ *   pnpm check:a11y              既定（部品カテゴリのみ）
+ *   pnpm check:a11y --all        解説カテゴリも含めて全 story
+ *   A11Y_URL=... pnpm check:a11y 配信先を差し替える
+ *
+ * なぜ addon-a11y と別に要るか:
+ *
+ * `.storybook/preview.tsx` は axe の自動実行を切っている（ページ遷移の
+ * たびに走ると開発が重いため）。パネルから手で押せば動くが、**CI では
+ * 誰も押さない**。実際 CI は build-storybook を回すだけで、a11y は
+ * 一度も検査されていなかった。押し忘れを検出できない仕組みは無いのと同じ。
+ *
+ * なぜ axe でなく自前の計算か:
+ *
+ * 半透明を合成してから測る必要がある。素の背景色をそのまま使うと、
+ * `alpha(color, 0.12)` を敷いた面の上の文字を実際より低く見積もる
+ * （テーブル見出しを 2.56:1 と報告しかけたが、合成すると 5.16:1 だった）。
+ * 計算部は scripts/audit-contrast.mjs で検証済みのものを共有している。
+ *
+ * 何を対象から外しているか（黙って減らさない）:
+ *
+ * 解説カテゴリ（Design Tokens / Guide / Design Philosophy）は、色見本や
+ * 「悪い例」を意図的に描画する。ここを混ぜると常時赤になり、gate として
+ * 機能しない。--all を付ければ数字は出るので、隠してはいない。
+ */
+
+import { chromium } from 'playwright'
+
+import { CONTRAST_AUDIT } from './lib/contrast-audit.mjs'
+
+const URL = process.env.A11Y_URL ?? 'http://localhost:6099'
+const SHOW_ALL = process.argv.includes('--all')
+
+/**
+ * 意図的に基準外の見本を描く解説カテゴリ。
+ * 既定の gate からは外すが、外したことは必ず出力する
+ */
+const DOC_PREFIXES = [
+  'design-tokens-',
+  'guide-',
+  'design-philosophy-',
+  'tools-',
+]
+
+/**
+ * 描画されたかの判定。
+ * 「判定できた文字要素の数」で見てはいけない。Button 単体の story は
+ * 正常でも文字要素が 1 つしか無く、61 件を誤って「描画失敗」と数えた。
+ * story 本体の DOM 要素数と、Storybook のエラー表示の有無で見る
+ */
+const MIN_DOM_NODES = 10
+
+const LIVENESS = () => {
+  const root = document.querySelector('#storybook-root')
+  const err = document.querySelector('.sb-errordisplay')
+  return {
+    nodes: root ? root.querySelectorAll('*').length : 0,
+    // .sb-errordisplay は常に DOM にある。表示されているかで見る
+    errorShown: !!err && getComputedStyle(err).display !== 'none',
+  }
+}
+
+const isDoc = (id) => DOC_PREFIXES.some((p) => id.startsWith(p))
+
+let index
+try {
+  index = await (await fetch(`${URL}/index.json`)).json()
+} catch {
+  console.error(
+    `❌ Storybook が配信されていません (${URL})\n` +
+      '   pnpm build-storybook してから静的配信し、A11Y_URL で指すか 6099 で配信してください。'
+  )
+  process.exit(1)
+}
+
+const all = Object.values(index.entries).filter((e) => e.type === 'story')
+const targets = SHOW_ALL ? all : all.filter((e) => !isDoc(e.id))
+const skipped = all.length - targets.length
+
+if (targets.length === 0) {
+  console.error(
+    '❌ 対象 story が 0 件です。index.json の中身を確認してください。'
+  )
+  process.exit(1)
+}
+
+const browser = await chromium.launch()
+const page = await browser.newPage({ viewport: { width: 1280, height: 900 } })
+
+const fails = new Map()
+let unknown = 0
+let checked = 0
+let empty = 0
+
+for (const story of targets) {
+  try {
+    await page.goto(`${URL}/iframe.html?id=${story.id}&viewMode=story`, {
+      waitUntil: 'load',
+      timeout: 20000,
+    })
+    await page.waitForTimeout(160)
+
+    // 描画に失敗した story は違反 0 件を返す。確認しないと壊れた画面ほど緑になる
+    const live = await page.evaluate(LIVENESS)
+    if (live.errorShown || live.nodes < MIN_DOM_NODES) {
+      empty++
+      console.error(
+        `  ⚠ ${story.id}: 描画されていません（要素 ${live.nodes} / エラー表示 ${live.errorShown}）`
+      )
+      continue
+    }
+
+    const r = await page.evaluate(CONTRAST_AUDIT)
+    checked++
+    unknown += r.unknown.length
+
+    // disabled な部品は WCAG 1.4.3 の対象外
+    for (const f of r.fails.filter((x) => !x.disabled)) {
+      // 同じ原因（同じ色・同じ要素）は 1 行にまとめる。
+      // 文字列を key に入れるとカレンダーの日付が 1 日 1 行になって読めない
+      const key = `${f.got}|${f.need}|${f.label}|${f.color}|${f.bg}`
+      const prev = fails.get(key)
+      fails.set(key, {
+        ...f,
+        n: (prev?.n ?? 0) + 1,
+        samples: [...new Set([...(prev?.samples ?? []), f.text])].slice(0, 4),
+        where: prev?.where ?? story.title,
+      })
+    }
+  } catch {
+    empty++
+  }
+}
+
+await browser.close()
+
+const rows = [...fails.values()].sort((a, b) => a.got - b.got)
+const count = rows.reduce((a, r) => a + r.n, 0)
+
+console.log(
+  `${checked} story / 判定不能 ${unknown} 箇所` +
+    (skipped ? ` / 解説カテゴリ ${skipped} story は対象外` : '')
+)
+for (const r of rows) {
+  console.log(
+    `  ${r.got}:1 (要 ${r.need}) ${r.size}px ×${r.n}  ${r.color} on ${r.bg}\n` +
+      `      ${r.label} @${r.where}  例: ${r.samples.map((s) => `"${s}"`).join(' ')}`
+  )
+}
+
+if (empty) {
+  console.error(
+    `\n⚠ ${empty} story を判定できませんでした（描画失敗の可能性）。` +
+      '未検査が残っているので緑とみなせません。'
+  )
+  process.exit(1)
+}
+
+if (count) {
+  console.error(
+    `\n❌ コントラスト不足 ${count} 箇所 / ${rows.length} パターン\n` +
+      '   面の色 (main) を文字に使っていないか確認してください。' +
+      '前景用には textContrast があります。'
+  )
+  process.exit(1)
+}
+
+console.log('\n✅ 描画結果にコントラスト不足なし')

--- a/scripts/lib/contrast-audit.mjs
+++ b/scripts/lib/contrast-audit.mjs
@@ -1,0 +1,185 @@
+/**
+ * 実描画のコントラスト計算（単一ソース）
+ *
+ * scripts/audit-contrast.mjs（アプリを測る）と scripts/check-a11y.mjs
+ * （Storybook を測る）が同じ計算を使う。片方だけ直すと数字が食い違う。
+ *
+ * ここでの判断:
+ * - 半透明は祖先を辿って合成してから測る。素の背景色で測ると嘘の数字になる
+ * - 背景画像・グラデーションの上、絶対配置の要素は「判定不能」として分ける。
+ *   下地が確定しないので、破綻と断定すると誤報になる
+ * - SVG の文字は color ではなく fill で描かれる
+ * - WCAG 2.1 1.4.3: 24px 以上 / 18.66px 以上の bold は 3:1、それ以外は 4.5:1
+ *
+ * この関数は page.evaluate に渡してブラウザ内で走る。外の変数を参照しない
+ */
+export const CONTRAST_AUDIT = () => {
+  const parse = (c) => {
+    const m = c.match(/rgba?\(([^)]+)\)/)
+    if (!m) return null
+    const p = m[1].split(',').map(Number)
+    return { r: p[0], g: p[1], b: p[2], a: p.length > 3 ? p[3] : 1 }
+  }
+  const lum = ({ r, g, b }) => {
+    const f = (v) => {
+      const c = v / 255
+      return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+    }
+    return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b)
+  }
+  // 親も子も半透明のとき、合成結果を不透明として扱うと走査がそこで
+  // 止まり、実際とは違う背景色を報告する。アルファを保って積み上げる
+  const over = (fg, bg) => {
+    const a = fg.a + bg.a * (1 - fg.a)
+    if (a === 0) return { r: 0, g: 0, b: 0, a: 0 }
+    return {
+      r: (fg.r * fg.a + bg.r * bg.a * (1 - fg.a)) / a,
+      g: (fg.g * fg.a + bg.g * bg.a * (1 - fg.a)) / a,
+      b: (fg.b * fg.a + bg.b * bg.a * (1 - fg.a)) / a,
+      a,
+    }
+  }
+  const ratio = (a, b) => {
+    const [x, y] = [lum(a), lum(b)].sort((p, q) => q - p)
+    return (x + 0.05) / (y + 0.05)
+  }
+  // 背景画像やグラデーションが挟まると、実際に描かれる面は計算できない。
+  // 「基準を割っている」と誤って報告しないよう、判定不能として分ける
+  const hasImageBackdrop = (el) => {
+    let node = el
+    while (node && node !== document.documentElement.parentNode) {
+      if (getComputedStyle(node).backgroundImage !== 'none') return true
+      node = node.parentElement
+    }
+    return false
+  }
+  const effectiveBg = (el) => {
+    let node = el,
+      acc = null
+    while (node && node !== document.documentElement.parentNode) {
+      const bg = parse(getComputedStyle(node).backgroundColor)
+      if (bg && bg.a > 0) {
+        acc = acc ? over(acc, bg) : bg
+        if (acc.a >= 1) return acc
+      }
+      node = node.parentElement
+    }
+    // 走査しきっても不透明にならなければ、ページの地（キャンバス）に落とす
+    const canvas = parse(
+      getComputedStyle(document.documentElement).backgroundColor
+    ) ?? { r: 255, g: 255, b: 255, a: 1 }
+    const base = canvas.a > 0 ? canvas : { r: 255, g: 255, b: 255, a: 1 }
+    return acc ? over(acc, { ...base, a: 1 }) : { ...base, a: 1 }
+  }
+  /**
+   * SVG の文字の実際の下地。
+   *
+   * 文字を覆っている塗り図形のうち**最も小さいもの**を採る。
+   * 「最大の図形」にすると、図解 SVG で地の白い矩形を拾い、色付きの箱に
+   * 乗った白文字を「白地の上の白文字」と誤報する。
+   * 覆う図形が無ければ DOM 祖先の背景に落とす
+   */
+  const svgBackdrop = (el) => {
+    const svg = el.ownerSVGElement
+    if (!svg) return effectiveBg(el)
+    const t = el.getBoundingClientRect()
+    const cx = t.left + t.width / 2
+    const cy = t.top + t.height / 2
+    let best = null
+    let bestArea = Infinity
+    for (const shape of svg.querySelectorAll(
+      'circle,rect,path,ellipse,polygon'
+    )) {
+      const f = parse(getComputedStyle(shape).fill)
+      if (!f || f.a === 0) continue
+      const r = shape.getBoundingClientRect()
+      // 文字の中心を覆っているものだけが下地になりうる
+      if (cx < r.left || cx > r.right || cy < r.top || cy > r.bottom) continue
+      const area = r.width * r.height
+      if (area > 0 && area < bestArea) {
+        bestArea = area
+        best = f
+      }
+    }
+    if (!best) return effectiveBg(el)
+    // 図形が半透明なら、その下の面と合成する
+    return best.a >= 1 ? best : over(best, effectiveBg(el))
+  }
+
+  const out = []
+  const unknown = []
+  // 判定できた要素数。0 に近ければ描画されていない
+  let total = 0
+  for (const el of document.querySelectorAll('*')) {
+    const text = [...el.childNodes]
+      .filter((n) => n.nodeType === 3)
+      .map((n) => n.textContent.trim())
+      .join('')
+    if (!text) continue
+    const cs = getComputedStyle(el)
+    if (
+      cs.visibility === 'hidden' ||
+      cs.display === 'none' ||
+      Number(cs.opacity) === 0
+    )
+      continue
+    const r = el.getBoundingClientRect()
+    if (r.width < 2 || r.height < 2) continue
+    // SVG の文字は color ではなく fill で描かれる。color を読むと
+    // 親アイコンの色を文字色と取り違える
+    const isSvgText = el.ownerSVGElement != null || el.tagName === 'text'
+    const fg = parse(isSvgText ? cs.fill : cs.color)
+    if (!fg) continue
+    total++
+    // SVG の文字の下地は、DOM 祖先の background-color ではなく同じ svg 内の
+    // 図形の fill。祖先を辿ると「白い数字を白いページ地の上」と測ってしまう
+    // （Stepper の現在ステップを 1:1 と誤報した）
+    const bg = isSvgText ? svgBackdrop(el) : effectiveBg(el)
+    const composed = fg.a < 1 ? over(fg, bg) : fg
+    const size = parseFloat(cs.fontSize)
+    const bold = Number(cs.fontWeight) >= 700
+    const large = size >= 24 || (size >= 18.66 && bold)
+    const need = large ? 3 : 4.5
+    const got = ratio(composed, bg)
+    if (got < need) {
+      // 絶対配置の要素は、背後に何が敷かれているか DOM の祖先からは分からない
+      // （兄弟のスクリムや画像の上に乗る）。破綻と断定できない
+      const floating = (() => {
+        let n = el
+        while (n && n !== document.body) {
+          const pos = getComputedStyle(n).position
+          if (pos === 'absolute' || pos === 'fixed') return true
+          n = n.parentElement
+        }
+        return false
+      })()
+      if (hasImageBackdrop(el) || floating) {
+        unknown.push(text.slice(0, 30))
+        continue
+      }
+      out.push({
+        text: text.slice(0, 34),
+        label: `${el.tagName}${el.className && typeof el.className === 'string' ? '.' + el.className.split(' ').slice(0, 2).join('.') : ''}`,
+        got: Math.round(got * 100) / 100,
+        need,
+        color: isSvgText ? cs.fill : cs.color,
+        bg: `rgb(${Math.round(bg.r)},${Math.round(bg.g)},${Math.round(bg.b)})`,
+        size,
+        disabled: el.closest('[disabled],.Mui-disabled') != null,
+      })
+    }
+  }
+  // 明るい面がダークに混ざっていないか
+  const bright = []
+  for (const el of document.querySelectorAll('*')) {
+    const bg = parse(getComputedStyle(el).backgroundColor)
+    if (!bg || bg.a < 0.9) continue
+    const r = el.getBoundingClientRect()
+    if (r.width * r.height < 4000) continue
+    if (lum(bg) > 0.5)
+      bright.push(
+        `${el.tagName}.${String(el.className).slice(0, 24)} rgb(${bg.r},${bg.g},${bg.b})`
+      )
+  }
+  return { fails: out, unknown, bright: bright.slice(0, 6), total }
+}

--- a/src/components/ui/calendar/monthView.tsx
+++ b/src/components/ui/calendar/monthView.tsx
@@ -115,10 +115,11 @@ export const MonthView = ({
               variant='body2'
               sx={{
                 fontWeight: 400,
+                // main は面のための色。文字に使うと 12px で 2.5〜4.4:1 にしかならない
                 color: isSunday(index)
-                  ? 'error.main'
+                  ? 'error.textContrast'
                   : isSaturday(index)
-                    ? 'info.main'
+                    ? 'info.textContrast'
                     : 'text.primary',
               }}>
               {dayName}
@@ -182,12 +183,14 @@ export const MonthView = ({
                         bgcolor: isToday(date) ? 'primary.main' : 'transparent',
                         color: isToday(date)
                           ? 'primary.contrastText'
-                          : !isCurrentMonth(date)
-                            ? 'text.disabled'
+                          : // 当月外の日付は「無効な操作対象」ではなく読む情報。
+                            // text.disabled では 1.64:1 で読めない
+                            !isCurrentMonth(date)
+                            ? 'text.secondary'
                             : isSunday(dayIndex)
-                              ? 'error.main'
+                              ? 'error.textContrast'
                               : isSaturday(dayIndex)
-                                ? 'info.main'
+                                ? 'info.textContrast'
                                 : 'text.primary',
                         fontWeight: isToday(date) ? 700 : 400,
                       }}>

--- a/src/components/ui/text/sectionTitle.tsx
+++ b/src/components/ui/text/sectionTitle.tsx
@@ -29,7 +29,8 @@ export const SectionTitle = ({
             mb: -0.5,
             mr: 1,
             ml: 0,
-            color: theme.palette.error.main,
+            // main は面のための色。18.2px の非太字では 4.38:1 で 4.5 に届かない
+            color: theme.palette.error.textContrast,
             fontSize: '1.3em',
             lineHeight: '1',
             ...(props.sx || {}),


### PR DESCRIPTION
## なぜ

`.storybook/preview.tsx` はaxeの自動実行を切っている（ページ遷移のたびに走ると開発が重い）。パネルから手で押せば動くが、**CIでは誰も押さない**。実際CIは `build-storybook` を回すだけで、a11yは一度も検査されていなかった。押し忘れを検出できない仕組みは、無いのと同じ。

ビルドした物を実ブラウザで描画して測るgateを足した。

## 何を測るか

`pnpm check:a11y` — 部品カテゴリ138 storyを実描画して、WCAG 2.1 1.4.3のコントラストを見る。**約1分**。

計算は `scripts/lib/contrast-audit.mjs` に単一ソース化し、アプリを測る `audit-contrast.mjs` と共有する。片方だけ直して数字が食い違うのを防ぐ。

### axeではなく自前の計算にした理由

半透明を合成してから測る必要がある。素の `backgroundColor` を使うと `alpha(color, 0.12)` を敷いた面の上の文字を実際より低く見積もる（過去にテーブル見出しを2.56:1と報告しかけたが、合成すると5.16:1だった）。

### SVGの下地の取り方を直した

SVGの文字の下地はDOM祖先の `background-color` ではなく、同じ `<svg>` 内の図形の `fill`。祖先を辿ると **Stepperの現在ステップ（青丸の上の白文字、実際は約7.4:1）を1:1と誤報**していた。

覆う図形のうち**最小のもの**を採る。「最大」にすると図解SVGで地の白い矩形を拾い、色付きの箱に乗った白文字を「白地の白文字」と誤報する（実際に踏んだ）。

### 対象から外したもの（黙って減らさない）

解説カテゴリ（`design-tokens-` / `guide-` / `design-philosophy-` / `tools-`）63 storyは、色見本と意図的な悪い例を描くので既定のgateから外した。外した件数は必ず出力し、`--all` で数字も出せる。

`--all` で見つかったGuide図解の実際の不具合は https://github.com/BoxPistols/kaze-ux/issues/115 に分けた（白地に白の `⚙` 等）。

## 直した違反（部品側24箇所 → 0）

| 場所 | 前 | 原因 | 後 |
| --- | --- | --- | --- |
| `monthView` 曜日ヘッダー | 2.52:1 / 4.38:1 | `error.main` / `info.main` を文字色に使用 | `error.textContrast` / `info.textContrast` |
| `monthView` 日付セル | 2.52:1 / 4.38:1 | 同上 | 同上 |
| `monthView` 当月外の日付 | 1.64:1 | `text.disabled`。これは「無効な操作対象」ではなく読む情報 | `text.secondary` |
| `sectionTitle` 必須マーク `*` | 4.38:1 | `error.main`。18.2px非太字は4.5が要る | `error.textContrast` |

`main` は面のための色で、文字に使うと12px前後では基準に届かない。前景用の `textContrast` を使う。

## 検証

**gateが緑になること**

```
138 story / 判定不能 0 箇所 / 解説カテゴリ 63 story は対象外

✅ 描画結果にコントラスト不足なし
```

**gateが落ちうること**（落ちないgateを入れない）

`--all` で解説カテゴリを混ぜるとexit 1で574箇所を報告する。

**描画判定が働くこと**

存在しないstoryを指すと `.sb-errordisplay` を検出する。story本体のDOM要素数で見ており、Button単体のように文字要素が1つしかないstoryを誤って「描画失敗」と数えない（最初にこれで61件を誤判定した）。

**CIステップをローカルで実行して確認**

YAMLから `run:` ブロックを抜き出してそのまま回し、exit 0 / exit 1の両方を確認した。過程で2つ自分の書き方の不具合を潰している。

- 背景プロセスがステップのstdoutを掴んだままだとログ収集がEOFを待って終わらない → `>/dev/null 2>&1`
- 非対話bashでは背景ジョブがスクリプト自身と同じプロセスグループに入るため、`kill -- -$PGID` でステップ自体が死ぬ → 停止処理は置かない（job終了時にランナーごと片付く）

- `pnpm test:run` 686件 / 40ファイルgreen
- `tsc --noEmit` / `pnpm lint` / `prettier --check` clean

## 残り

- ダークモードは未測定（今はlightのみ）
- タッチターゲット寸法（WCAG 2.2 SC 2.5.8）は未測定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jav2H6vtcjoLJk6N34N8hD
