### PR TITLE
fix(chat): 保存済みの旧モデル ID を現行モデルへ正規化する

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Build Storybook
         if: steps.target.outputs.target == 'all' || steps.target.outputs.target == 'storybook'
         env:
-          VITE_OPENAI_MODEL: 'gpt-4.1-nano'
+          VITE_OPENAI_MODEL: 'gpt-5.6-luna'
         run: |
           pnpm run build-storybook
           mkdir -p gh-pages/storybook

--- a/src/components/ui/ChatSupport/__tests__/chatSupportConstants.test.ts
+++ b/src/components/ui/ChatSupport/__tests__/chatSupportConstants.test.ts
@@ -15,6 +15,8 @@ import {
   ENGINEER_PROMPT_EXTENSION,
   OPENAI_MODELS,
   GEMINI_MODELS,
+  DEFAULT_MODEL,
+  resolveSupportedModel,
 } from '../chatSupportConstants'
 import type { ShortcutBinding } from '../chatSupportTypes'
 
@@ -247,6 +249,11 @@ describe('normalizeChatConfig', () => {
     expect(result.apiKey).toBe(DEFAULT_CHAT_CONFIG.apiKey)
   })
 
+  it('一覧から外れた旧モデルを既定モデルに寄せる', () => {
+    const result = normalizeChatConfig({ model: 'gpt-5.4-nano' })
+    expect(result.model).toBe(DEFAULT_MODEL)
+  })
+
   it('shortcutsが不正でもデフォルトショートカットを返す', () => {
     const result = normalizeChatConfig({ shortcuts: 'bad' })
     expect(result.shortcuts.sendMessage).toBeDefined()
@@ -321,6 +328,18 @@ describe('loadChatConfig', () => {
     )
     const config = loadChatConfig()
     expect(config.model).toBe('gpt-5.6-luna')
+  })
+
+  it('保存済みの旧モデルは読み込み時に既定モデルへ戻す', () => {
+    getItemSpy.mockReturnValue(
+      JSON.stringify({
+        apiKey: 'sk-custom-key',
+        model: 'gpt-5.4-nano',
+        uiMode: 'widget',
+      })
+    )
+    const config = loadChatConfig()
+    expect(config.model).toBe(DEFAULT_MODEL)
   })
 
   it('カスタムAPIキー使用時はモデルをそのまま保持する', () => {
@@ -442,5 +461,34 @@ describe('プロンプト拡張定数', () => {
   it('ENGINEER_PROMPT_EXTENSIONが非空', () => {
     expect(ENGINEER_PROMPT_EXTENSION.length).toBeGreaterThan(0)
     expect(ENGINEER_PROMPT_EXTENSION).toContain('エンジニア')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveSupportedModel
+// ---------------------------------------------------------------------------
+
+describe('resolveSupportedModel', () => {
+  it('一覧にあるモデルはそのまま返す', () => {
+    for (const model of [...OPENAI_MODELS, ...GEMINI_MODELS]) {
+      expect(resolveSupportedModel(model.value)).toBe(model.value)
+    }
+  })
+
+  it('未知の OpenAI モデルは OpenAI の既定に寄せる', () => {
+    expect(resolveSupportedModel('gpt-5.4-nano')).toBe(DEFAULT_MODEL)
+    expect(resolveSupportedModel('gpt-4.1-nano')).toBe(DEFAULT_MODEL)
+  })
+
+  it('未知の Gemini モデルは Gemini の既定に寄せる', () => {
+    expect(resolveSupportedModel('gemini-1.5-flash')).toBe(
+      GEMINI_MODELS[0].value
+    )
+  })
+
+  it('空文字・非文字列は既定モデルに寄せる', () => {
+    expect(resolveSupportedModel('')).toBe(DEFAULT_MODEL)
+    expect(resolveSupportedModel(undefined)).toBe(DEFAULT_MODEL)
+    expect(resolveSupportedModel(42)).toBe(DEFAULT_MODEL)
   })
 })

--- a/src/components/ui/ChatSupport/chatSupportConstants.ts
+++ b/src/components/ui/ChatSupport/chatSupportConstants.ts
@@ -331,6 +331,24 @@ export const GEMINI_MODELS: ModelOption[] = [
 /** 全モデル一覧（後方互換） */
 export const DEFAULT_MODELS = [...OPENAI_MODELS, ...GEMINI_MODELS]
 
+/** プロバイダーごとの既定モデル */
+const providerDefaultModel = (isGemini: boolean): string =>
+  isGemini ? (GEMINI_MODELS[0]?.value ?? DEFAULT_MODEL) : DEFAULT_MODEL
+
+/**
+ * 一覧から外れたモデル ID を同プロバイダーの既定へ寄せる。
+ * localStorage に旧世代（gpt-5.4-nano 等）が残っていると、ヘッダーが古い名前を
+ * 表示し、モデル選択が空欄になるため、読み込み時点で必ず現行の値へ正規化する
+ */
+export const resolveSupportedModel = (model: unknown): string => {
+  if (typeof model !== 'string' || !model) return DEFAULT_MODEL
+  const isGemini = model.includes('gemini')
+  const catalog = isGemini ? GEMINI_MODELS : OPENAI_MODELS
+  return catalog.some((m) => m.value === model)
+    ? model
+    : providerDefaultModel(isGemini)
+}
+
 // ---------------------------------------------------------------------------
 // Config正規化・ロード
 // ---------------------------------------------------------------------------
@@ -355,8 +373,7 @@ export const normalizeChatConfig = (value: unknown): ChatSupportConfig => {
       typeof value.apiKey === 'string' && value.apiKey
         ? value.apiKey
         : DEFAULT_CHAT_CONFIG.apiKey,
-    model:
-      typeof value.model === 'string' ? value.model : DEFAULT_CHAT_CONFIG.model,
+    model: resolveSupportedModel(value.model),
     uiMode: value.uiMode === 'sidebar' ? 'sidebar' : 'widget',
     sidebarWidth:
       typeof value.sidebarWidth === 'number'


### PR DESCRIPTION
localStorageに残ったgpt-5.4-nanoのような一覧外のモデルIDがそのまま 復元され、ヘッダーが旧モデル名を表示し、AIモデル選択が空欄になっていた。
読み込み時にresolveSupportedModelで同プロバイダーの既定（OpenAIは
gpt-5.6-luna / Geminiはgemini-2.5-flash）へ寄せる。

あわせてdeploy-pagesワークフローのVITE_OPENAI_MODELもgpt-4.1-nanoからgpt-5.6-lunaに更新した。


Claude-Session: https://claude.ai/code/session_01EENcp2JJiR9SHhfiKB2XBK

# 課題・背景

- 課題名、このPRの主題
- 関連URL
- issue番号

## 実装した事

- [ ] xxx
- [ ] xxx
- [ ] xxx

## 動作確認

レビュー方法を、いずれか１つ選択

- [ ] ファイルやコードの確認だけでOK
- [ ] 起動してブラウザでの確認も必要

## 特にレビューしてほしい点

- xxx
- xxx
- xxx

## 今回レビュースコープ外の事

- xxx
- xxx

## キャプチャ

UI変更時のキャプチャ

### Before

### After


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 改善
  * AIチャットサポートで、対応していないモデルや不正な設定を検出し、プロバイダーに応じた既定モデルへ自動的に切り替えるようになりました。
  * 空の値や不正な入力が設定されている場合も、安定して利用できるよう改善しました。
  * Storybookで使用するAIモデルを更新しました。

* テスト
  * 対応モデルの維持、未知のモデルや旧設定のフォールバック動作を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
