### PR TITLE
feat(mcp): 公開と流布の準備 — MCP Registry 対応・英語の入口・LP 導線

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 導入手順を読む / Getting started
+    url: https://github.com/BoxPistols/kaze-ux/blob/main/docs/guides/using-from-other-repos.md
+    about: 他リポジトリから MCP / Plugin を使う通しの手順
+  - name: Storybook（実物を見る）
+    url: https://kaze-ux.vercel.app
+    about: コンポーネント・トークン・MCP の紹介ページ
+  - name: セキュリティ報告 / Security
+    url: https://github.com/BoxPistols/kaze-ux/security/advisories/new
+    about: 脆弱性は公開 Issue ではなくこちらから非公開で報告してください

--- a/.github/ISSUE_TEMPLATE/mcp-question.yml
+++ b/.github/ISSUE_TEMPLATE/mcp-question.yml
@@ -1,0 +1,54 @@
+name: MCP / Plugin の質問・不具合
+description: kaze-mcp や Claude Code Plugin を他リポジトリで使うときの質問・不具合
+title: '[mcp] '
+labels: [mcp]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        導入手順は [docs/guides/using-from-other-repos.md](https://github.com/BoxPistols/kaze-ux/blob/main/docs/guides/using-from-other-repos.md)、
+        仕組みは [DESIGN.md](https://github.com/BoxPistols/kaze-ux/blob/main/DESIGN.md) にあります。
+        **セキュリティに関わる問題はここではなく [Security Advisories](https://github.com/BoxPistols/kaze-ux/security/advisories/new) からお願いします。**
+
+  - type: dropdown
+    id: route
+    attributes:
+      label: 導入方法
+      options:
+        - Claude Code Plugin（/plugin install）
+        - .mcp.json に手動登録（Claude Code）
+        - .cursor/mcp.json に手動登録（Cursor）
+        - npm（npx kaze-mcp）
+        - その他
+    validations:
+      required: true
+
+  - type: textarea
+    id: what
+    attributes:
+      label: 何が起きましたか
+      description: 期待した動きと実際の動き
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: 再現手順
+      placeholder: |
+        1. ...
+        2. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: env
+    attributes:
+      label: 環境
+      description: |
+        `pnpm check:mcp` の出力があれば貼ってください（リポジトリ内で試せる場合）。
+      placeholder: |
+        OS:
+        Node:
+        クライアント（Claude Code / Cursor / その他）:
+        kaze-mcp のバージョン:

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -7,7 +7,7 @@ Kaze Design System の知識・ルール・部品を、**このリポジトリ�
 > **知識はデータに、強制は仕組みに、コードは最低限に。**
 
 - 個別計画: [`docs/plans/mcp-release.md`](docs/plans/mcp-release.md)（MCP 版リリースの要件定義・詳細設計）
-- 導入マニュアル: [`docs/guides/using-from-other-repos.md`](docs/guides/using-from-other-repos.md)（消費側） / [`docs/guides/npm-publishing.md`](docs/guides/npm-publishing.md)（npm 公開）
+- 導入マニュアル: [`docs/guides/using-from-other-repos.md`](docs/guides/using-from-other-repos.md)（消費側） / [`docs/guides/npm-publishing.md`](docs/guides/npm-publishing.md)（npm / MCP Registry 公開） / [`docs/guides/going-public.md`](docs/guides/going-public.md)（公開と流布）
 - リポジトリ内の開発規約: [`CLAUDE.md`](CLAUDE.md) / [`AI_DEVELOPMENT_RULES.md`](AI_DEVELOPMENT_RULES.md)
 
 ## 1. 全体図
@@ -214,7 +214,25 @@ SubAgent・Hook がすべて入る。個別導入（MCP だけ欲しい）は §
 | 新しい機械検査       | `hooks/check-prohibited.mjs` + `scripts/`                | ESLint で書けるものを Hook に書く |
 | MCP 新ツール         | 最終手段。まずデータ拡張で解決できないか検討             | —                                 |
 
-## 10. 検証
+## 10. 流布（見つけてもらう）
+
+作っただけでは使われない。**置き場所を用意して初めて発見される。**
+
+| 段階       | 何を用意するか             | 置き場所                                                                 |
+| ---------- | -------------------------- | ------------------------------------------------------------------------ |
+| 見つかる   | パッケージとカタログ登録   | npm（`kaze-mcp`）→ MCP Registry（`io.github.boxpistols/kaze-mcp`）       |
+| わかる     | 30 秒で何かが伝わる説明    | README 冒頭（英語）/ LP の MCP セクション / Storybook `Guide/MCP Server` |
+| 試せる     | 迷わず 1 回動かせる手順    | [`using-from-other-repos.md`](docs/guides/using-from-other-repos.md)     |
+| 使い続ける | 古びていないと外から分かる | CI の検査 + リリース                                                     |
+
+MCP Registry は**メタデータしか持たない**ので、npm 公開が先。順序と手順は
+[`going-public.md`](docs/guides/going-public.md)。
+
+配布の導線には必ず owner が出る（`/plugin marketplace add <owner>/<repo>`、
+`io.github.<owner>/`）。そのため `check:anon` が守る範囲は「個人に届く情報」
+（メール・実名・ローカルパス）で、**リポジトリの公開名義は通す**。
+
+## 11. 検証
 
 | コマンド                    | 保証すること                                 |
 | --------------------------- | -------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # Kaze Design System
 
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![MCP Server](https://img.shields.io/badge/MCP-kaze--mcp-0057B8.svg)](mcp/README.md)
+[![Storybook](https://img.shields.io/badge/Storybook-live-FF4785.svg)](https://kaze-ux.vercel.app)
+
+> **Design system knowledge for AI agents.** Tokens, component specs, and
+> prohibited patterns are generated from a single machine-readable source and
+> served to Claude Code / Cursor over MCP — so agents write UI code that matches
+> the system, in any repository.
+> [Get started →](docs/guides/using-from-other-repos.md) ·
+> [Architecture →](DESIGN.md)
+
 MUI + Tailwind CSS + Storybook で構築したデザインシステム。
 
 このプロジェクトが他と違うのは 2 点です。
@@ -50,6 +61,21 @@ MUI + Tailwind CSS + Storybook で構築したデザインシステム。
 | **KazeLogistics**  | 配送監視・地図・リアルタイムダッシュボード          | `/sky-kaze/`  |
 
 ## Quick Start
+
+### 他のリポジトリで使う（デザインシステムとして）
+
+Claude Code なら 2 コマンドで、MCP・Skills・レビュー用 SubAgent・禁止パターンを
+止める Hook まで入ります。
+
+```
+/plugin marketplace add BoxPistols/kaze-ux
+/plugin install kaze-design@kaze-ux
+```
+
+Cursor など他のクライアントは `.mcp.json` に登録すれば MCP だけ使えます。
+通しの手順は [`docs/guides/using-from-other-repos.md`](docs/guides/using-from-other-repos.md)。
+
+### このリポジトリを動かす（開発）
 
 ```bash
 pnpm install

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security Policy / セキュリティ方針
+
+## Reporting a vulnerability / 脆弱性の報告
+
+**Please do not open a public issue for security problems.**
+Use [GitHub Security Advisories](https://github.com/BoxPistols/kaze-ux/security/advisories/new)
+so the report stays private until a fix is available.
+
+セキュリティに関わる問題は **公開 Issue を立てないでください**。
+上記の GitHub Security Advisories から非公開で報告してください。
+
+Please include: what you found, how to reproduce it, and the affected version.
+We aim to acknowledge within a few days.
+
+## Scope / 範囲
+
+This repository ships three things that can affect a consumer's machine:
+
+| Component               | What it does                                | Risk surface                                             |
+| ----------------------- | ------------------------------------------- | -------------------------------------------------------- |
+| `kaze-mcp` (MCP server) | Reads local data files, answers over stdio  | Local file reads only. **No network access, no writes**  |
+| Claude Code plugin      | Installs skills, a review agent, and a hook | The hook runs `hooks/check-prohibited.mjs` on file edits |
+| Storybook / demo apps   | Documentation and examples                  | Static hosting                                           |
+
+The MCP server does not make network requests and does not write files.
+It reads the design-system data files described in [`DESIGN.md`](DESIGN.md).
+
+## What we check automatically / 自動で検査していること
+
+Security-relevant checks run in CI on every pull request:
+
+| Check                  | Command                 | What it catches                                           |
+| ---------------------- | ----------------------- | --------------------------------------------------------- |
+| Secret scanning        | Gitleaks + `check:live` | Credentials in the repository and in **deployed bundles** |
+| Dependency scanning    | Trivy (SCA)             | Known vulnerabilities in dependencies                     |
+| Anonymity of artifacts | `pnpm check:anon`       | Personal contact details leaking into shared builds       |
+
+`check:live` exists because a real API key was once served in a production
+Storybook bundle while source-only scans stayed green. Scanning the source is
+not the same as scanning what is actually shipped.
+
+## Supported versions / サポート対象
+
+The latest `main` and the most recent `kaze-mcp` release on npm.
+This project has no long-term support branches.

--- a/docs/guides/going-public.md
+++ b/docs/guides/going-public.md
@@ -1,0 +1,100 @@
+# 公開と流布（メンテナ向けチェックリスト）
+
+kaze-ux を public にし、MCP / Skills を**探している人に見つかる場所**へ載せるまでの手順。
+
+「作った」と「見つけてもらえる」は別問題で、後者は置き場所を用意しないと起きない。
+このガイドは後者だけを扱う。中身の作り方は [`DESIGN.md`](../../DESIGN.md)。
+
+## 0. 何が終わっていて、何が残っているか
+
+| 段階                                     | 状態                      |
+| ---------------------------------------- | ------------------------- |
+| 試せる（導入手順・マニュアル・検査）     | ✅ 完了                   |
+| わかる（英語の入口・LP の導線・バッジ）  | ✅ 完了                   |
+| 見つかる（public 化・npm・MCP Registry） | ⬜ **人手が必要**（下記） |
+
+コードでできることは終わっている。残りはアカウント権限が要る操作だけ。
+
+## 1. public 化の前に（1 回だけ）
+
+```bash
+pnpm check:share   # 匿名性 + 配信中の資格情報
+```
+
+これが緑であることを確認してから公開する。**公開後に消しても、履歴と
+キャッシュは残る**ので順番を逆にしない。
+
+この検査が守る範囲は「個人に届く情報」（メールアドレス・実名・ローカルパス）。
+リポジトリの owner とパスは公開名義として通す — 配布の導線
+（`/plugin marketplace add <owner>/<repo>`、MCP Registry の
+`io.github.<owner>/`）に必ず出るもので、秘匿と両立しないため。
+
+## 2. public にする
+
+GitHub の Web UI から:
+
+**Settings → General → 一番下の Danger Zone → Change repository visibility → Make public**
+
+API では変更できないため、ここだけは手作業になる。
+
+公開直後にやること:
+
+- Settings → General → Features で **Discussions** を有効化（質問の受け皿。
+  Issue より敷居が低い）
+- About（右上の歯車）→ description を英語併記にする。
+  例: `Design system knowledge for AI agents — tokens, component specs and rule
+checks over MCP. MUI + Tailwind + Storybook.`
+- About → Website に `https://kaze-ux.vercel.app` が入っているか確認
+- topics は設定済み（`mcp` / `design-system` / `design-tokens` / `ai-agents` ほか）。
+  **public になって初めて検索に効く**
+
+## 3. npm に公開する
+
+手順は [`npm-publishing.md`](npm-publishing.md) §1〜§3。
+
+```bash
+pnpm check:mcp-package   # 配布物が本当に動くか
+cd mcp && npm publish --access public
+```
+
+## 4. MCP Registry に載せる（ここが「自然に発見される」場所）
+
+手順は [`npm-publishing.md`](npm-publishing.md) §3.5。npm 公開が前提。
+
+```bash
+mcp-publisher login github
+cd mcp && mcp-publisher publish
+```
+
+登録名は `io.github.boxpistols/kaze-mcp`。
+
+## 5. 外に置く（任意・効果は 1〜4 の後）
+
+- **GitHub Release** を切る（`kaze-mcp@0.2.0`）。リリースがあると、
+  更新されている
+  プロジェクトだと外から分かる
+- **awesome 系リストへ PR**。`awesome-mcp-servers` などに 1 行足す。
+  文面の下書き:
+
+  > **[kaze-mcp](https://github.com/BoxPistols/kaze-ux/tree/main/mcp)** —
+  > Design system knowledge for AI agents. Serves design tokens, component
+  > specs, and prohibited-pattern checks over MCP, so agents write UI code that
+  > matches the system. Works with any design system that provides the same
+  > data files.
+
+- **Storybook を入口として共有する**（`https://kaze-ux.vercel.app`）。
+  読む人にとっては、実物が動いているページが一番速い説明になる
+
+## 6. 公開後に効き続けるようにする
+
+| やること                                             | なぜ                                                   |
+| ---------------------------------------------------- | ------------------------------------------------------ |
+| ルール・トークンを変えたら生成物を再生成して publish | 古い仕様を配ると、使う側は黙って古い値を掴む           |
+| CI を緑に保つ                                        | 検査が落ちているリポジトリは、外から見ると信用できない |
+| Issue / Discussions に反応する                       | 反応がないプロジェクトは使われなくなる                 |
+
+## 7. 元に戻したくなったら
+
+private に戻す操作は同じ場所からできるが、**すでに clone / fork / npm
+install された分は戻らない**。npm も publish 済みバージョンは削除しても
+同じ番号を再利用できない。1 の検査を先に通すのはこのため。

--- a/docs/guides/npm-publishing.md
+++ b/docs/guides/npm-publishing.md
@@ -85,6 +85,46 @@ publish 前に赤くなります（実際に 3 ファイルを抜いて落ちる
 - ツール・リソースの追加 → minor (`0.x.0`)
 - ツールの引数・返却形式の破壊的変更 → major
 
+## 3.5 MCP Registry に登録する（発見される場所に載せる）
+
+npm 公開は「入れられる」状態を作るだけで、**探している人に見つかる場所には
+まだ載っていません**。MCP クライアントがサーバーを探すカタログが
+[MCP Registry](https://registry.modelcontextprotocol.io/) で、
+uber.design/base-mcp のような公開デザインシステムが並ぶのはここです。
+
+Registry は**メタデータしか持ちません**。実体は npm 側にあるので、
+必ず npm publish（§3）を先に済ませてください。
+
+準備は済んでいます:
+
+| ファイル                        | 役割                                                            |
+| ------------------------------- | --------------------------------------------------------------- |
+| `mcp/server.json`               | Registry へ渡すマニフェスト（名前・説明・npm パッケージの指定） |
+| `mcp/package.json` の `mcpName` | 所有者の検証。`server.json` の `name` と一致する必要がある      |
+
+名義は `io.github.boxpistols/kaze-mcp`。GitHub 認証を使う場合、
+名前空間は `io.github.<アカウント名>/` に固定されます。
+両者のずれは `pnpm check:mcp-package` が検出します（CI でも走ります）。
+
+```bash
+# 1) publisher CLI を入れる（Homebrew / Snap / GitHub Releases のいずれか）
+brew install mcp-publisher
+
+# 2) GitHub でログイン（io.github.boxpistols/* の名前空間が付与される）
+mcp-publisher login github
+
+# 3) 登録（mcp/ で実行。server.json を読む）
+cd mcp && mcp-publisher publish
+```
+
+登録後は各 MCP クライアントのカタログから `kaze-mcp` が見つかります。
+GitHub Actions で自動化する場合は `mcp-publisher login github-oidc` を使い、
+ワークフローに `permissions: id-token: write` を与えます。
+
+**バージョンを上げたら Registry 側も publish し直します。**
+`server.json` の `version` と `packages[0].version` を `package.json` と
+揃えてから実行してください（揃っていなければ検査が止めます）。
+
 ## 4. 公開後にやること
 
 | 対象                                    | 変更                                                                         |
@@ -106,7 +146,8 @@ publish 前に赤くなります（実際に 3 ファイルを抜いて落ちる
 ## 6. チェックリスト（公開直前に見る）
 
 - [ ] `npm view kaze-mcp` が 404（初回のみ）
-- [ ] `pnpm check:mcp-package` が通る（同梱・ビルド・リポジトリ外での起動を一括で見る）
+- [ ] `pnpm check:mcp-package` が通る（レジストリ名義・同梱・リポジトリ外での起動を一括で見る）
+- [ ] npm publish 後に MCP Registry へも登録した（§3.5）
 - [ ] `pnpm check:mcp` が通る
 - [ ] 生成物が最新（`pnpm export-tokens && pnpm export-metadata && pnpm export-rules`）
 - [ ] バージョンを適切に上げた（`mcp/package.json`）

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,5 +1,15 @@
 # kaze-mcp — Kaze Design System MCP Server
 
+**Design system knowledge for AI agents.** Serves design tokens, component
+specs, and prohibited-pattern checks over MCP, so Claude Code / Cursor write UI
+code that matches the system — in any repository. Runs over stdio, reads local
+files only: **no network access, no writes**.
+
+Works with any design system that provides the same data files
+（[see below](#他のデザインシステムで使う)）.
+
+---
+
 Kaze Design System の設計知識（デザイントークン・コンポーネント仕様・禁止ルール）を
 MCP (Model Context Protocol) で AI エージェントに供給するサーバー。
 

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kaze-mcp",
   "version": "0.2.0",
-  "description": "Kaze Design System MCP Server — AI エージェント向けトークン検索・コンポーネント仕様取得・ルールチェック",
+  "description": "Design system knowledge for AI agents — design tokens, component specs, and rule checks (Kaze Design System) / デザインシステムの知識を AI エージェントへ供給する MCP サーバー",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
@@ -10,6 +10,7 @@
   "files": [
     "dist",
     "data",
+    "server.json",
     "README.md"
   ],
   "engines": {
@@ -28,10 +29,16 @@
   "homepage": "https://github.com/BoxPistols/kaze-ux/tree/main/mcp",
   "keywords": [
     "mcp",
+    "mcp-server",
     "design-system",
     "design-tokens",
-    "ai",
+    "ai-agents",
     "claude",
+    "claude-code",
+    "cursor",
+    "storybook",
+    "mui",
+    "tailwindcss",
     "kaze"
   ],
   "dependencies": {
@@ -43,5 +50,6 @@
     "typescript": "^5.9.3",
     "vitest": "^1.6.1"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "mcpName": "io.github.boxpistols/kaze-mcp"
 }

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.boxpistols/kaze-mcp",
+  "description": "Design system knowledge for AI agents — design tokens, component specs, and prohibited-pattern checks from the Kaze Design System (MUI + Tailwind + Storybook). Works with any design system that provides the same data files.",
+  "version": "0.2.0",
+  "repository": {
+    "url": "https://github.com/BoxPistols/kaze-ux",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "kaze-mcp",
+      "version": "0.2.0",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/scripts/check-anonymity.mjs
+++ b/scripts/check-anonymity.mjs
@@ -56,27 +56,81 @@ const deriveIdentity = () => {
     if (t.length > 2) values.add(t)
   }
 
+  /**
+   * プロジェクトとして公開している名義。**ここは伏せる対象ではない。**
+   *
+   * リポジトリを公開して配る以上、導線には必ずリポジトリのパスが出る。
+   * Plugin の導入は `/plugin marketplace add <owner>/<repo>`、MCP Registry の
+   * 名前空間は `io.github.<owner>/...` で、どちらも owner を含む形しか無い。
+   * つまり**配布と owner の秘匿は両立しない**。
+   *
+   * そこで守る範囲を分ける。伏せるのは個人に届く情報（メールアドレス・実名・
+   * noreply の数字 ID）で、リポジトリの owner とパスは公開名義として通す。
+   * public なリポジトリでは owner はすでに誰でも見られるので、成果物に載っても
+   * 情報は増えない。一方メールと実名は、載せなければ載らない。
+   */
+  const publicIdentity = new Set()
+  const addPublic = (v) => {
+    const t = (v ?? '').trim()
+    if (t.length > 2) publicIdentity.add(t.toLowerCase())
+  }
+
   const remote = git('remote get-url origin')
   if (remote) {
-    add(remote.replace(/\.git$/, ''))
+    addPublic(remote.replace(/\.git$/, ''))
     // git@host:owner/repo / https://host/owner/repo の両方から owner を取る
     const m = remote.match(/[:/]([^/:]+)\/([^/]+?)(\.git)?$/)
     if (m) {
-      add(m[1])
-      add(`${m[1]}/${m[2]}`)
+      addPublic(m[1])
+      addPublic(`${m[1]}/${m[2]}`)
     }
   }
-  add(git('config user.email'))
-  add(git('config user.name'))
-  for (const line of git('log --format=%an%x09%ae -200').split('\n')) {
-    const [name, email] = line.split('\t')
+  /**
+   * 人ではない作者かどうか。**bot と AI は伏せる対象ではない。**
+   *
+   * 名前まで伏せると、**その名前を説明した本文が身元の混入として弾かれる**。
+   * 実際 `user.name = Claude` の環境でビルドした瞬間、「Claude Code に
+   * 対応している」と書いたページが一斉に落ちた。伏せても個人には辿れない
+   * 一方、デザインシステムの説明としては書かないわけにいかない語だった。
+   *
+   * 判定は名前ではなくメールで行う。GitHub の users.noreply.github.com は
+   * 実在の人物を隠したものなので対象に残す（数字 ID が本人に紐づく）。
+   * それ以外の noreply は自動化とみなす。
+   */
+  const isMachine = (name, email) =>
+    /\[bot\]$/.test(name ?? '') ||
+    (/^noreply@/i.test(email ?? '') &&
+      !/users\.noreply\.github\.com$/i.test(email ?? ''))
+
+  /**
+   * 作者を 1 人ぶん取り込む。
+   *
+   * ローカルの git 設定とコミット履歴の両方を通す。**片方だけに判定を
+   * 掛けても意味が無い**（履歴側だけ除外していたとき、CI の
+   * `user.name` が素通りして同じ誤検出が残った）。
+   */
+  const addAuthor = (name, email) => {
+    if (isMachine(name, email)) return
     add(name)
     add(email)
+  }
+
+  addAuthor(git('config user.name'), git('config user.email'))
+  for (const line of git('log --format=%an%x09%ae -200').split('\n')) {
+    const [name, email] = line.split('\t')
+    addAuthor(name, email)
   }
   // noreply の数字 ID も本人に紐づく
   for (const v of [...values]) {
     const m = v.match(/^(\d+)\+/)
     if (m) add(m[1])
+  }
+
+  // git の user.name やコミット作者が owner と同じ文字列のことがある。
+  // 公開名義と一致するものはここで落とす（大文字小文字は無視。GitHub は
+  // 表記を変えても同じアカウントに解決するため、片方だけ残すと意味が無い）
+  for (const v of [...values]) {
+    if (publicIdentity.has(v.toLowerCase())) values.delete(v)
   }
 
   const escape = (t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')

--- a/scripts/check-mcp-package.mjs
+++ b/scripts/check-mcp-package.mjs
@@ -24,6 +24,7 @@ import { spawn } from 'node:child_process'
 import {
   existsSync,
   mkdtempSync,
+  readFileSync,
   readdirSync,
   rmSync,
   symlinkSync,
@@ -44,7 +45,61 @@ const MCP = resolve(ROOT, 'mcp')
 const work = mkdtempSync(resolve(tmpdir(), 'kaze-mcp-pack-'))
 let failed = false
 
+/**
+ * MCP Registry は `package.json` の `mcpName` と `server.json` の `name` が
+ * 一致することで、そのパッケージの所有者を確かめる。**ずれると publish が
+ * 弾かれる**が、ずれても手元では何も起きないので気づけない。
+ * バージョンも同じ理由で揃っている必要がある（上げ忘れが起きやすい）。
+ */
+const checkRegistryManifest = () => {
+  const pkg = JSON.parse(readFileSync(resolve(MCP, 'package.json'), 'utf-8'))
+  const server = JSON.parse(readFileSync(resolve(MCP, 'server.json'), 'utf-8'))
+  const npmPkg = server.packages?.[0] ?? {}
+
+  const mismatches = [
+    [
+      'package.json の mcpName',
+      pkg.mcpName,
+      'server.json の name',
+      server.name,
+    ],
+    [
+      'package.json の version',
+      pkg.version,
+      'server.json の version',
+      server.version,
+    ],
+    [
+      'package.json の version',
+      pkg.version,
+      'server.json の packages[0].version',
+      npmPkg.version,
+    ],
+    [
+      'package.json の name',
+      pkg.name,
+      'server.json の packages[0].identifier',
+      npmPkg.identifier,
+    ],
+  ].filter(([, a, , b]) => a !== b)
+
+  if (mismatches.length) {
+    console.error('❌ MCP Registry 用の名義が揃っていません:')
+    for (const [aLabel, a, bLabel, b] of mismatches) {
+      console.error(
+        `   ${aLabel} = ${a ?? '(未設定)'} / ${bLabel} = ${b ?? '(未設定)'}`
+      )
+    }
+    process.exit(1)
+  }
+  console.log(
+    `✅ レジストリ名義 ${server.name} (v${server.version}) が揃っています`
+  )
+}
+
 try {
+  checkRegistryManifest()
+
   // --- 1. publish と同じ経路で tarball を作る ---
   console.log('📦 npm pack（prepack でデータ同梱 + ビルド）...')
   execFileSync('npm', ['pack', '--pack-destination', work], {

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1154,6 +1154,152 @@ export const LandingPage = () => {
       {/* セパレーター */}
       <BauhausDivider variant='c' />
 
+      {/* ===== MCP Server ===== */}
+      <Box sx={{ py: { xs: 8, md: 14 } }}>
+        <Box sx={{ ...CONTAINER_SX }}>
+          <motion.div
+            initial={{ opacity: 0 }}
+            whileInView={{ opacity: 1 }}
+            viewport={{ once: true }}>
+            <Typography sx={EYEBROW_SX}>MCP Server</Typography>
+            <Typography sx={DISPLAY_SX}>AI に設計知識を配る</Typography>
+            <Typography sx={{ ...SECTION_LEAD_SX, mb: 4 }}>
+              トークン・部品仕様・禁止ルールを MCP
+              で供給する。別のリポジトリでも AI が Kaze
+              に準拠したコードを書けるようになる
+            </Typography>
+          </motion.div>
+
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' },
+              gap: { xs: 3, md: 6 },
+              alignItems: 'start',
+            }}>
+            {/* 導入 */}
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.5 }}>
+              <Typography sx={{ fontSize: '0.9rem', fontWeight: 700, mb: 1.5 }}>
+                Claude Code なら 2 コマンド
+              </Typography>
+              <Box
+                component='pre'
+                sx={{
+                  m: 0,
+                  p: 2.5,
+                  borderRadius: 2,
+                  overflowX: 'auto',
+                  fontSize: '0.86rem',
+                  lineHeight: 1.9,
+                  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+                  color: 'text.primary',
+                  border: '1px solid',
+                  borderColor: isDark
+                    ? 'rgba(255,255,255,0.12)'
+                    : 'rgba(0,0,0,0.12)',
+                  bgcolor: isDark
+                    ? 'rgba(255,255,255,0.03)'
+                    : 'rgba(0,0,0,0.02)',
+                }}>
+                {'/plugin marketplace add BoxPistols/kaze-ux\n'}
+                {'/plugin install kaze-design@kaze-ux'}
+              </Box>
+              <Typography
+                sx={{
+                  fontSize: '0.9rem',
+                  color: 'text.secondary',
+                  lineHeight: 1.9,
+                  mt: 2,
+                }}>
+                MCP に加えて Skills・レビュー用の SubAgent・禁止パターンを止める
+                Hook が一度に入る。Cursor などは
+                <Box component='code' sx={{ mx: 0.5 }}>
+                  .mcp.json
+                </Box>
+                に登録すれば MCP だけ使える
+              </Typography>
+            </motion.div>
+
+            {/* 何が引けるか */}
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.5, delay: 0.1 }}>
+              <Typography sx={{ fontSize: '0.9rem', fontWeight: 700, mb: 1.5 }}>
+                エージェントが引けるもの
+              </Typography>
+              <Box sx={{ display: 'grid', gap: 1.5 }}>
+                {[
+                  {
+                    name: 'get_token',
+                    desc: 'デザイントークンをドットパスで取得',
+                  },
+                  {
+                    name: 'get_component',
+                    desc: '部品の props・a11y・import 元',
+                  },
+                  {
+                    name: 'check_rule',
+                    desc: '書いたコードを禁止パターンに照合',
+                  },
+                  { name: 'search', desc: 'トークンと部品を横断検索' },
+                ].map((tool) => (
+                  <Box
+                    key={tool.name}
+                    sx={{
+                      display: 'flex',
+                      gap: 1.5,
+                      alignItems: 'baseline',
+                      flexWrap: 'wrap',
+                    }}>
+                    <Box
+                      component='code'
+                      sx={{
+                        fontSize: '0.86rem',
+                        fontWeight: 700,
+                        color: 'primary.main',
+                        fontFamily:
+                          'ui-monospace, SFMono-Regular, Menlo, monospace',
+                      }}>
+                      {tool.name}
+                    </Box>
+                    <Typography
+                      sx={{ fontSize: '0.9rem', color: 'text.secondary' }}>
+                      {tool.desc}
+                    </Typography>
+                  </Box>
+                ))}
+              </Box>
+              <Box
+                component='a'
+                href={`${APP_LINKS.storybook()}?path=/story/guide-mcp-server--overview`}
+                sx={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 1,
+                  mt: 3,
+                  fontSize: '0.9rem',
+                  fontWeight: 700,
+                  color: 'primary.main',
+                  textDecoration: 'none',
+                  transition: motionOf(['opacity'], 'macro'),
+                  '&:hover': { opacity: 0.7 },
+                }}>
+                導入手順と仕組みを見る →
+              </Box>
+            </motion.div>
+          </Box>
+        </Box>
+      </Box>
+
+      {/* セパレーター */}
+      <BauhausDivider variant='b' />
+
       {/* ===== 使い方 ===== */}
       <Box sx={{ py: { xs: 8, md: 14 } }}>
         <Box sx={{ ...CONTAINER_SX }}>

--- a/src/stories/00-Guide/McpServer.stories.tsx
+++ b/src/stories/00-Guide/McpServer.stories.tsx
@@ -150,7 +150,7 @@ const McpServerContent = () => {
       <CodeBlock
         language='bash'
         caption='Claude Code Plugin なら 2 コマンドで全部入り（MCP + Skills + SubAgent + Hook）'>
-        {`/plugin marketplace add boxpistols/kaze-ux
+        {`/plugin marketplace add BoxPistols/kaze-ux
 /plugin install kaze-design@kaze-ux`}
       </CodeBlock>
 


### PR DESCRIPTION
# 課題・背景

- リポジトリをpublicにし、MCP / Skillsを**探している人に見つかる場所**へ載せるための準備
- 関連URL: [docs/guides/going-public.md](https://github.com/BoxPistols/kaze-ux/blob/claude/kaze-design-system-mcp-1qv931/docs/guides/going-public.md)

「作った」と「見つけてもらえる」は別問題で、後者は置き場所を用意しないと起きない。
現状は導線がゼロで、`BoxPistols/kaze-ux` を**既に知っている人しか辿り着けない**。

## 実装した事

### 匿名性方針の整理（判断が要った箇所）

配布の導線には必ずownerが出る — Pluginは `/plugin marketplace add <owner>/<repo>`、
MCP Registryの名前空間は `io.github.<owner>/` で固定。**秘匿と配布は両立しない**。

そこで `check:anon` が守る範囲を整理した内容:

| 対象 | 扱い |
| --- | --- |
| 個人メール・実名・ローカルパス・SNSリンク | **引き続き遮断** |
| リポジトリのowner / パス（公開名義） | 通す（publicでは既に誰でも見られる） |

- [x] 負のテストで確認: 個人メール・実名・`/Users/...` は今も検出され、
      `Claude Code` と `BoxPistols/kaze-ux` だけが通る
- [x] **併せてAI由来の誤検出を修正** — `user.name = Claude` の環境でビルドすると
      「Claude Codeに対応している」と書いたページが一斉に落ちていた。botとAIは
      個人に辿れないので対象外にする（判定は名前ではなくメールで行い、GitHubの
      `users.noreply.github.com` は人物として残す）

### MCP Registry対応

- [x] `mcp/server.json`（登録名 `io.github.boxpistols/kaze-mcp`）
- [x] `mcp/package.json` に `mcpName`。Registryが所有権を検証する
- [x] **名義とバージョンのずれを `check:mcp-package` が検出**（publish時にしか
      現れない不整合なので、手元で止める）

### 発見性

- [x] README冒頭に英語のリード文とバッジ、他リポジトリ向けQuick Start
- [x] npm description / keywordsを英語併記に（レジストリ検索は英語圏が主戦場）
- [x] `mcp/README.md`（npmページの顔）に英語リード
- [x] **LPにMCPセクション** — トップから1スクロールで発見できる導線。
      Storybookの `Guide/MCP Server` へリンク

### OSS公開の作法

- [x] `SECURITY.md`（報告経路・攻撃面・自動検査の一覧）
- [x] Issueテンプレート（MCP / Plugin用）と `config.yml`
- [x] `docs/guides/going-public.md` — public化前の検査からawesomeリスト投稿文面まで

## 動作確認

レビュー方法を、いずれか１つ選択

- [ ] ファイルやコードの確認だけでOK
- [x] 起動してブラウザでの確認も必要（LPのMCPセクション）

ローカルで確認済み:

- `pnpm check:share`（匿名性 + 配信中の資格情報）✅ — **フルビルドし直して確認**
- `check:mcp-package` ✅ / `check:mcp` ✅ / `check:skills` ✅ / `check:rules` ✅
- `lint` ✅ / `tsc --noEmit` ✅ / `test:run` 709件 ✅
- ドキュメントの相対リンク・IssueテンプレートのYAML ✅

**DS自身のテストが新UIの違反を検出した**ため修正済み: LPに足した文字サイズが
12px下限を割っていた（`0.8rem` × 14px = 11.2px）。既存の下限 `0.86rem` に合わせた。

## 特にレビューしてほしい点

- 匿名性方針の線引き（ownerは通す / 個人情報は遮断）が意図と合っているか
- bot・AIを検査対象から外す判定（メールで判定し、GitHubのnoreplyは人物として残す）
- LPのMCPセクションの配置と分量

## 今回レビュースコープ外の事

以下は**アカウント権限が必要**で、コードでは実施できない（手順は `going-public.md`）:

- リポジトリのpublic化（GitHubのSettingsからのみ。API不可）
- `npm publish` と `mcp-publisher publish`

## キャプチャ

UI変更時のキャプチャ

### Before

LPにMCPへの言及なし（外から来た人はMCPに辿り着けない）

### After

LPに「MCP Server / AIに設計知識を配る」セクション。導入コマンド・4ツールの一覧・
Storybookの解説ページへの導線

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Toy4uHJ8UsbL79SqwTPKHU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Toy4uHJ8UsbL79SqwTPKHU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 新機能
  * MCP Serverの概要、導入方法、提供ツールをランディングページで案内。
  * MCP Registryへの公開に対応し、関連情報を追加。
  * GitHub Issueテンプレートとセキュリティ報告手順を整備。

* ドキュメント
  * READMEにMCP、Storybook、Claude Code Pluginの導入ガイドを追加。
  * npm・MCP Registryへの公開手順と運用ガイドを追加。
  * MCPサーバーの機能、利用方法、安全性に関する説明を拡充。

* 品質改善
  * 公開前の匿名性、構成情報、パッケージ整合性チェックを強化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
