### PR TITLE
fix(a11y): 操作対象の寸法を CI で測り、24x24 に届かない箇所を直す

### DIFF
--- a/scripts/check-a11y.mjs
+++ b/scripts/check-a11y.mjs
@@ -30,6 +30,7 @@
 import { chromium } from 'playwright'
 
 import { CONTRAST_AUDIT } from './lib/contrast-audit.mjs'
+import { TAP_TARGET_AUDIT } from './lib/tap-target-audit.mjs'
 
 const URL = process.env.A11Y_URL ?? 'http://localhost:6099'
 const SHOW_ALL = process.argv.includes('--all')
@@ -90,10 +91,15 @@ if (targets.length === 0) {
 const browser = await chromium.launch()
 const page = await browser.newPage({ viewport: { width: 1280, height: 900 } })
 
+/** WCAG 2.2 SC 2.5.8 (AA) の最小操作対象。44 は 2.5.5 (AAA) なので使わない */
+const MIN_TAP_PX = 24
+
 const fails = new Map()
+const tapFails = new Map()
 let unknown = 0
 let checked = 0
 let empty = 0
+let tapTotal = 0
 
 /**
  * 1 story を測る。読み込みに失敗した場合は null を返す。
@@ -109,7 +115,7 @@ const measure = async (story) => {
         waitUntil: 'load',
         timeout: attempt === 0 ? 20000 : 40000,
       })
-      await page.waitForTimeout(160)
+      await page.waitForTimeout(400)
 
       // 描画に失敗した story は違反 0 件を返す。確認しないと壊れた画面ほど緑になる
       const live = await page.evaluate(LIVENESS)
@@ -119,7 +125,11 @@ const measure = async (story) => {
         if (attempt === 0) continue
         return { live, r: null }
       }
-      return { live, r: await page.evaluate(CONTRAST_AUDIT) }
+      return {
+        live,
+        r: await page.evaluate(CONTRAST_AUDIT),
+        tap: await page.evaluate(TAP_TARGET_AUDIT, MIN_TAP_PX),
+      }
     } catch {
       // 読み込み自体の失敗。次の試行へ
     }
@@ -160,6 +170,18 @@ for (const story of targets) {
         where: prev?.where ?? story.title,
       })
     }
+
+    tapTotal += measured.tap.total
+    for (const f of measured.tap.fails) {
+      const key = `${f.label}|${f.w}x${f.h}`
+      const prev = tapFails.get(key)
+      tapFails.set(key, {
+        ...f,
+        n: (prev?.n ?? 0) + 1,
+        samples: [...new Set([...(prev?.samples ?? []), f.text])].slice(0, 3),
+        where: prev?.where ?? story.title,
+      })
+    }
   }
 }
 
@@ -168,14 +190,29 @@ await browser.close()
 const rows = [...fails.values()].sort((a, b) => a.got - b.got)
 const count = rows.reduce((a, r) => a + r.n, 0)
 
+const tapRows = [...tapFails.values()].sort((a, b) => a.h * a.w - b.h * b.w)
+const tapCount = tapRows.reduce((a, r) => a + r.n, 0)
+
 console.log(
-  `${checked} story / 判定不能 ${unknown} 箇所` +
+  `${checked} story / コントラスト判定不能 ${unknown} 箇所 / ` +
+    `操作対象 ${tapTotal} 個` +
     (skipped ? ` / 解説カテゴリ ${skipped} story は対象外` : '')
 )
+
+if (rows.length) console.log('\nコントラスト:')
 for (const r of rows) {
   console.log(
     `  ${r.got}:1 (要 ${r.need}) ${r.size}px ×${r.n}  ${r.color} on ${r.bg}\n` +
       `      ${r.label} @${r.where}  例: ${r.samples.map((s) => `"${s}"`).join(' ')}`
+  )
+}
+
+if (tapRows.length)
+  console.log(`\n操作対象の寸法 (要 ${MIN_TAP_PX}x${MIN_TAP_PX}):`)
+for (const r of tapRows) {
+  console.log(
+    `  ${r.w}x${r.h} ×${r.n}  ${r.label} @${r.where}` +
+      `  例: ${r.samples.map((s) => `"${s}"`).join(' ')}`
   )
 }
 
@@ -187,13 +224,25 @@ if (empty) {
   process.exit(1)
 }
 
-if (count) {
-  console.error(
-    `\n❌ コントラスト不足 ${count} 箇所 / ${rows.length} パターン\n` +
-      '   面の色 (main) を文字に使っていないか確認してください。' +
-      '前景用には textContrast があります。'
-  )
+if (count || tapCount) {
+  const parts = []
+  if (count) {
+    parts.push(
+      `コントラスト不足 ${count} 箇所 / ${rows.length} パターン\n` +
+        '   面の色 (main) を文字に使っていないか確認してください。' +
+        '前景用には textContrast があります。'
+    )
+  }
+  if (tapCount) {
+    parts.push(
+      `操作対象が ${MIN_TAP_PX}px 未満 ${tapCount} 箇所 / ${tapRows.length} パターン\n` +
+        '   高さが足りないことが多いです。inline-flex + minHeight で確保できます。'
+    )
+  }
+  console.error(`\n❌ ${parts.join('\n❌ ')}`)
   process.exit(1)
 }
 
-console.log('\n✅ 描画結果にコントラスト不足なし')
+console.log(
+  `\n✅ コントラスト不足なし / 操作対象はすべて ${MIN_TAP_PX}x${MIN_TAP_PX} 以上`
+)

--- a/scripts/lib/tap-target-audit.mjs
+++ b/scripts/lib/tap-target-audit.mjs
@@ -1,0 +1,80 @@
+/**
+ * 操作対象の寸法を測る（WCAG 2.2 SC 2.5.8 / Level AA）
+ *
+ * 基準は 24x24 CSS px。44x44 は SC 2.5.5 (AAA) なのでここでは見ない。
+ *
+ * **除外は「クラス名の許可リスト」でなく性質で決める。**
+ * 名前で外すと、同じ性質の別の部品が入ってきたときに素通りする。
+ * 最初に雑に測ったときは 170 箇所、次に 52 箇所と出たが、
+ * どちらも下の除外が足りず、実際の不具合は 25 箇所だった。
+ *
+ * 除外する性質:
+ * - 非表示 (display/visibility/opacity 0)
+ * - 操作できない (pointer-events:none / disabled / aria-disabled)
+ * - 支援技術からもキーボードからも到達しない (aria-hidden かつ tabindex<0)
+ *   → MUI X の値保持用 input (1x1) がこれに当たる
+ * - アニメーション実行中（寸法が確定していない）
+ *   → 全 story に注入される ChatSupport の FAB がこれに当たる
+ * - 0x0（非表示の祖先の中にある）
+ * - 文中のインラインリンク（SC 2.5.8 の明示的な例外）
+ *
+ * この関数は page.evaluate に渡してブラウザ内で走る。外の変数を参照しない
+ */
+export const TAP_TARGET_AUDIT = (min) => {
+  const SELECTOR = [
+    'button',
+    'a[href]',
+    'input',
+    'select',
+    'textarea',
+    '[role="button"]',
+    '[role="link"]',
+    '[role="tab"]',
+    '[role="checkbox"]',
+    '[role="switch"]',
+    '[role="menuitem"]',
+  ].join(',')
+
+  const out = []
+  let total = 0
+
+  for (const el of document.querySelectorAll(SELECTOR)) {
+    const cs = getComputedStyle(el)
+    if (cs.display === 'none' || cs.visibility === 'hidden') continue
+    if (Number(cs.opacity) === 0 || cs.pointerEvents === 'none') continue
+    if (el.hasAttribute('disabled')) continue
+    if (el.getAttribute('aria-disabled') === 'true') continue
+    // 支援技術から隠され、かつキーボードでも到達しないものは操作対象ではない
+    if (el.getAttribute('aria-hidden') === 'true' && el.tabIndex < 0) continue
+    if (
+      el.getAnimations &&
+      el.getAnimations().some((a) => a.playState === 'running')
+    )
+      continue
+
+    const r = el.getBoundingClientRect()
+    // 0x0 は非表示の祖先の中にある
+    if (r.width === 0 || r.height === 0) continue
+
+    // 文中のインラインリンクは SC 2.5.8 の例外
+    if (el.tagName === 'A' && cs.display.startsWith('inline')) continue
+
+    total++
+    if (r.width >= min && r.height >= min) continue
+
+    out.push({
+      w: Math.round(r.width),
+      h: Math.round(r.height),
+      label: `${el.tagName}${
+        el.className && typeof el.className === 'string'
+          ? '.' + el.className.split(' ').slice(0, 2).join('.')
+          : ''
+      }`,
+      text: (el.textContent || el.getAttribute('aria-label') || '')
+        .trim()
+        .slice(0, 20),
+    })
+  }
+
+  return { fails: out, total }
+}

--- a/scripts/vrt.mjs
+++ b/scripts/vrt.mjs
@@ -171,9 +171,13 @@ try {
       })
       await page.waitForTimeout(320)
       await page.screenshot({ path: file })
-      return true
-    } catch {
-      return false
+      return null
+    } catch (e) {
+      // 失敗の理由を捨てない。件数だけだと「何が撮れなかったか」が分からず、
+      // 一番変えた story が落ちていても「差分なし」に見えてしまう
+      return String(e?.message ?? e)
+        .split('\n')[0]
+        .slice(0, 90)
     } finally {
       await page.close()
     }
@@ -197,13 +201,19 @@ try {
 
   console.log(`  ${common.length} story を撮影中...`)
   const diffs = []
-  let failed = 0
+  const failures = []
   for (const id of common) {
     const bf = join(OUT, 'before', `${id}.png`)
     const hf = join(OUT, 'after', `${id}.png`)
     const df = join(OUT, 'diff', `${id}.png`)
-    if (!(await shoot(BASE, id, bf)) || !(await shoot(HEAD, id, hf))) {
-      failed++
+    const beforeErr = await shoot(BASE, id, bf)
+    const headErr = beforeErr ? null : await shoot(HEAD, id, hf)
+    if (beforeErr || headErr) {
+      failures.push({
+        id,
+        side: beforeErr ? '比較元' : '作業ツリー',
+        reason: beforeErr ?? headErr,
+      })
       continue
     }
     const d = pixelDiff(bf, hf, df)
@@ -218,7 +228,8 @@ try {
     const n1 = join(WORK, 'n1.png')
     let worst = -1
     for (let i = 0; i < NOISE_SAMPLES; i++) {
-      if (!(await shoot(HEAD, r.id, n1))) break
+      // shoot は成功で null、失敗で理由の文字列を返す
+      if (await shoot(HEAD, r.id, n1)) break
       const d = pixelDiff(join(OUT, 'after', `${r.id}.png`), n1, noiseFile)
       if (d > worst) worst = d
       // 既にゆらぎと判定できる大きさなら、それ以上測らない
@@ -239,12 +250,23 @@ try {
   )
   const total = VIEWPORT.width * VIEWPORT.height
 
-  console.log(`\n撮影 ${common.length - failed} 件（失敗 ${failed}）`)
-  console.log(`  完全一致 ${common.length - failed - diffs.length} 件`)
+  console.log(
+    `\n撮影 ${common.length - failures.length} 件（失敗 ${failures.length}）`
+  )
+  console.log(`  完全一致 ${common.length - failures.length - diffs.length} 件`)
   console.log(`  見た目が変わった ${real.length} 件`)
   console.log(`  描画のゆらぎ ${noisy.length} 件（自己差分が同程度）`)
   if (added.length) console.log(`  追加された story ${added.length} 件`)
   if (removed.length) console.log(`  削除された story ${removed.length} 件`)
+
+  // 撮影できなかったものは必ず名指しする。件数だけだと、いちばん変えた
+  // story が落ちていても「差分なし」に見えてしまう
+  if (failures.length) {
+    console.log('\n撮影できなかった story（未検証。差分なしとみなせない）:')
+    for (const f of failures) {
+      console.log(`  ${f.id}  [${f.side}] ${f.reason}`)
+    }
+  }
 
   if (real.length) {
     console.log('\n見た目が変わった story（差分の大きい順）:')
@@ -285,14 +307,24 @@ try {
     '',
     `| | 件数 |`,
     `| --- | --- |`,
-    `| 撮影 | ${common.length - failed} |`,
-    `| 完全一致 | ${common.length - failed - diffs.length} |`,
+    `| 撮影 | ${common.length - failures.length} |`,
+    `| 完全一致 | ${common.length - failures.length - diffs.length} |`,
     `| 見た目が変わった | ${real.length} |`,
     `| 描画のゆらぎ | ${noisy.length} |`,
-    `| 撮影失敗 | ${failed} |`,
+    `| 撮影失敗 | ${failures.length} |`,
     `| 追加された story | ${added.length} |`,
     `| 削除された story | ${removed.length} |`,
     '',
+    ...(failures.length
+      ? [
+          '## 撮影できなかった（未検証）',
+          '',
+          '| story | 側 | 理由 |',
+          '| --- | --- | --- |',
+          ...failures.map((f) => `| ${f.id} | ${f.side} | ${f.reason} |`),
+          '',
+        ]
+      : []),
     ...(real.length
       ? [
           '## 見た目が変わった',
@@ -343,13 +375,14 @@ try {
         baseSha: sh(`git rev-parse ${BASE_REF}`),
         headSha: sh('git rev-parse HEAD'),
         viewport: VIEWPORT,
-        shot: common.length - failed,
-        identical: common.length - failed - diffs.length,
+        shot: common.length - failures.length,
+        identical: common.length - failures.length - diffs.length,
         changed: real,
         noisy,
         added,
         removed,
-        failed,
+        failed: failures.length,
+        failures,
       },
       null,
       2

--- a/src/stories/03-Layout/Grid.stories.tsx
+++ b/src/stories/03-Layout/Grid.stories.tsx
@@ -5,6 +5,13 @@ import { breakpointValues } from '@/themes/breakpoints'
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
+/** WCAG 2.2 SC 2.5.8 の最小操作対象 (24x24) */
+const LINK_TAP_TARGET = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  minHeight: 24,
+} as const
+
 const meta: Meta = {
   title: 'Layout/Grid System',
   parameters: {
@@ -228,13 +235,17 @@ const ResponsiveContent = () => {
         <Typography variant='body1' sx={{ fontWeight: 700, mb: 1.5 }}>
           参考リンク
         </Typography>
-        <Stack spacing={0.75}>
+        {/* Stack の子はフレックス項目になり、幅いっぱい・高さ 18px のリンクに
+            なる。操作対象として WCAG 2.2 SC 2.5.8 の 24px に届かないので、
+            文字幅に収めたうえで高さを確保する */}
+        <Stack spacing={0.75} alignItems='flex-start'>
           <Link
             href='https://mui.com/material-ui/react-grid/'
             target='_blank'
             rel='noopener noreferrer'
             variant='body1'
-            color='primary'>
+            color='primary'
+            sx={LINK_TAP_TARGET}>
             MUI Grid v7
           </Link>
           <Link
@@ -242,7 +253,8 @@ const ResponsiveContent = () => {
             target='_blank'
             rel='noopener noreferrer'
             variant='body1'
-            color='primary'>
+            color='primary'
+            sx={LINK_TAP_TARGET}>
             MUI Breakpoints
           </Link>
         </Stack>

--- a/src/themes/theme.ts
+++ b/src/themes/theme.ts
@@ -506,11 +506,37 @@ const componentStyles = {
         color: theme.palette.info.textContrast,
       }),
       sizeSmall: {
+        // 表示専用の Chip は密度を優先して 20 のまま（MUI 既定は 24）
         height: 20,
         fontSize: fontSizesVariant.sm, // 最小フォントサイズ12px原則に準拠
         '& .MuiChip-label': {
           paddingLeft: 6,
           paddingRight: 6,
+        },
+        // 押せる / 消せる Chip は操作対象なので WCAG 2.2 SC 2.5.8 の
+        // 24x24 が要る。拠り所なく 20 に縮めていたので MUI 既定へ戻す。
+        // 表示専用と分けることで、状態表示の見た目は変えずに済む
+        '&.MuiChip-clickable, &.MuiChip-deletable': {
+          height: 24,
+        },
+      },
+    },
+  },
+  // パンくずのリンク。
+  // ライブラリ既定では行の高さぶん（実測 22px）しかなく、WCAG 2.2 SC 2.5.8 の
+  // 24x24 を割る。文中のインラインリンクは同基準の例外だが、パンくずは
+  // ナビゲーションなので例外に当たらない。
+  // 高さだけを確保し、文字サイズと余白は既定のままにする
+  MuiBreadcrumbs: {
+    styleOverrides: {
+      // li スロットではなく ol に当てる。折りたたみ用の «…» ボタン
+      // (aria-label="Show path") は MuiBreadcrumbs-li が付かない素の <li> に
+      // 入るため、li スロットからは届かない（実測して気づいた）
+      ol: {
+        '& li > a, & li > button, & li > .MuiLink-root': {
+          display: 'inline-flex',
+          alignItems: 'center',
+          minHeight: 24,
         },
       },
     },


### PR DESCRIPTION
WCAG 2.2 SC 2.5.8 (AA) の24x24を実描画で測る。44はSC 2.5.5 (AAA) なのでここでは見ない。

## まず訂正

https://github.com/BoxPistols/kaze-ux/issues/117 で「170箇所」、その後「52箇所」と報告したが、**どちらも測り方が雑だった**。除外をクラス名の許可リストでなく性質で決めると、実際の不具合は **25箇所**。

除外する性質（名前で外すと同じ性質の別部品が素通りする）:

| 性質 | 実例 |
| --- | --- |
| 非表示 / `pointer-events:none` / `disabled` | `MuiSelect-nativeInput`（送信用の隠しinput） |
| `aria-hidden` かつ `tabindex<0` | MUI Xの値保持用input（1x1） |
| アニメーション実行中 | 全storyに注入されるChatSupportのFAB（2x2 / 7x7 / 16x16に見えていた） |
| 0x0 | 非表示の祖先の中にある要素 |
| 文中のインラインリンク | SC 2.5.8の明示的な例外 |

## 直した25箇所

| 寸法 | 件数 | 対応 |
| --- | --- | --- |
| 70×22 | 14 | `MuiBreadcrumbs` を追加してリンクに `minHeight: 24` |
| 85×20 | 8 | `MuiChip.sizeSmall` の押せるChipだけ24に戻す |
| 1224×18 | 2 | `Grid.stories` のStack内リンクを `inline-flex` + `minHeight` |
| 24×16 | 1 | パンくずの折りたたみ «…» ボタン（上記Breadcrumbsで解決） |

**Chipについて根拠がある。** themeが `sizeSmall.height` を20に落としていた（MUI v7の既定は24）。拠り所なく縮めた結果が基準割れなので、**操作対象になるChipだけライブラリ既定へ戻す**。表示専用のChipは20のままなので、状態表示の見た目は変わらない。

**`MuiBreadcrumbs` は `li` スロットでは届かない。** 折りたたみボタン（`aria-label="Show path"`）だけ `MuiBreadcrumbs-li` が付かない素の `<li>` に入るため、`ol` スロット側に当てる必要があった。DOM経路を実測して判明した。

## VRTの欠陥を2つ直した

**撮影失敗が件数しか残らなかった。** 最初の実行で「失敗3件」と出ていた中身は `patterns-navigation--breadcrumb-patterns` / `patterns-navigation--app-bar-with-drawer` / `patterns-form-layout--settings-form` — **今回いちばん変えた3 story** だった。名前が出ないので「差分なし」と読みかけた。id / 失敗側 / 理由をコンソール・`report.md`・`result.json` すべてに出す。

修正後に測り直すと、隠れていた2件がそのまま差分として現れた（`settings-form` 5,718px、`breadcrumb-patterns` 636px）。

**自分の修正がnoise測定を反転させかけた。** `shoot()` の戻り値を「成功=true」から「成功=null / 失敗=理由」に変えた際、ゆらぎ測定の `if (!(await shoot(...))) break` が**成功時にbreak** する形になっていた。そのままなら自己差分が測れず、本物の変化が「描画のゆらぎ」に分類されて消える。全呼び出しを洗って直した。

## 検証

**gate**

```
138 story / コントラスト判定不能 0 箇所 / 操作対象 442 個 / 解説カテゴリ 63 story は対象外

✅ コントラスト不足なし / 操作対象はすべて 24x24 以上
```

**落ちうることの確認** — 閾値を44 (AAA) に上げるとexit 1で5パターン報告する。

**VRT** — 201/201撮影（失敗0）。見た目が変わった7件はすべて意図した変化:

| 差分 | story | 内容 |
| --- | --- | --- |
| 17,190 px (1.49%) | patterns-data-display--card-grid | フィルタChipが4px高くなり、以下が縦シフト |
| 13,099 px (1.14%) | patterns-data-display--searchable-table | 同上 |
| 5,718 px (0.50%) | patterns-form-layout--settings-form | 同上 |
| 2,039 px (0.18%) | components-maps-map3d--new-york | 地図タイルの描画ゆらぎ |
| 1,950 px (0.17%) | tools-visual-editor--default | プリセットChip |
| 1,780 px (0.15%) | layout-grid-system--responsive | リンクの高さ |
| 636 px (0.06%) | patterns-navigation--breadcrumb-patterns | 折りたたみボタンと現在ページChip |

差分画像を見て確認済み。いずれも再レイアウトではなく4px分の縦シフト。

- `pnpm test:run` 686件 / 40ファイルgreen
- `tsc --noEmit` / `pnpm lint` / `prettier --check` clean

## 判断が要るところ

Chipが4px高くなるのはデータ表示パターン全体に出ます。密度を優先して現状維持にするなら、`MuiChip.sizeSmall` の `&.MuiChip-clickable, &.MuiChip-deletable` ブロックだけ落とせば戻せます（その場合SC 2.5.8は満たさないままになります）。

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jav2H6vtcjoLJk6N34N8hD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
- 操作対象の最小サイズ（24px）を監査するアクセシビリティ検査を追加。
- コントラスト不足と操作対象サイズ不足をまとめて検出し、詳細を表示。

## 改善
- チップ、パンくずリスト、グリッド内リンクの操作領域を24px以上に改善。
- ビジュアルテストの撮影失敗内容を結果・Markdown・JSONレポートで確認可能に。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
