### PR TITLE
fix(docs): Guide の図解 SVG の文字色を面に合わせ、半透明図形の測り方を直す

### DIFF
--- a/scripts/check-a11y.mjs
+++ b/scripts/check-a11y.mjs
@@ -95,25 +95,55 @@ let unknown = 0
 let checked = 0
 let empty = 0
 
-for (const story of targets) {
-  try {
-    await page.goto(`${URL}/iframe.html?id=${story.id}&viewMode=story`, {
-      waitUntil: 'load',
-      timeout: 20000,
-    })
-    await page.waitForTimeout(160)
+/**
+ * 1 story を測る。読み込みに失敗した場合は null を返す。
+ *
+ * 一度の失敗で赤にしない。マシンが混んでいると読み込みが 20 秒を
+ * 超えることがあり、それで gate が落ちると「たまに落ちるので無視」に
+ * なって検査そのものが死ぬ。ただし**再試行しても駄目なら落とす**
+ */
+const measure = async (story) => {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      await page.goto(`${URL}/iframe.html?id=${story.id}&viewMode=story`, {
+        waitUntil: 'load',
+        timeout: attempt === 0 ? 20000 : 40000,
+      })
+      await page.waitForTimeout(160)
 
-    // 描画に失敗した story は違反 0 件を返す。確認しないと壊れた画面ほど緑になる
-    const live = await page.evaluate(LIVENESS)
-    if (live.errorShown || live.nodes < MIN_DOM_NODES) {
-      empty++
-      console.error(
-        `  ⚠ ${story.id}: 描画されていません（要素 ${live.nodes} / エラー表示 ${live.errorShown}）`
-      )
-      continue
+      // 描画に失敗した story は違反 0 件を返す。確認しないと壊れた画面ほど緑になる
+      const live = await page.evaluate(LIVENESS)
+      // エラー表示は再試行しても変わらないので即座に確定させる
+      if (live.errorShown) return { live, r: null }
+      if (live.nodes < MIN_DOM_NODES) {
+        if (attempt === 0) continue
+        return { live, r: null }
+      }
+      return { live, r: await page.evaluate(CONTRAST_AUDIT) }
+    } catch {
+      // 読み込み自体の失敗。次の試行へ
     }
+  }
+  return null
+}
 
-    const r = await page.evaluate(CONTRAST_AUDIT)
+for (const story of targets) {
+  const measured = await measure(story)
+
+  if (!measured || !measured.r) {
+    empty++
+    const live = measured?.live
+    console.error(
+      `  ⚠ ${story.id}: 描画されていません` +
+        (live
+          ? `（要素 ${live.nodes} / エラー表示 ${live.errorShown}）`
+          : '（読み込みに 2 回失敗）')
+    )
+    continue
+  }
+
+  {
+    const r = measured.r
     checked++
     unknown += r.unknown.length
 
@@ -130,8 +160,6 @@ for (const story of targets) {
         where: prev?.where ?? story.title,
       })
     }
-  } catch {
-    empty++
   }
 }
 

--- a/scripts/lib/contrast-audit.mjs
+++ b/scripts/lib/contrast-audit.mjs
@@ -85,25 +85,29 @@ export const CONTRAST_AUDIT = () => {
     const t = el.getBoundingClientRect()
     const cx = t.left + t.width / 2
     const cy = t.top + t.height / 2
-    let best = null
-    let bestArea = Infinity
+    // 文字の中心を覆う図形を、小さい順（＝上に描かれている順）に集める。
+    // 半透明の図形は下の図形と合成しないと正しい面にならない。
+    // DOM 祖先へ直に落とすと、青い帯の上の 20% 白チップを「白」と測る
+    const covering = []
     for (const shape of svg.querySelectorAll(
       'circle,rect,path,ellipse,polygon'
     )) {
       const f = parse(getComputedStyle(shape).fill)
       if (!f || f.a === 0) continue
       const r = shape.getBoundingClientRect()
-      // 文字の中心を覆っているものだけが下地になりうる
       if (cx < r.left || cx > r.right || cy < r.top || cy > r.bottom) continue
       const area = r.width * r.height
-      if (area > 0 && area < bestArea) {
-        bestArea = area
-        best = f
-      }
+      if (area > 0) covering.push({ f, area })
     }
-    if (!best) return effectiveBg(el)
-    // 図形が半透明なら、その下の面と合成する
-    return best.a >= 1 ? best : over(best, effectiveBg(el))
+    if (covering.length === 0) return effectiveBg(el)
+    covering.sort((a, b) => a.area - b.area)
+    let acc = null
+    for (const { f } of covering) {
+      acc = acc ? over(acc, f) : f
+      if (acc.a >= 1) return acc
+    }
+    // 図形を積んでも不透明にならなければ、その下は DOM の面
+    return over(acc, effectiveBg(el))
   }
 
   const out = []

--- a/src/stories/00-Guide/ForDesigners.stories.tsx
+++ b/src/stories/00-Guide/ForDesigners.stories.tsx
@@ -470,7 +470,7 @@ const ForDesignersContent = () => {
             x='110'
             y='78'
             textAnchor='middle'
-            fill={theme.palette.primary.main}
+            fill={theme.palette.primary.textContrast}
             style={{
               fontSize: '14px',
               fontWeight: 700,
@@ -580,7 +580,7 @@ const ForDesignersContent = () => {
             x='610'
             y='78'
             textAnchor='middle'
-            fill={theme.palette.success.main}
+            fill={theme.palette.success.textContrast}
             style={{
               fontSize: '14px',
               fontWeight: 700,

--- a/src/stories/00-Guide/HowToUse.stories.tsx
+++ b/src/stories/00-Guide/HowToUse.stories.tsx
@@ -183,13 +183,15 @@ const HowToUseContent = () => {
             style={{ fontSize: 12, fill: 'rgba(255,255,255,0.8)' }}>
             Padding: Standard / None
           </text>
+          {/* 白 0.2 だと合成後の面が明るく、上に乗る白の歯車が 4.49:1 で
+              4.5 に 0.01 届かない。面を少し暗くして前景の余裕を作る */}
           <rect
             x='670'
             y='12'
             width='24'
             height='24'
             rx='4'
-            fill='rgba(255,255,255,0.2)'
+            fill='rgba(255,255,255,0.15)'
           />
           <text
             x='676'

--- a/src/stories/00-Guide/MuiTailwind.stories.tsx
+++ b/src/stories/00-Guide/MuiTailwind.stories.tsx
@@ -95,8 +95,10 @@ const MuiTailwindContent = () => {
           <defs>
             <style>{`
               .at-text { font-family: -apple-system, BlinkMacSystemFont, sans-serif; }
-              .at-title { font-size: 14px; font-weight: 700; fill: #fff; }
-              .at-file { font-size: 12px; fill: rgba(255,255,255,0.7); font-family: ui-monospace, monospace; }
+              /* fill は箱ごとに変わるので指定しない。白を固定すると
+                 success.main の上で 2.92:1、0.7 の白は 2.17:1 まで落ちる */
+              .at-title { font-size: 14px; font-weight: 700; }
+              .at-file { font-size: 12px; font-family: ui-monospace, monospace; }
               .at-label { font-size: 12px; fill: ${theme.palette.text.primary}; }
               .at-code { font-size: 12px; fill: ${theme.palette.text.secondary}; font-family: ui-monospace, monospace; }
               .at-arrow { stroke: ${theme.palette.primary.main}; stroke-width: 2.5; fill: none; marker-end: url(#arrowhead); }
@@ -124,10 +126,20 @@ const MuiTailwindContent = () => {
             rx='10'
             fill={theme.palette.primary.main}
           />
-          <text x='110' y='38' textAnchor='middle' className='at-text at-title'>
+          <text
+            x='110'
+            y='38'
+            textAnchor='middle'
+            className='at-text at-title'
+            fill={theme.palette.primary.contrastText}>
             MUI Theme
           </text>
-          <text x='110' y='58' textAnchor='middle' className='at-text at-file'>
+          <text
+            x='110'
+            y='58'
+            textAnchor='middle'
+            className='at-text at-file'
+            fill={theme.palette.primary.contrastText}>
             src/themes/theme.ts
           </text>
 
@@ -140,10 +152,20 @@ const MuiTailwindContent = () => {
             rx='10'
             fill={theme.palette.success.main}
           />
-          <text x='360' y='38' textAnchor='middle' className='at-text at-title'>
+          <text
+            x='360'
+            y='38'
+            textAnchor='middle'
+            className='at-text at-title'
+            fill={theme.palette.success.contrastText}>
             CSS Variables
           </text>
-          <text x='360' y='58' textAnchor='middle' className='at-text at-file'>
+          <text
+            x='360'
+            y='58'
+            textAnchor='middle'
+            className='at-text at-file'
+            fill={theme.palette.success.contrastText}>
             src/index.css
           </text>
 
@@ -156,10 +178,20 @@ const MuiTailwindContent = () => {
             rx='10'
             fill={theme.palette.info.main}
           />
-          <text x='610' y='38' textAnchor='middle' className='at-text at-title'>
+          <text
+            x='610'
+            y='38'
+            textAnchor='middle'
+            className='at-text at-title'
+            fill={theme.palette.info.contrastText}>
             Tailwind Config
           </text>
-          <text x='610' y='58' textAnchor='middle' className='at-text at-file'>
+          <text
+            x='610'
+            y='58'
+            textAnchor='middle'
+            className='at-text at-file'
+            fill={theme.palette.info.contrastText}>
             tailwind.config.js
           </text>
 


### PR DESCRIPTION
## まず訂正

https://github.com/BoxPistols/kaze-ux/issues/115 に「白地に白で完全に見えない」と書いたが、**それは自分の測り方が原因の誇張**だった。

SVGの半透明図形の下地をDOM祖先の背景に直接落としていたため、青い帯の上に置かれた20% 白のチップを「白」と測り、その上の白い歯車を1:1と報告していた。図形を上から順に合成するよう直すと **4.49:1**。4.5に0.01届かないという話で、不可視ではない。

同じ理由でissueの表に載せた比率も一部ずれていた。実際に直すべきだった箇所は下表の通り。

## 計測側

- `svgBackdrop` が、文字を覆う図形を**小さい順（＝上に描かれている順）に合成**するようにした。1枚目が不透明ならそこで確定、積んでも不透明にならなければDOMの面に落とす
- 読み込み失敗を **1回だけ再試行**する。混雑時に20秒を超えて赤になると「たまに落ちるので無視」になり、検査そのものが死ぬ。ただしエラー表示は再試行しても変わらないので即座に確定させる（壊れたstoryを再試行で隠さない）

## 図解側（実測で確認した違反のみ）

| 場所 | 前 | 原因 | 後 |
| --- | --- | --- | --- |
| MuiTailwind統合アーキテクチャ図 | 2.92:1 / 2.17:1 | 3つの箱に対し文字を `#fff` と `rgba(255,255,255,0.7)` で固定。`success.main` の上では届かない | 箱ごとに `contrastText` |
| HowToUseツールバー図の歯車 | 4.49:1 | チップの白0.2で合成後の面が明るい | チップを0.15にして面を暗くする |
| ForDesignersフロー図の見出し | 2.76:1 | `primary.main` / `success.main` を文字色に使用（薄いtintの上） | `textContrast` |

`.at-title` / `.at-file` の共有クラスから `fill` を外し、箱ごとに指定する形にした。共有クラスに白を固定すると、どれか1つの面で必ず割れる。

## 検証

- 部品カテゴリ138 story: 違反0 / 判定不能0で緑
- `--all`（解説カテゴリ込み）で **SVG図解の違反0件**（変更前は6件）
- `index.json` に存在しないstoryを1件足した配信に対して実行し、**exit 1** かつ該当idが出力されることを確認。再試行が壊れたstoryを隠していない

```
⚠ components-bogus--does-not-exist: 描画されていません（要素 0 / エラー表示 true）
138 story / 判定不能 0 箇所 / 解説カテゴリ 63 story は対象外
⚠ 1 story を判定できませんでした（描画失敗の可能性）。未検査が残っているので緑とみなせません。
```

- `pnpm test:run` 686件 / 40ファイルgreen
- `tsc --noEmit` / `pnpm lint` / `prettier --check` clean

## 残り

`--all` には解説カテゴリの違反がまだ残るが、色見本・コントラストの「良い例 / 悪い例」の実演が大半で、図解の不具合とは性質が違う。仕分けは別途。

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jav2H6vtcjoLJk6N34N8hD
