### PR TITLE
fix(a11y): ダークモードを測るようにし、contained Button 等の破綻を直す

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -101,30 +101,64 @@
     font-family: var(--font-family) !important;
   }
 
-  /* Heading styles */
+  /* Heading styles
+     docs ページと story 内の節見出し向け。
+
+     .MuiAccordion-heading を除外しているのは、MUI が a11y のために内部で
+     出す素の h3 にまで !important のライト固定色が当たり、ダークで
+     2.08:1 になっていたため。余白 2em も部品の中に入り込んでいた。
+
+     [class*='Mui'] のような広い除外にはしない。story が
+     <Box component='h3'> で節見出しを書いており、MuiBox-root ごと
+     巻き込んで装飾が消える（VRT で 2 story の崩れとして出た）。
+     他の部品で同じことが起きたら pnpm check:a11y が拾う */
   :where(
-    h1:not(.sb-anchor, .sb-unstyled, .sb-unstyled h1, .MuiTypography-root)
+    h1:not(
+      .sb-anchor,
+      .sb-unstyled,
+      .sb-unstyled h1,
+      .MuiTypography-root,
+      .MuiAccordion-heading
+    )
   ):first-of-type {
     color: var(--color-Storybook) !important;
     margin: 0.75em 0 !important;
   }
 
   :where(
-    h2:not(.sb-anchor, .sb-unstyled, .sb-unstyled h2, .MuiTypography-root)
+    h2:not(
+      .sb-anchor,
+      .sb-unstyled,
+      .sb-unstyled h2,
+      .MuiTypography-root,
+      .MuiAccordion-heading
+    )
   ) {
     color: var(--color-Mui) !important;
     margin: 1.5em 0 1em !important;
   }
 
   :where(
-    h3:not(.sb-anchor, .sb-unstyled, .sb-unstyled h3, .MuiTypography-root)
+    h3:not(
+      .sb-anchor,
+      .sb-unstyled,
+      .sb-unstyled h3,
+      .MuiTypography-root,
+      .MuiAccordion-heading
+    )
   ) {
     color: var(--color-TextSecondary) !important;
     margin: 2em 0 0.75em !important;
   }
 
   :where(
-    h4:not(.sb-anchor, .sb-unstyled, .sb-unstyled h4, .MuiTypography-root)
+    h4:not(
+      .sb-anchor,
+      .sb-unstyled,
+      .sb-unstyled h4,
+      .MuiTypography-root,
+      .MuiAccordion-heading
+    )
   ) {
     color: var(--color-TextSecondary) !important;
     margin: 1em 0 0.5em !important;

--- a/scripts/check-a11y.mjs
+++ b/scripts/check-a11y.mjs
@@ -2,9 +2,10 @@
 /**
  * **描画された** Storybook のコントラストを検査する。
  *
- *   pnpm check:a11y              既定（部品カテゴリのみ）
- *   pnpm check:a11y --all        解説カテゴリも含めて全 story
- *   A11Y_URL=... pnpm check:a11y 配信先を差し替える
+ *   pnpm check:a11y                    既定（部品カテゴリ / light + dark-kaze）
+ *   pnpm check:a11y --all              解説カテゴリも含めて全 story
+ *   A11Y_THEMES=dark-dracula pnpm ...  テーマを指定
+ *   A11Y_URL=... pnpm check:a11y       配信先を差し替える
  *
  * なぜ addon-a11y と別に要るか:
  *
@@ -34,6 +35,21 @@ import { TAP_TARGET_AUDIT } from './lib/tap-target-audit.mjs'
 
 const URL = process.env.A11Y_URL ?? 'http://localhost:6099'
 const SHOW_ALL = process.argv.includes('--all')
+
+/**
+ * 検査するテーマ。
+ *
+ * light だけを測っていた間、ダークの contained Button が 2.46:1 のまま
+ * 半年気づかれなかった。片方だけ測るのは測っていないのとあまり変わらない。
+ *
+ * dark-dracula は既知の未対応があるため既定から外している
+ * （textContrast が X.lighter の面に対して保証されていない構造の問題）。
+ * A11Y_THEMES で明示すれば測れる。
+ */
+const THEMES = (process.env.A11Y_THEMES ?? 'light,dark-kaze')
+  .split(',')
+  .map((t) => t.trim())
+  .filter(Boolean)
 
 /**
  * 意図的に基準外の見本を描く解説カテゴリ。
@@ -108,13 +124,16 @@ let tapTotal = 0
  * 超えることがあり、それで gate が落ちると「たまに落ちるので無視」に
  * なって検査そのものが死ぬ。ただし**再試行しても駄目なら落とす**
  */
-const measure = async (story) => {
+const measure = async (story, theme) => {
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
-      await page.goto(`${URL}/iframe.html?id=${story.id}&viewMode=story`, {
-        waitUntil: 'load',
-        timeout: attempt === 0 ? 20000 : 40000,
-      })
+      await page.goto(
+        `${URL}/iframe.html?id=${story.id}&viewMode=story&globals=theme:${theme}`,
+        {
+          waitUntil: 'load',
+          timeout: attempt === 0 ? 20000 : 40000,
+        }
+      )
       await page.waitForTimeout(400)
 
       // 描画に失敗した story は違反 0 件を返す。確認しないと壊れた画面ほど緑になる
@@ -137,22 +156,22 @@ const measure = async (story) => {
   return null
 }
 
-for (const story of targets) {
-  const measured = await measure(story)
+for (const theme of THEMES) {
+  for (const story of targets) {
+    const measured = await measure(story, theme)
 
-  if (!measured || !measured.r) {
-    empty++
-    const live = measured?.live
-    console.error(
-      `  ⚠ ${story.id}: 描画されていません` +
-        (live
-          ? `（要素 ${live.nodes} / エラー表示 ${live.errorShown}）`
-          : '（読み込みに 2 回失敗）')
-    )
-    continue
-  }
+    if (!measured || !measured.r) {
+      empty++
+      const live = measured?.live
+      console.error(
+        `  ⚠ [${theme}] ${story.id}: 描画されていません` +
+          (live
+            ? `（要素 ${live.nodes} / エラー表示 ${live.errorShown}）`
+            : '（読み込みに 2 回失敗）')
+      )
+      continue
+    }
 
-  {
     const r = measured.r
     checked++
     unknown += r.unknown.length
@@ -161,10 +180,11 @@ for (const story of targets) {
     for (const f of r.fails.filter((x) => !x.disabled)) {
       // 同じ原因（同じ色・同じ要素）は 1 行にまとめる。
       // 文字列を key に入れるとカレンダーの日付が 1 日 1 行になって読めない
-      const key = `${f.got}|${f.need}|${f.label}|${f.color}|${f.bg}`
+      const key = `${theme}|${f.got}|${f.need}|${f.label}|${f.color}|${f.bg}`
       const prev = fails.get(key)
       fails.set(key, {
         ...f,
+        theme,
         n: (prev?.n ?? 0) + 1,
         samples: [...new Set([...(prev?.samples ?? []), f.text])].slice(0, 4),
         where: prev?.where ?? story.title,
@@ -194,15 +214,15 @@ const tapRows = [...tapFails.values()].sort((a, b) => a.h * a.w - b.h * b.w)
 const tapCount = tapRows.reduce((a, r) => a + r.n, 0)
 
 console.log(
-  `${checked} story / コントラスト判定不能 ${unknown} 箇所 / ` +
-    `操作対象 ${tapTotal} 個` +
+  `${THEMES.join(' + ')} / ${checked} 回描画（${targets.length} story × ${THEMES.length} テーマ） / ` +
+    `コントラスト判定不能 ${unknown} 箇所 / 操作対象 ${tapTotal} 個` +
     (skipped ? ` / 解説カテゴリ ${skipped} story は対象外` : '')
 )
 
 if (rows.length) console.log('\nコントラスト:')
 for (const r of rows) {
   console.log(
-    `  ${r.got}:1 (要 ${r.need}) ${r.size}px ×${r.n}  ${r.color} on ${r.bg}\n` +
+    `  [${r.theme}] ${r.got}:1 (要 ${r.need}) ${r.size}px ×${r.n}  ${r.color} on ${r.bg}\n` +
       `      ${r.label} @${r.where}  例: ${r.samples.map((s) => `"${s}"`).join(' ')}`
   )
 }
@@ -244,5 +264,6 @@ if (count || tapCount) {
 }
 
 console.log(
-  `\n✅ コントラスト不足なし / 操作対象はすべて ${MIN_TAP_PX}x${MIN_TAP_PX} 以上`
+  `\n✅ ${THEMES.join(' + ')} すべてでコントラスト不足なし / ` +
+    `操作対象はすべて ${MIN_TAP_PX}x${MIN_TAP_PX} 以上`
 )

--- a/scripts/vrt.mjs
+++ b/scripts/vrt.mjs
@@ -55,8 +55,14 @@ const NOISE_RATIO = 0.5
  * 実際に踏んだ: 3D 地図の story が 125,970px の差分で「変わった」と判定
  * されたが、実体は地形メッシュの描画ゆらぎだった。1 回の撮り直しが
  * たまたま近いフレームを掴んだため。最大値を採る。
+ *
+ * 3 回でも足りなかった。Drawer の story は同じ版で 4 回撮ると
+ * 0 / 0 / 0 / 2647px と、**4 回に 1 回だけ**ずれる。3 回引いて全部 0 なら
+ * 「本物の変化」に昇格してしまう（実際に 2,204px の誤検出が出た）。
+ * 5 回に増やしても取りこぼしは残るので、判定は必ず自己差分の値と
+ * 併せて読むこと。
  */
-const NOISE_SAMPLES = 3
+const NOISE_SAMPLES = 5
 
 const args = process.argv.slice(2)
 const limitAt = args.indexOf('--limit')
@@ -158,7 +164,16 @@ try {
 
   const browser = await chromium.launch()
   const shoot = async (base, id, file) => {
-    const page = await browser.newPage({ viewport: VIEWPORT })
+    // newPage 自体が失敗しうる（長時間の実行で "Target crashed" を実際に踏んだ）。
+    // try の外に置くと 200 story の途中で全体が落ちる
+    let page
+    try {
+      page = await browser.newPage({ viewport: VIEWPORT })
+    } catch (e) {
+      return `newPage: ${String(e?.message ?? e)
+        .split('\n')[0]
+        .slice(0, 70)}`
+    }
     try {
       await page.goto(`${base}/iframe.html?id=${id}&viewMode=story`, {
         waitUntil: 'load',
@@ -179,7 +194,7 @@ try {
         .split('\n')[0]
         .slice(0, 90)
     } finally {
-      await page.close()
+      await page.close().catch(() => {})
     }
   }
 

--- a/src/stories/04-Components/UI/ResizableDivider/ResizableDivider.stories.tsx
+++ b/src/stories/04-Components/UI/ResizableDivider/ResizableDivider.stories.tsx
@@ -34,7 +34,17 @@ type Story = StoryObj<typeof meta>
 /**
  * パネルの共通コンテンツ
  */
-const PanelContent = ({ label, size }: { label: string; size: number }) => (
+const PanelContent = ({
+  label,
+  size,
+  // 色を敷いた面では合成後が明るくなり、text.secondary では届かないことがある。
+  // 敷く側が前景を指定できるようにする
+  labelColor = 'text.secondary',
+}: {
+  label: string
+  size: number
+  labelColor?: string
+}) => (
   <Box
     sx={{
       display: 'flex',
@@ -44,7 +54,7 @@ const PanelContent = ({ label, size }: { label: string; size: number }) => (
       flexDirection: 'column',
       gap: 1,
     }}>
-    <Typography variant='subtitle2' color='text.secondary'>
+    <Typography variant='subtitle2' color={labelColor}>
       {label}
     </Typography>
     <Typography variant='h6' color='text.primary'>
@@ -228,13 +238,18 @@ const BothDirectionsDemo = () => {
           orientation='horizontal'
         />
 
-        {/* 右下パネル */}
+        {/* 右下パネル。action.selected を敷くと合成後の面が明るくなり、
+            text.secondary では 4.17:1 で 4.5 に届かない（ダーク実測） */}
         <Box
           sx={{
             flex: 1,
             bgcolor: 'action.selected',
           }}>
-          <PanelContent label='右下パネル（自動調整）' size={0} />
+          <PanelContent
+            label='右下パネル（自動調整）'
+            size={0}
+            labelColor='text.primary'
+          />
         </Box>
       </Box>
     </Paper>

--- a/src/themes/colorToken.ts
+++ b/src/themes/colorToken.ts
@@ -445,8 +445,15 @@ const darkSchemeEnvMap: Record<ColorScheme, SchemeEnv> = {
     lighter: '#44475A',
     background: { default: '#282A36', paper: '#343746' },
     // secondary は Dracula の comment 色 (#6272A4) を色相・彩度そのままに
-    // 明度だけ上げたもの。元の値は paper 上で 3.03:1 と AA に届かなかった
-    text: { primary: '#F8F8F2', secondary: '#9ca2c4', disabled: '#6272A4' },
+    // 明度だけ上げたもの。元の値は paper 上で 3.03:1 と AA に届かなかった。
+    //
+    // その後 #9ca2c4 まで上げたが、それでも足りなかった。paper (4.70:1) で
+    // 測って決めていたためで、action.hover / selected を敷いた面に置くと
+    // 合成後が rgb(64,67,80) になり 3.92:1 まで落ちる。テーブル見出しや
+    // Card のラベルなど、色を敷いた面に乗る用途の方が多く、実測で 66 箇所が
+    // 割れていた。tint 面を基準に取り直した値が #aab0cd
+    // (tint 4.59:1 / paper 5.50:1 / default 6.65:1)
+    text: { primary: '#F8F8F2', secondary: '#aab0cd', disabled: '#6272A4' },
     action: {
       hover: 'rgba(248, 248, 242, 0.06)',
       selected: 'rgba(80, 216, 216, 0.15)',

--- a/src/themes/theme.ts
+++ b/src/themes/theme.ts
@@ -160,13 +160,12 @@ const componentStyles = {
         color: colorData.text.disabled,
         backgroundColor: colorData.grey[300],
       },
+      // 文字色は色ごとの contrastText に任せる（下の contained* スロット）。
+      // ここで白を一括指定していたため、パレットが持つ濃色の contrastText を
+      // 詳細度で握り潰していた。ライトは main が濃紺なので白で成立していたが、
+      // ダークは main が明るい青になり、実測で 2.46:1 (kaze) / 2.37:1 (dracula)
+      // しか出ていなかった
       contained: ({ theme }: { theme: Theme }) => ({
-        '&.MuiButton-contained.MuiButton-root': {
-          color:
-            theme.palette.mode === 'light'
-              ? colorData.text.white
-              : colorData.dark.text.white,
-        },
         '&.MuiButton-contained.MuiButton-root.MuiButton-containedInherit': {
           color: theme.palette.text.primary,
         },
@@ -203,9 +202,18 @@ const componentStyles = {
           const slot = ({ theme }: { theme: Theme }) => ({
             color: theme.palette[key].textContrast,
           })
+          // contained は面が main なので、前景は textContrast ではなく
+          // contrastText（main に対して実測で選ばれた色）を使う。
+          // contained の一括指定と同じ詳細度にして、確実に効かせる
+          const filled = ({ theme }: { theme: Theme }) => ({
+            '&.MuiButton-contained.MuiButton-root': {
+              color: theme.palette[key].contrastText,
+            },
+          })
           return [
             [`text${cap}`, slot],
             [`outlined${cap}`, slot],
+            [`contained${cap}`, filled],
           ]
         })
       ),


### PR DESCRIPTION
https://github.com/BoxPistols/kaze-ux/pull/116 で入れたgateは **lightしか測っていなかった**。その結果、DSでいちばん目立つcontained Buttonがダークで2.46:1のまま残っていた。片方だけ測るのは、測っていないのとあまり変わらない。

## 検査を広げた

`pnpm check:a11y` をテーマごとに回す。既定は **light + dark-kaze**（138 story × 2 = 276回描画、約2分）。

`A11Y_THEMES=dark-dracula pnpm check:a11y` で切り替えられる。dark-draculaは既知の未対応があるため既定から外している（https://github.com/BoxPistols/kaze-ux/issues/121）。

## 直したもの

### contained Button（27箇所 / 両ダークスキーム）

| テーマ | 前 | 後 |
| --- | --- | --- |
| light | 6.87:1 | 6.87:1（変化なし） |
| dark-kaze | **2.46:1** | **7.26:1** |
| dark-dracula | **2.37:1** | **7.28:1** |

themeが色に関係なく白を焼き込んでいた。

```
'&.MuiButton-contained.MuiButton-root': {
  color: theme.palette.mode === 'light' ? colorData.text.white : colorData.dark.text.white,
},
```

詳細度 (0,2,0) がMUI既定の `containedPrimary` (0,1,0) に勝つため、**パレットが持つ濃色の `contrastText`（`#06182e` = 8.06:1）が一切効いていなかった**。ライトは `main` が濃紺なので白で成立し、**ダークにしたときだけ破綻する**構造。

色ごとの `contained*` スロットで `contrastText` を使う形に変えた。`text*` / `outlined*` が既に同じ形なので書き方も揃う。

### Accordionの見出し（1箇所、2.08:1）

`preview-head.html` のdocs用見出し規則が `!important` のライト固定色を、**MUIがa11yのために内部で出す素の `h3`（`.MuiAccordion-heading`）にまで**当てていた。余白 `2em` も部品の中に入り込んでいた。

除外は `.MuiAccordion-heading` に限定している。**`[class*='Mui']` まで広げたら2 storyが崩れた** — storyが `<Box component='h3'>` で節見出しを書いており、`MuiBox-root` ごと巻き込んで装飾が消える。VRTで16,203px / 15,162pxの崩れとして出たので戻した。

### draculaの `text.secondary`（36箇所）

`paper` (4.70:1) を基準に決めていたが、`action.hover` / `selected` を敷いた面では合成後 `rgb(64,67,80)` になり **3.92:1** まで落ちる。テーブル見出し・Cardのラベルなど、色を敷いた面に乗る用途の方が多い。

tint面を基準に取り直して `#9ca2c4` → `#aab0cd`（tint 4.59:1 / paper 5.50:1 / default 6.65:1）。

### ResizableDividerのstory（3箇所、4.17:1）

`action.selected` を敷いた面で `text.secondary` が届かない。敷く側が前景を指定できるようにした。

## VRTの追加修正

**`newPage` 自体の失敗を捕まえていなかった。** `try` の外にあり、`Target crashed` で201 storyの途中に全体が落ちた。

**`NOISE_SAMPLES` 3 → 5。** Drawerのstoryは**同じ版で4回撮ると0 / 0 / 0 / 2647px** と、4回に1回だけずれる。3回引いて全部0だと「本物の変化」に誤って昇格する。実際に2,204pxの誤検出が出て、自己差分を実測するまで自分の変更のせいだと思い込んでいた。5回でも取りこぼしは残るので、判定は自己差分の値と併せて読む必要がある（その旨をコメントに残した）。

## 検証

```
light + dark-kaze / 276 回描画（138 story × 2 テーマ） / コントラスト判定不能 0 箇所 / 操作対象 884 個

✅ light + dark-kaze すべてでコントラスト不足なし / 操作対象はすべて 24x24 以上
```

**落ちうることの確認** — `A11Y_THEMES=dark-dracula` はexit 1で既知の30箇所を報告する。

**VRT** — 201/201撮影・失敗0。見た目が変わった7件はいずれも意図した色変更（Design Tokensのダーク見本など）か上記の描画ゆらぎ。Accordionはラベル1行のみでレイアウト不変。

- `pnpm test:run` 686件 / 40ファイルgreen
- `tsc --noEmit` / `pnpm lint` / `prettier --check` clean

## 残り

`textContrast` が `X.lighter` の面に対して保証されていない構造の問題（dark-draculaの30箇所）は https://github.com/BoxPistols/kaze-ux/issues/121 に分けた。6テーマ全体に及ぶ変更になるため、このPRには含めていない。

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jav2H6vtcjoLJk6N34N8hD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- アクセシビリティ
  - 複数テーマでアクセシビリティ検査を実行できるようになりました。
  - テーマ別にコントラスト違反を確認でき、対象テーマも指定できます。

- 改善
  - ボタンの文字色を背景色に応じて調整し、視認性を向上しました。
  - Draculaテーマの補助テキスト色を改善しました。
  - リサイズ可能なパネルのラベル色を調整しました。

- ビジュアルテスト
  - スクリーンショット比較の安定性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
